### PR TITLE
Optimization of Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN yum -y install epel-release  && \
     pip install --no-cache-dir python-memcached wheel pexpect psutil python-daemon && \
     rm -rf /var/cache/yum
 
-ENV LANG en_US.UTF-8 \
-    LANGUAGE en_US:en \
-    LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
 
 VOLUME /runner/inventory
 VOLUME /runner/project

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,19 +3,20 @@ FROM centos:7
 ADD https://github.com/krallin/tini/releases/download/v0.14.0/tini /tini
 
 # Install Ansible Runner
-RUN yum -y update && yum -y install epel-release  && \
+RUN yum -y install epel-release  && \
     yum -y install ansible python-psutil python-pip bubblewrap bzip2 python-crypto \
                    which gcc python-devel libxml2 libxml2-devel krb5 krb5-devel curl curl-devel \
                    openssh openssh-clients && \
-    pip install --no-cache-dir python-memcached wheel pexpect psutil python-daemon pipenv setuptools && \
+    pip install --no-cache-dir -U setuptools && \
+    pip install --no-cache-dir python-memcached wheel pexpect psutil python-daemon pipenv && \
     localedef -c -i en_US -f UTF-8 en_US.UTF-8 && \
     chmod +x /tini && \
     rm -rf /var/cache/yum
 
 
-ENV LANG en_US.UTF-8 \
-    LANGUAGE en_US:en \
-    LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
 
 ENTRYPOINT ["/tini", "--"]
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,5 @@ image:
 	docker build --rm=true -t $(IMAGE_NAME) .
 
 devimage:
+	docker pull centos:7
 	docker build --rm=true -t $(IMAGE_NAME)-dev -f Dockerfile.dev .


### PR DESCRIPTION
The Dockerfiles provided are sub-optimal.

* The most volatile directives (the ones adding the actual Ansible Runner code) should be pushed to the bottom to speed rebuilds
* A `yum update` shouldn't be run - it adds unnecessary bloat to the final image. Using the most recent image is preferable.
* `RUN` commands should be compressed into a single layer
* `pip` and `yum` should clean up after themselves, lest they leave wasteful cache lying around
* Other directives like `ENV` can be compressed into single layers

Before: (total size: 448 MB, adding 20 layers and 253 MB to `centos:7`)
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
63136610a3d9        24 seconds ago      /bin/sh -c #(nop)  CMD ["/bin/sh" "-c" "an...   0 B                 
033c91e08576        24 seconds ago      /bin/sh -c #(nop)  ENV RUNNER_BASE_COMMAND...   0 B                 
a580846a16a6        25 seconds ago      /bin/sh -c #(nop) WORKDIR /                     0 B                 
8d178f746531        25 seconds ago      /bin/sh -c #(nop)  ENTRYPOINT ["/tini" "--"]    0 B                 
b5e8b66ef856        25 seconds ago      /bin/sh -c #(nop)  VOLUME [/runner/artifacts]   0 B                 
3676f438f720        26 seconds ago      /bin/sh -c #(nop)  VOLUME [/runner/project]     0 B                 
07b669d1789a        26 seconds ago      /bin/sh -c #(nop)  VOLUME [/runner/inventory]   0 B                 
11c64a89689c        26 seconds ago      /bin/sh -c #(nop) ADD dir:fc0472b7cacb3248...   10 B                
01044d11cf03        26 seconds ago      /bin/sh -c #(nop) ADD dir:839982eb338832c9...   157 B               
02a57e9c42fb        27 seconds ago      /bin/sh -c #(nop) ADD dir:0ac023ecab3eb0c8...   48 B                
4cea882bf0c7        27 seconds ago      /bin/sh -c chmod +x /tini                       19.9 kB             
a179ff26bb71        28 seconds ago      /bin/sh -c #(nop) ADD tarsum.v1+sha256:85c...   19.9 kB             
59dad2dcfea8        28 seconds ago      /bin/sh -c #(nop)  ENV LC_ALL=en_US.UTF-8       0 B                 
debf395c593c        28 seconds ago      /bin/sh -c #(nop)  ENV LANGUAGE=en_US:en        0 B                 
159948ac51eb        29 seconds ago      /bin/sh -c #(nop)  ENV LANG=en_US.UTF-8         0 B                 
d15f12b42908        29 seconds ago      /bin/sh -c localedef -c -i en_US -f UTF-8 ...   3.49 MB             
d0103042e7d5        30 seconds ago      /bin/sh -c pip install /ansible_runner-1.0...   146 kB              
93daed8c42b4        31 seconds ago      /bin/sh -c #(nop) ADD file:6132987aae0bda8...   26 kB               
99ee5d989e31        31 seconds ago      /bin/sh -c pip install python-memcached wh...   5.11 MB             
8d1d8c89b577        35 seconds ago      /bin/sh -c yum -y update && yum -y install...   244 MB              
2d194b392dd1        8 days ago          /bin/sh -c #(nop)  CMD ["/bin/bash"]            0 B                 
<missing>           8 days ago          /bin/sh -c #(nop)  LABEL name=CentOS Base ...   0 B                 
<missing>           8 days ago          /bin/sh -c #(nop) ADD file:8d83f3e2c14f39e...   195 MB              
```

After: (total size: 299 MB, adding 15 layers and 102 MB to `centos:7`)
```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
81c3de48c1c6        12 minutes ago      /bin/sh -c pip install --no-cache-dir /ans...   146 kB              
e4478339c80b        12 minutes ago      /bin/sh -c #(nop) ADD file:33b9d43d60198bb...   26 kB               
dca6a64c8f66        12 minutes ago      /bin/sh -c #(nop) ADD dir:fc0472b7cacb3248...   10 B                
3461db1e160c        12 minutes ago      /bin/sh -c #(nop) ADD dir:839982eb338832c9...   157 B               
e14854fd49fa        12 minutes ago      /bin/sh -c #(nop) ADD dir:0ac023ecab3eb0c8...   48 B                
870b4942ead3        12 minutes ago      /bin/sh -c #(nop)  CMD ["/bin/sh" "-c" "an...   0 B                 
f402162fcbb9        12 minutes ago      /bin/sh -c #(nop)  ENV RUNNER_BASE_COMMAND...   0 B                 
ec170b51e8b7        12 minutes ago      /bin/sh -c #(nop) WORKDIR /                     0 B                 
6c760906d7a8        12 minutes ago      /bin/sh -c #(nop)  ENTRYPOINT ["/tini" "--"]    0 B                 
805d3288fbf5        12 minutes ago      /bin/sh -c #(nop)  VOLUME [/runner/artifacts]   0 B                 
704a16a7ed32        12 minutes ago      /bin/sh -c #(nop)  VOLUME [/runner/project]     0 B                 
118c014d8048        12 minutes ago      /bin/sh -c #(nop)  VOLUME [/runner/inventory]   0 B                 
06167f0f9b54        12 minutes ago      /bin/sh -c #(nop)  ENV LANG=en_US.UTF-8   ...   0 B                 
cbc2e0ceb27a        12 minutes ago      /bin/sh -c yum -y install epel-release  &&...   103 MB              
1a2fa3d676ac        13 minutes ago      /bin/sh -c #(nop) ADD tarsum.v1+sha256:85c...   19.9 kB             
2d194b392dd1        8 days ago          /bin/sh -c #(nop)  CMD ["/bin/bash"]            0 B                 
<missing>           8 days ago          /bin/sh -c #(nop)  LABEL name=CentOS Base ...   0 B                 
<missing>           8 days ago          /bin/sh -c #(nop) ADD file:8d83f3e2c14f39e...   195 MB              
```