### PR TITLE
Upload a sample fix for the ssh_key issue

### DIFF
--- a/ansible_runner/loader.py
+++ b/ansible_runner/loader.py
@@ -79,6 +79,24 @@ class ArtifactLoader(object):
             self.logger.exception(exc)
             pass
 
+
+    def _load_ssh_key(self, contents):
+        '''
+        Attempts to validate the contents of a ssh key
+
+        Args:
+            contents (string): The contents to validate
+
+        Retunrs:
+            dict: If the contents correspond to a valid ssh key
+
+            None: if the contents are not a ssh key
+        '''
+        if contents.startswith('-----BEGIN RSA PRIVATE KEY-----'):
+            return contents
+        else:
+            return None
+
     def get_contents(self, path):
         '''
         Loads the contents of the file specified by path
@@ -161,7 +179,7 @@ class ArtifactLoader(object):
             self.logger.exception(exc)
             raise ConfigurationError('unable to encode file contents')
 
-        for deserializer in (self._load_json, self._load_yaml):
+        for deserializer in (self._load_json, self._load_ssh_key, self._load_yaml):
             parsed_data = deserializer(contents)
             if parsed_data:
                 break


### PR DESCRIPTION
This is the temporary fix I added in order to may the env/ssh_key to be loaded correctly when trying to run ansible from the python interface. Details at (https://github.com/ansible/ansible-runner/issues/65)