### PR TITLE
Fixes test_dump_artifacts_private_data_dir on Mac OS

### DIFF
--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import tempfile
 
 from pytest import raises
 from mock import patch
@@ -26,14 +27,14 @@ def test_isinventory():
 
 
 def test_dump_artifacts_private_data_dir():
-    data_dir = '/tmp'
+    data_dir = tempfile.gettempdir()
     kwargs = {'private_data_dir': data_dir}
     dump_artifacts(kwargs)
     assert kwargs['private_data_dir'] == data_dir
 
     kwargs = {'private_data_dir': None}
     dump_artifacts(kwargs)
-    assert kwargs['private_data_dir'].startswith('/tmp/tmp')
+    assert kwargs['private_data_dir'].startswith(tempfile.gettempdir())
     shutil.rmtree(kwargs['private_data_dir'])
 
     with raises(ValueError):


### PR DESCRIPTION
Changes hard-coded /tmp to use tempfile.gettempdir()