### PR TITLE
Replaces os.mknod with portable equivalent

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -91,7 +91,7 @@ def main():
     if args.command != 'run':
         stderr_path = os.path.join(args.private_data_dir, 'daemon.log')
         if not os.path.exists(stderr_path):
-            os.mknod(stderr_path, stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR)
+            os.close(os.open(stderr_path, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
         stderr = open(stderr_path, 'w+')
 
     if args.command in ('start', 'run'):

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -64,7 +64,7 @@ class Runner(object):
 
         try:
             os.makedirs(self.config.artifact_dir)
-            os.mknod(stdout_filename, stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR)
+            os.close(os.open(stdout_filename, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
         except OSError as exc:
             if exc.errno == errno.EEXIST and os.path.isdir(self.config.artifact_dir):
                 pass
@@ -140,7 +140,7 @@ class Runner(object):
         ]:
             artifact_path = os.path.join(self.config.artifact_dir, filename)
             if not os.path.exists(artifact_path):
-                os.mknod(artifact_path, stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR)
+                os.close(os.open(artifact_path, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
             with open(artifact_path, 'w') as f:
                 f.write(str(data))
         return self.status, self.rc

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -22,6 +22,7 @@ import pipes
 import threading
 import pexpect
 import logging
+import stat
 
 from uuid import uuid4
 from collections import Mapping
@@ -252,7 +253,7 @@ class RunnerConfig(object):
         This blocks the thread until an external process (such as ssh-agent)
         reads data from the pipe.
         '''
-        os.mkfifo(path, 0o600)
+        os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
         threading.Thread(target=lambda p, d: open(p, 'w').write(d),
                          args=(path, data)).start()
 

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -7,6 +7,7 @@ import fcntl
 import tempfile
 import hashlib
 import logging
+import stat
 
 from functools import partial
 from collections import Iterable, Mapping
@@ -125,7 +126,7 @@ def dump_artifact(obj, path, filename=None):
 
     if not os.path.exists(fn) or p_sha1.hexdigest() != c_sha1.hexdigest():
         lock_fp = os.path.join(path, '.artifact_write_lock')
-        lock_fd = os.open(lock_fp, os.O_RDWR | os.O_CREAT, 0o600)
+        lock_fd = os.open(lock_fp, os.O_RDWR | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR)
         fcntl.lockf(lock_fd, fcntl.LOCK_EX)
 
         try:


### PR DESCRIPTION
os.mknod is not available to users on Mac OS.  os.mknod causes two tests
to fail: test_cmdline_playbook and test_cmdline_playbook_hosts.
Replacing os.mknod with os.open and setting permissions on create in one
step preserves security, makes the code portable, and makes the
test pass.