### PR TITLE
implement Python logging

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -6,6 +6,7 @@ import errno
 import signal
 import codecs
 import collections
+import logging
 
 import pexpect
 import psutil
@@ -15,6 +16,8 @@ from .exceptions import CallbackError, AnsibleRunnerException
 
 
 class Runner(object):
+
+    logger = logging.getLogger('ansible-runner')
 
     def __init__(self, config, cancel_callback=None, remove_partials=True):
         self.config = config
@@ -49,7 +52,7 @@ class Runner(object):
                 if self.remove_partials:
                     os.remove(partial_filename)
             except IOError as e:
-                print("Failed writing event data: {}".format(e))
+                self.logger.exception("Failed writing event data: {}".format(e))
 
     def run(self):
         '''
@@ -159,7 +162,7 @@ class Runner(object):
 
         Example:
 
-            {  
+            {
                "event":"runner_on_ok",
                "uuid":"00a50d9c-161a-4b74-b978-9f60becaf209",
                "stdout":"ok: [localhost] => {\\r\\n    \\"   msg\\":\\"Test!\\"\\r\\n}",
@@ -168,13 +171,13 @@ class Runner(object):
                "created":"2018-04-05T18:24:36.096725",
                "end_line":10,
                "start_line":7,
-               "event_data":{  
+               "event_data":{
                   "play_pattern":"all",
                   "play":"all",
                   "task":"debug",
                   "task_args":"msg=Test!",
                   "remote_addr":"localhost",
-                  "res":{  
+                  "res":{
                      "msg":"Test!",
                      "changed":false,
                      "_ansible_verbose_always":true,

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -6,11 +6,60 @@ import os
 import fcntl
 import tempfile
 import hashlib
+import logging
 
+from functools import partial
 from collections import Iterable, Mapping
 from io import StringIO
 from six import string_types
 
+
+STDOUT_MSG_FORMAT = '%(message)s'
+DEBUG_MSG_FORMAT = '%(asctime)s:[%(module)s.%(funcName)s:%(lineno)s]: %(message)s'
+
+LOGGER = logging.getLogger('ansible-runner')
+
+
+display = partial(LOGGER.log, 60)
+
+
+def configure_logging(filename=None, debug=False):
+    '''
+    Configures the logging facility
+
+    Args:
+        filename (string): The name of the file to log debug messages to.  If
+            this argument is None, then file logging is disabled.
+
+        debug (string): Specifies if debug should be sent to stdout.  If the
+            value of this argument is True, debug messages are sent to
+            stdout.  If this value is False, only display messages (level 60)
+            are sent ot stdout.
+
+    Returns:
+        None
+    '''
+    root_logger = logging.getLogger('')
+    root_logger.setLevel(logging.DEBUG)
+
+    # Set up logging to a file
+    if filename:
+        file_handler = logging.FileHandler(filename)
+        formatter = logging.Formatter(DEBUG_MSG_FORMAT)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+
+    if debug:
+        stdout_handler.setLevel(10)
+        formatter = logging.Formatter(DEBUG_MSG_FORMAT)
+    else:
+        stdout_handler.setLevel(60)
+        formatter = logging.Formatter(STDOUT_MSG_FORMAT)
+
+    stdout_handler.setFormatter(formatter)
+    root_logger.addHandler(stdout_handler)
 
 
 def isplaybook(obj):
@@ -86,7 +135,7 @@ def dump_artifact(obj, path, filename=None):
     return fn
 
 
-def to_artifacts(kwargs):
+def dump_artifacts(kwargs):
     '''
     Introspect the kwargs and dump objects to disk
     '''

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -5,7 +5,7 @@ from pytest import raises
 from mock import patch
 
 from ansible_runner.utils import isplaybook, isinventory
-from ansible_runner.utils import dump_artifacts, dump_artifact
+from ansible_runner.utils import dump_artifacts
 
 
 def test_isplaybook():

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -5,7 +5,7 @@ from pytest import raises
 from mock import patch
 
 from ansible_runner.utils import isplaybook, isinventory
-from ansible_runner.utils import to_artifacts
+from ansible_runner.utils import dump_artifacts, dump_artifact
 
 
 def test_isplaybook():
@@ -25,29 +25,29 @@ def test_isinventory():
         assert isinventory(obj) is False, obj
 
 
-def test_to_artifacts_private_data_dir():
+def test_dump_artifacts_private_data_dir():
     data_dir = '/tmp'
     kwargs = {'private_data_dir': data_dir}
-    to_artifacts(kwargs)
+    dump_artifacts(kwargs)
     assert kwargs['private_data_dir'] == data_dir
 
     kwargs = {'private_data_dir': None}
-    to_artifacts(kwargs)
+    dump_artifacts(kwargs)
     assert kwargs['private_data_dir'].startswith('/tmp/tmp')
     shutil.rmtree(kwargs['private_data_dir'])
 
     with raises(ValueError):
         data_dir = '/foo'
         kwargs = {'private_data_dir': data_dir}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
 
 
-def test_to_artifacts_playbook():
+def test_dump_artifacts_playbook():
     with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
         # playbook as a native object
         pb = [{'playbook': [{'hosts': 'all'}]}]
         kwargs = {'private_data_dir': '/tmp', 'playbook': pb}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1
         data, fp, fn = mock_dump_artifact.call_args[0]
         assert data == json.dumps(pb)
@@ -59,7 +59,7 @@ def test_to_artifacts_playbook():
         # playbook as a path
         pb = 'test.yml'
         kwargs = {'private_data_dir': '/tmp', 'playbook': pb}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 0
         assert mock_dump_artifact.called is False
 
@@ -69,17 +69,17 @@ def test_to_artifacts_playbook():
         for obj in ({'foo': 'bar'}, None, True, False, 'foo', []):
             mock_dump_artifact.reset_mock()
             kwargs = {'private_data_dir': '/tmp', 'playbook': obj}
-            to_artifacts(kwargs)
+            dump_artifacts(kwargs)
             assert mock_dump_artifact.call_count == 0
             assert mock_dump_artifact.called is False
 
 
-def test_to_artifacts_inventory():
+def test_dump_artifacts_inventory():
     with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
         # inventory as a string (INI)
         inv = '[all]\nlocalhost'
         kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1
         data, fp, fn = mock_dump_artifact.call_args[0]
         assert data == inv
@@ -91,7 +91,7 @@ def test_to_artifacts_inventory():
         # inventory as a path
         inv = '/tmp'
         kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 0
         assert mock_dump_artifact.called is False
         assert kwargs['inventory'] == inv
@@ -101,7 +101,7 @@ def test_to_artifacts_inventory():
         # inventory as a native object
         inv = {'foo': 'bar'}
         kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1
         data, fp, fn = mock_dump_artifact.call_args[0]
         assert data == json.dumps(inv)
@@ -109,11 +109,11 @@ def test_to_artifacts_inventory():
         assert fn == 'hosts.json'
 
 
-def test_to_artifacts_extravars():
+def test_dump_artifacts_extravars():
     with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
         extravars = {'foo': 'bar'}
         kwargs = {'private_data_dir': '/tmp', 'extravars': extravars}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1
         data, fp, fn = mock_dump_artifact.call_args[0]
         assert data == json.dumps(extravars)
@@ -122,11 +122,11 @@ def test_to_artifacts_extravars():
         assert 'extravars' not in kwargs
 
 
-def test_to_artifacts_passwords():
+def test_dump_artifacts_passwords():
     with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
         passwords = {'foo': 'bar'}
         kwargs = {'private_data_dir': '/tmp', 'passwords': passwords}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1
         data, fp, fn = mock_dump_artifact.call_args[0]
         assert data == json.dumps(passwords)
@@ -135,11 +135,11 @@ def test_to_artifacts_passwords():
         assert 'passwords' not in kwargs
 
 
-def test_to_artifacts_settings():
+def test_dump_artifacts_settings():
     with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
         settings = {'foo': 'bar'}
         kwargs = {'private_data_dir': '/tmp', 'settings': settings}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1
         data, fp, fn = mock_dump_artifact.call_args[0]
         assert data == json.dumps(settings)
@@ -148,11 +148,11 @@ def test_to_artifacts_settings():
         assert 'settings' not in kwargs
 
 
-def test_to_artifacts_ssh_key():
+def test_dump_artifacts_ssh_key():
     with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
         ssh_key = '1234567890'
         kwargs = {'private_data_dir': '/tmp', 'ssh_key': ssh_key}
-        to_artifacts(kwargs)
+        dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1
         data, fp, fn = mock_dump_artifact.call_args[0]
         assert data == ssh_key


### PR DESCRIPTION
This change implements the Python logging facility for handling message
logging to both stdout and to a debug log file.  To use the logging
facility perform the following in module code:

```
import logging
log = logging.getLogger('ansible-runner')
log.info('i can now log message')
```

To send messages to stdout use the display function in `utils.py`.