### PR TITLE
fixes bug that overwrites the inventory file

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -60,7 +60,7 @@ def main():
     group.add_argument("-r", "--role", default=DEFAULT_RUNNER_ROLE,
                        help="Invoke an Ansible role directly without a playbook")
 
-    parser.add_argument("--hosts", default='all',
+    parser.add_argument("--hosts",
                         help="Define the set of hosts to execute against")
 
     parser.add_argument("-i", "--ident",

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -64,8 +64,8 @@ class RunnerConfig(object):
     def prepare_env(self):
         try:
             passwords = self.loader.load_file('env/passwords', Mapping)
-            self.expect_passwords= {
-                re.rcompile(pattern, re.M): password
+            self.expect_passwords = {
+                re.compile(pattern, re.M): password
                 for pattern, password in iteritems(passwords)
             }
         except ConfigurationError as exc:

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -110,7 +110,7 @@ def dump_artifact(obj, path, filename=None):
         os.makedirs(path)
     else:
         p_sha1 = hashlib.sha1()
-        p_sha1.update(obj)
+        p_sha1.update(obj.encode(encoding='UTF-8'))
 
     if filename is None:
         fd, fn = tempfile.mkstemp(dir=path)
@@ -119,7 +119,9 @@ def dump_artifact(obj, path, filename=None):
 
     if os.path.exists(fn):
         c_sha1 = hashlib.sha1()
-        c_sha1.update(open(fn).read())
+        with open(fn) as f:
+            contents = f.read()
+        c_sha1.update(contents.encode(encoding='UTF-8'))
 
     if not os.path.exists(fn) or p_sha1.hexdigest() != c_sha1.hexdigest():
         lock_fp = os.path.join(path, '.artifact_write_lock')

--- a/test/unit/test___main__.py
+++ b/test/unit/test___main__.py
@@ -1,0 +1,121 @@
+import os
+import sys
+import uuid
+import json
+import random
+import string
+import tempfile
+import shutil
+
+from pytest import raises
+
+from ansible_runner.__main__ import main
+
+
+def random_string():
+    return ''.join(random.choice(string.ascii_uppercase + string.digits)
+                   for _ in range(random.randint(3, 20)))
+
+
+def random_json(keys=None):
+    data = dict()
+    if keys:
+        for key in keys:
+            data[key] = random_string()
+    else:
+        for _ in range(0, 5):
+            data[random_string()] = random_string()
+    return json.dumps(data)
+
+
+def cmdline(command, *args):
+    cmdline = ['ansible-runner', command]
+    cmdline.extend(args)
+    sys.argv = cmdline
+
+
+def test_main_bad_private_data_dir():
+    tmpfile = os.path.join('/tmp', str(uuid.uuid4().hex))
+    open(tmpfile, 'w').write(random_string())
+
+    cmdline('run', tmpfile)
+
+    try:
+        with raises(OSError):
+            main()
+    finally:
+        os.remove(tmpfile)
+
+
+def test_cmdline_playbook():
+    try:
+        private_data_dir = tempfile.mkdtemp()
+        play = [{'hosts': 'all', 'tasks': [{'debug': {'msg': random_string()}}]}]
+
+        path = os.path.join(private_data_dir, 'project')
+        os.makedirs(path)
+
+        playbook = os.path.join(path, 'main.yaml')
+        with open(playbook, 'w') as f:
+            f.write(json.dumps(play))
+
+        path = os.path.join(private_data_dir, 'inventory')
+        os.makedirs(path)
+
+        inventory = os.path.join(path, 'hosts')
+        with open(inventory, 'w') as f:
+            f.write('localhost')
+
+        cmdline('run', private_data_dir, '-p', playbook, '--inventory', inventory)
+
+        with raises(SystemExit) as exc:
+            main()
+            assert exc.type == SystemExit
+            assert exc.value.code == 0
+
+        with open(playbook) as f:
+            assert json.loads(f.read()) == play
+
+        with open(inventory) as f:
+            assert f.read() == 'localhost'
+
+    finally:
+        shutil.rmtree(private_data_dir)
+
+
+def test_cmdline_playbook_hosts():
+    try:
+        private_data_dir = tempfile.mkdtemp()
+        play = [{'hosts': 'all', 'tasks': [{'debug': {'msg': random_string()}}]}]
+
+        path = os.path.join(private_data_dir, 'project')
+        os.makedirs(path)
+
+        playbook = os.path.join(path, 'main.yaml')
+        with open(playbook, 'w') as f:
+            f.write(json.dumps(play))
+
+        path = os.path.join(private_data_dir, 'inventory')
+        os.makedirs(path)
+
+        inventory = os.path.join(path, 'hosts')
+        with open(inventory, 'w') as f:
+            f.write('localhost')
+
+        cmdline('run', private_data_dir, '-p', playbook, '--hosts', 'all')
+
+        with raises(SystemExit) as exc:
+            main()
+            assert exc.type == SystemExit
+            assert exc.value.code == 0
+
+        with open(playbook) as f:
+            assert json.loads(f.read()) == play
+
+        with open(inventory) as f:
+            assert f.read() == 'all'
+
+    finally:
+        shutil.rmtree(private_data_dir)
+
+

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -1,3 +1,4 @@
+
 from ansible_runner.runner_config import RunnerConfig
 from mock import patch
 from collections import Mapping
@@ -14,6 +15,18 @@ def envvar_side_effect(*args, **kwargs):
         return ""
     else:
         return None
+
+
+def password_side_effect(*args, **kwargs):
+    if args[0] == 'env/passwords':
+        return {'Password': 'secret'}
+    elif args[1] == Mapping:
+        return dict()
+    elif args[1] == string_types:
+        return ""
+    else:
+        return None
+
 
 
 def test_prepare_environment_vars_only_strings():
@@ -34,3 +47,10 @@ def test_prepare_environment_pexpect_defaults():
         rc.prepare_env()
         assert TIMEOUT in rc.expect_passwords
         assert EOF in rc.expect_passwords
+
+
+def test_prepare_env_passwords():
+    rc = RunnerConfig(private_data_dir='/')
+    with patch.object(rc.loader, 'load_file', side_effect=password_side_effect):
+        rc.prepare_env()
+        assert 'secret' in rc.expect_passwords.values()


### PR DESCRIPTION
This fix addresses a bug where the inventory file will get overwritten
due to a default value for the hosts argument when running
ansible-runner from the command line.  This is due to a change that set
the default value for the hosts argument.  This fix removes the default
value and restores the operation to run as expected.