### PR TITLE
Updating README for programmatic invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ NOTE: This particular part is under heavy development at the moment so expect th
 
 ```
 $ python
->>> from ansible_runner.run import __run__
->>> __run__("/runner", hosts="/runner/inventory", playbook="test.yml")
+>>> from ansible_runner import RunnerConfig, Runner
+>>> c = RunnerConfig(base_dir='demo', playbook='test.yml')
+>>> c.prepare()
+>>> Runner(c).run()
 
 PLAY [all] *********************************************************************
 
@@ -178,6 +180,8 @@ ok: [localhost] => {
 
 PLAY RECAP *********************************************************************
 localhost                  : ok=2    changed=0    unreachable=0    failed=0   
+
+('successful', 0)
 ```
 
 ## Building the source distribution

--- a/ansible_runner/display_callback/minimal.py
+++ b/ansible_runner/display_callback/minimal.py
@@ -26,4 +26,4 @@ import ansible
 # Because of the way Ansible loads plugins, it's not possible to import
 # ansible.plugins.callback.minimal when being loaded as the minimal plugin. Ugh.
 minimal_plugin = os.path.join(os.path.dirname(ansible.__file__), 'plugins', 'callback', 'minimal.py')
-exec(compile(open(minimal_plugin, "rb").read(), minimal_plugin, 'exec'), globals, locals)
+exec(compile(open(minimal_plugin, "rb").read(), minimal_plugin, 'exec'), globals(), locals())

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -11,11 +11,10 @@ from .exceptions import ConfigurationError
 
 class RunnerConfig(object):
 
-    def __init__(self,
-                 base_dir=None, playbook=None, ident=uuid4(),
-                 inventory=None, limit=None,
+    def __init__(self, base_dir, playbook,
+                 ident=uuid4(), inventory=None, limit=None,
                  module=None, module_args=None):
-        self.base_dir = base_dir
+        self.base_dir = os.path.abspath(base_dir)
         self.ident = ident
         self.playbook = playbook
         self.inventory = inventory


### PR DESCRIPTION
- making base_dir and playbook required args for RunnerConfig
  can't invoke without them
- globals and locals in were being passed as functions in
  display_callback/minimal.py. Calling these functions passes
  the required dict for exec() to be called