### PR TITLE
update ansible-runner arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ playbook.  The following example demonstrates how to invoke a role directly
 using `ansible-runner`:
 
 ```bash
-$ ansible-runner run ./demo -r my_role --roles-path /path/to/roles
+$ ansible-runner run ./demo -r testrole --roles-path ./demo/roles
 ```
+
+The above example will run the role called `testrole` from the `demo` folder in
+the `ansible-runner` project root directory.
 
 
 # Understanding the Ansible Runner Directory Hierarchy Interface

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ The base reference container image includes a demo playbook and inventory that u
 $ docker run -it --rm -e RUNNER_PLAYBOOK=test.yml ansible/ansible-runner:latest
 ```
 
+The `ansible-runner` command can also directly run roles without the need for a
+playbook.  The following example demonstrates how to invoke a role directly
+using `ansible-runner`:
+
+```bash
+$ ansible-runner run ./demo -r my_role --roles-path /path/to/roles
+```
+
+
 # Understanding the Ansible Runner Directory Hierarchy Interface
 
 Ansible Runner takes most of its inputs from a particular directory structure. Some inputs can also be given on the command line. Primarily the `ansible-runner` command line utility requires at least two parameters:

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -1,4 +1,3 @@
-#!/bin/env python
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -35,8 +34,7 @@ from ansible_runner import run, run_async
 VERSION = pkg_resources.require("ansible_runner")[0].version
 DEFAULT_ROLES_PATH = os.getenv('ANSIBLE_ROLES_PATH', '/etc/ansible/roles')
 
-if __name__ == '__main__':
-
+def main():
     parser = argparse.ArgumentParser(description='manage ansible execution')
     parser.add_argument('--version', action='version', version=VERSION)
 

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -1,3 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 import threading
 import os
 import logging

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -1,19 +1,10 @@
-from uuid import uuid4
-import pkg_resources
 import threading
-import argparse
-import signal
-import errno
-import json
-import stat
-import sys
 import os
 import logging
 
-from .runner_config import RunnerConfig
-from .runner import Runner
-from .utils import dump_artifacts, configure_logging
-
+from ansible_runner.runner_config import RunnerConfig
+from ansible_runner.runner import Runner
+from ansible_runner.utils import dump_artifacts, configure_logging
 
 logging.getLogger('ansible-runner').addHandler(logging.NullHandler())
 
@@ -131,70 +122,3 @@ def run_async(**kwargs):
     runner_thread = threading.Thread(target=r.run)
     runner_thread.start()
     return runner_thread, r
-
-
-
-def main():
-    version = pkg_resources.require("ansible_runner")[0].version
-    parser = argparse.ArgumentParser(description='manage ansible execution')
-    parser.add_argument('--version', action='version', version=version)
-    parser.add_argument('command', choices=['run', 'start',
-                                            'stop', 'is-alive'])
-    parser.add_argument('private_data_dir',
-                        help='Base directory containing Runner metadata (project, inventory, etc')
-    parser.add_argument("--hosts")
-    parser.add_argument("-p", "--playbook", default=os.getenv("RUNNER_PLAYBOOK", None))
-    parser.add_argument("-i", "--ident",
-                        default=uuid4(),
-                        help="An identifier that will be used when generating the"
-                             "artifacts directory and can be used to uniquely identify a playbook run")
-    args = parser.parse_args()
-    pidfile = os.path.join(args.private_data_dir, 'pid')
-    try:
-        os.makedirs(args.private_data_dir)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST and os.path.isdir(args.private_data_dir):
-            pass
-        else:
-            raise
-    stderr_path = os.path.join(args.private_data_dir, 'daemon.log')
-    if not os.path.exists(stderr_path):
-        os.mknod(stderr_path, stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR)
-    stderr = open(stderr_path, 'w+')
-
-    if args.command in ('start', 'run'):
-        if args.command == 'start':
-            import daemon
-            from daemon.pidfile import TimeoutPIDLockFile
-            context = daemon.DaemonContext(
-                pidfile=TimeoutPIDLockFile(pidfile),
-                stderr=stderr
-            )
-        else:
-            context = threading.Lock()
-        with context:
-            run_options = dict(private_data_dir=args.private_data_dir,
-                               ident=args.ident,
-                               playbook=args.playbook)
-            if args.hosts is not None:
-                run_options.update(inventory=args.hosts)
-            run(**run_options)
-            sys.exit(0)
-    try:
-        with open(pidfile, 'r') as f:
-            pid = int(f.readline())
-    except IOError:
-        sys.exit(1)
-
-    if args.command == 'stop':
-        try:
-            with open(os.path.join(args.private_data_dir, 'args'), 'r') as args:
-                Runner.handle_termination(pid, json.load(args), 'bwrap')
-        except IOError:
-            Runner.handle_termination(pid, [], 'bwrap')
-    elif args.command == 'is-alive':
-        try:
-            os.kill(pid, signal.SIG_DFL)
-            sys.exit(0)
-        except OSError:
-            sys.exit(1)

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -131,6 +131,7 @@ def dump_artifact(obj, path, filename=None):
                 f.write(str(obj))
         finally:
             fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+            os.remove(lock_fp)
 
     return fn
 

--- a/bin/ansible-runner
+++ b/bin/ansible-runner
@@ -1,0 +1,155 @@
+#!/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import pkg_resources
+import threading
+import argparse
+import signal
+import errno
+import json
+import stat
+import sys
+import os
+import shlex
+
+from uuid import uuid4
+
+from ansible_runner import run, run_async
+
+VERSION = pkg_resources.require("ansible_runner")[0].version
+DEFAULT_ROLES_PATH = os.getenv('ANSIBLE_ROLES_PATH', '/etc/ansible/roles')
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='manage ansible execution')
+    parser.add_argument('--version', action='version', version=VERSION)
+
+    parser.add_argument('command', choices=['run', 'start', 'stop', 'is-alive'])
+
+    parser.add_argument('private_data_dir',
+                        help='Base directory containing Runner metadata (project, inventory, etc')
+
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument("-p", "--playbook", default=os.getenv("RUNNER_PLAYBOOK", None),
+                       help="The name of the playbook to execute")
+
+    group.add_argument("-r", "--role",
+                       help="Invoke an Ansible role directly without a playbook")
+
+    parser.add_argument("--hosts", default='all',
+                        help="Define the set of hosts to execute against")
+
+    parser.add_argument("-i", "--ident",
+                        default=uuid4(),
+                        help="An identifier that will be used when generating the"
+                             "artifacts directory and can be used to uniquely identify a playbook run")
+
+    parser.add_argument("--roles-path", default=DEFAULT_ROLES_PATH,
+                        help="Path to the Ansible roles directory")
+
+    parser.add_argument("--role-vars",
+                        help="Variables to pass to the role at runtime")
+
+    parser.add_argument("--inventory")
+
+    args = parser.parse_args()
+
+    pidfile = os.path.join(args.private_data_dir, 'pid')
+
+    try:
+        os.makedirs(args.private_data_dir)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(args.private_data_dir):
+            pass
+        else:
+            raise
+
+    if args.command != 'run':
+        stderr_path = os.path.join(args.private_data_dir, 'daemon.log')
+        if not os.path.exists(stderr_path):
+            os.mknod(stderr_path, stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR)
+        stderr = open(stderr_path, 'w+')
+
+    if args.command in ('start', 'run'):
+        if args.role:
+
+            role = {'name': args.role}
+            if args.role_vars:
+                role_vars = {}
+                for item in shlex.split(args.role_vars):
+                    key, value = item.split('=')
+                    role_vars[key] = value
+                role['vars'] = role_vars
+
+            kwargs = {
+                'playbook': [{'hosts': args.hosts, 'roles': [role]}],
+                'inventory': args.inventory,
+            }
+
+            print('using inventory file %s' % args.inventory)
+
+            envvars = {}
+            if args.roles_path:
+                envvars['ANSIBLE_ROLES_PATH'] = args.roles_path
+
+            if envvars:
+                kwargs['envvars'] = envvars
+
+            res = run(**kwargs)
+            sys.exit(res.rc)
+
+        elif args.command == 'start':
+            import daemon
+            from daemon.pidfile import TimeoutPIDLockFile
+            context = daemon.DaemonContext(
+                pidfile=TimeoutPIDLockFile(pidfile),
+                stderr=stderr
+            )
+        else:
+            context = threading.Lock()
+
+        with context:
+            run_options = dict(private_data_dir=args.private_data_dir,
+                               ident=args.ident,
+                               playbook=args.playbook)
+            if args.hosts is not None:
+                run_options.update(inventory=args.hosts)
+            run(**run_options)
+            sys.exit(0)
+
+    try:
+        with open(pidfile, 'r') as f:
+            pid = int(f.readline())
+    except IOError:
+        sys.exit(1)
+
+    if args.command == 'stop':
+        try:
+            with open(os.path.join(args.private_data_dir, 'args'), 'r') as args:
+                Runner.handle_termination(pid, json.load(args), 'bwrap')
+        except IOError:
+            Runner.handle_termination(pid, [], 'bwrap')
+
+    elif args.command == 'is-alive':
+        try:
+            os.kill(pid, signal.SIG_DFL)
+            sys.exit(0)
+        except OSError:
+            sys.exit(1)

--- a/demo/roles/testrole/README.md
+++ b/demo/roles/testrole/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/demo/roles/testrole/defaults/main.yml
+++ b/demo/roles/testrole/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for testrole

--- a/demo/roles/testrole/handlers/main.yml
+++ b/demo/roles/testrole/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for testrole

--- a/demo/roles/testrole/meta/main.yml
+++ b/demo/roles/testrole/meta/main.yml
@@ -1,0 +1,57 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 1.2
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/demo/roles/testrole/tasks/main.yml
+++ b/demo/roles/testrole/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for testrole
+- name: just print a message to stdout
+  debug:
+    msg: "hello from the ansible-runner testrole!"

--- a/demo/roles/testrole/tests/inventory
+++ b/demo/roles/testrole/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/demo/roles/testrole/tests/test.yml
+++ b/demo/roles/testrole/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - testrole

--- a/demo/roles/testrole/vars/main.yml
+++ b/demo/roles/testrole/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for testrole

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setup(
         'six',
     ],
     zip_safe=False,
-    scripts=[
-        'bin/ansible-runner'
-    ]
+    entry_points={
+        'console_scripts': [
+            'ansible-runner = ansible_runner.__main__:main'
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ setup(
         'six',
     ],
     zip_safe=False,
-    entry_points={
-        'console_scripts': [
-            'ansible-runner=ansible_runner.interface:main',
-        ],
-    },
+    scripts=[
+        'bin/ansible-runner'
+    ]
 )


### PR DESCRIPTION
This change adds support for directly running roles from the cli interface.  To
execute a role directly without the need for a playbook, use the
following command

ansible-runner run . --role <role-name>

This will execute the role against the inventory.  Two additional
command line switches have been added.

* roles-path - used to set the path to the roles directory
* role-vars - used to inject vars to the role
