### PR TITLE
return output when playbook errors

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -183,6 +183,9 @@ class OutputEventFilter(object):
                 self._handle.write(stdout_actual + "\n")
 
             self._last_chunk = remainder
+        else:
+            sys.stdout.write(data + '\n')
+            self._handle.write(data + '\n')
 
     def close(self):
         value = self._buffer.getvalue()


### PR DESCRIPTION
This change addresses a problem where the instance of OutputEventFilter
wouldn't return any data to stdout.  This happens when the playbook
errors and event filter doesn't invoke the search.  This change will now
write the data to stdout even if the even search is not performed.

fixes #29