### PR TITLE
update gitignore to ignore pytest_cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /rpm-build
 /*.egg-info
 *.py[c,o]
+.pytest_cache


### PR DESCRIPTION
This change updates .gitignore to not consider pytest_cache/ as a valid
entry for adding to a change.