### PR TITLE
Get the abspath of the private_data_dir

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -15,7 +15,7 @@ class RunnerConfig(object):
                  private_data_dir=None, playbook=None, ident=uuid4(),
                  inventory=None, limit=None,
                  module=None, module_args=None):
-        self.private_data_dir = private_data_dir
+        self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = ident
         self.playbook = playbook
         self.inventory = inventory


### PR DESCRIPTION
when a relative path is given the files in the data dir
can't be found by ansible playbook. Getting the abspath
allows a relative path to be passed but still allows
ansible playbook to find the files in the data dir.