### PR TITLE
expose ansible-playbook verbosity to cli and api

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -77,7 +77,7 @@ def main():
     parser.add_argument("--inventory")
 
     parser.add_argument("-v", action="count",
-                        help="Increase the verbosity of the ansible-playbook output")
+                        help="Increase the verbosity with multiple v's (up to 5) of the ansible-playbook output")
 
     args = parser.parse_args()
 

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -76,6 +76,9 @@ def main():
 
     parser.add_argument("--inventory")
 
+    parser.add_argument("-v", action="count",
+                        help="Increase the verbosity of the ansible-playbook output")
+
     args = parser.parse_args()
 
     pidfile = os.path.join(args.private_data_dir, 'pid')
@@ -174,7 +177,8 @@ def main():
         with context:
             run_options = dict(private_data_dir=args.private_data_dir,
                                ident=args.ident,
-                               playbook=args.playbook)
+                               playbook=args.playbook,
+                               verbosity=args.v)
             if args.hosts is not None:
                 run_options.update(inventory=args.hosts)
             run(**run_options)

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -77,6 +77,7 @@ def run(**kwargs):
                      be read from ``env/settings`` in ``private_data_dir``.
     :param ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
+    :param verbosity: Control how verbose the output of ansible-playbook is
     :type private_data_dir: str
     :type ident: str
     :type playbook: str or filename or list
@@ -86,6 +87,7 @@ def run(**kwargs):
     :type passwords: dict
     :type settings: dict
     :type ssh_key: str
+    :type verbosity: int
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -57,7 +57,7 @@ class RunnerConfig(object):
     def __init__(self,
                  private_data_dir=None, playbook=None, ident=uuid4(),
                  inventory=None, limit=None,
-                 module=None, module_args=None):
+                 module=None, module_args=None, verbosity=None):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = ident
         self.playbook = playbook
@@ -71,6 +71,7 @@ class RunnerConfig(object):
             self.artifact_dir = os.path.join(self.private_data_dir, "artifacts", "{}".format(self.ident))
 
         self.extra_vars = None
+        self.verbosity = verbosity
 
         self.logger.info('private_data_dir: %s' % self.private_data_dir)
 
@@ -212,6 +213,9 @@ class RunnerConfig(object):
             exec_list.append(self.limit)
         if self.extra_vars:
             exec_list.extend(['-e', '@%s' % self.extra_vars])
+        if self.verbosity:
+            v = 'v' * self.verbosity
+            exec_list.append('-%s' % v)
         # Other parameters
         if base_command.endswith('ansible-playbook'):
             exec_list.append(self.playbook)

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -181,8 +181,13 @@ def test_generate_ansible_command():
     rc.extra_vars = '/env/extravars'
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', 'main.yaml']
-
     rc.extra_vars = None
+
+    rc.verbosity = 3
+    cmd = rc.generate_ansible_command()
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-vvv', 'main.yaml']
+    rc.verbosity = None
+
     rc.limit = 'hosts'
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', '--limit', 'hosts', 'main.yaml']
@@ -194,6 +199,7 @@ def test_generate_ansible_command():
     rc.module_args = 'test=string'
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible', '-i', '/inventory', '--limit', 'hosts', '-m', 'setup', '-a', 'test=string']
+
 
 
 def test_prepare_command_defaults():


### PR DESCRIPTION
This change adds a new config option to increase the verbosity of the
ansible playbook output.  In the command line form, you can now specify
`-v`, `-vv`, `-vvv`, etc and it will be passed to the ansible-playbook
at run time.  In the api form, set the kwarg `verbosity` to the number
of `-v`'s to append to `ansible-playbook`.

This closes #41 