### PR TITLE
change to how extra vars are handled

### DIFF
--- a/ansible_runner/loader.py
+++ b/ansible_runner/loader.py
@@ -121,6 +121,17 @@ class ArtifactLoader(object):
             path = os.path.expanduser(os.path.join(self.base_path, path))
         return path
 
+    def isfile(self, path):
+        '''
+        Check if the path is a file
+
+        :params path: The path to the file to check.  If the path is relative
+            it will be exanded to an absolute path
+
+        :returns: boolean
+        '''
+        return os.path.isfile(self.abspath(path))
+
     def load_file(self, path, objtype=None, encoding='utf-8'):
         '''
         Load the file specified by path

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -106,18 +106,15 @@ def test_prepare_env_passwords():
 def test_prepare_env_extra_vars_defaults():
     rc = RunnerConfig('/')
     rc.prepare_env()
-    assert rc.extra_vars == {}
+    assert rc.extra_vars is None
 
 
 def test_prepare_env_extra_vars():
     rc = RunnerConfig('/')
 
-    value = {'test': 'string'}
-    extravars_side_effect = partial(load_file_side_effect, 'env/extravars', value)
-
-    with patch.object(rc.loader, 'load_file', side_effect=extravars_side_effect):
+    with patch.object(rc.loader, 'isfile', side_effect=lambda x: True):
         rc.prepare_env()
-        assert rc.extra_vars  == value
+        assert rc.extra_vars == '/env/extravars'
 
 
 def test_prepare_env_settings_defaults():
@@ -181,9 +178,9 @@ def test_generate_ansible_command():
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', 'main.yaml']
 
-    rc.extra_vars = {'test': 'string'}
+    rc.extra_vars = '/env/extravars'
     cmd = rc.generate_ansible_command()
-    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', 'test=string', 'main.yaml']
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', 'main.yaml']
 
     rc.extra_vars = None
     rc.limit = 'hosts'


### PR DESCRIPTION
This change will no longer parse the `env/extravars` file and instead if
the file exists it will pass it directly to the `ansible-playbook` run
using the `- e @<path>` notation.  If `env/extravars` does not exist
then there is no change in functionality.

This will fix #62