### PR TITLE
Copying default os.environ to pass to pexpect

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -53,7 +53,8 @@ class RunnerConfig(object):
                 self.env.update(yaml.safe_load(f.read()))
         except Exception:
             print("Not loading environment vars")
-            self.env = dict()
+            # Still need to pass default environment to pexpect
+            self.env = os.environ.copy()
 
         try:
             with open(os.path.join(self.private_data_dir, "env", "extravars"), 'r') as f:


### PR DESCRIPTION
When we don't load an environment file the default environment
still needs to be passed to pexpect so that PATH exists