### PR TITLE
Update pexpect to 4.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'psutil',
-        'pexpect==4.5.0',
+        'pexpect==4.6.0',
         'python-daemon',
         'PyYAML',
         'six',


### PR DESCRIPTION
In fce332c (Upgrading pexpect (and some ancillary packages) to 4.6) the
Pipfile was updated to use pexpect 4.6.0 but setup.py wasn't.  This
seems strange so update setup.py to match.