### PR TITLE
add new feature for mananging cmdline options

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -91,6 +91,9 @@ def main():
     parser.add_argument("-v", action="count",
                         help="Increase the verbosity with multiple v's (up to 5) of the ansible-playbook output")
 
+    parser.add_argument("--cmdline",
+                        help="Command line options to pass to ansible-playbook at execution time")
+
     args = parser.parse_args()
 
     pidfile = os.path.join(args.private_data_dir, 'pid')
@@ -111,7 +114,6 @@ def main():
 
     if args.command in ('start', 'run'):
         if args.role:
-
             role = {'name': args.role}
             if args.role_vars:
                 role_vars = {}
@@ -133,6 +135,9 @@ def main():
 
             envvars_path = os.path.join(args.private_data_dir, 'env/envvars')
             envvars_exists = os.path.exists(envvars_path)
+
+            if args.cmdline:
+                kwargs['cmdline'] = args.cmdline
 
             playbook = None
             tmpvars = None
@@ -220,8 +225,13 @@ def main():
                                playbook=args.playbook,
                                verbosity=args.v,
                                json_mode=args.json)
+
             if args.hosts is not None:
                 run_options.update(inventory=args.hosts)
+
+            if args.cmdline:
+                run_options['cmdline'] = args.cmdline
+
             run(**run_options)
             sys.exit(0)
 

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -77,6 +77,7 @@ def run(**kwargs):
     :param settings: A dictionary containing settings values for the ``ansible-runner`` runtime environment. These will also
                      be read from ``env/settings`` in ``private_data_dir``.
     :param ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
+    :param cmdline: Commnad line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
     :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param verbosity: Control how verbose the output of ansible-playbook is
     :param artifact_dir: The path to the directory where artifacts should live
@@ -90,8 +91,8 @@ def run(**kwargs):
     :type passwords: dict
     :type settings: dict
     :type ssh_key: str
-    :type verbosity: int
     :type artifact_dir: str
+    :type cmdline: str
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -215,7 +215,6 @@ class RunnerConfig(object):
         try:
             cmdline_args = self.loader.load_file('env/cmdline', string_types)
             args = shlex.split(cmdline_args)
-            self.logger.debug(args)
             exec_list.extend(args)
         except ConfigurationError:
             pass

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -173,10 +173,12 @@ def dump_artifacts(kwargs):
             dump_artifact(json.dumps(obj), path, key)
             kwargs.pop(key)
 
-    if 'ssh_key' in kwargs:
-        path = os.path.join(private_data_dir, 'env')
-        dump_artifact(str(kwargs['ssh_key']), path, 'ssh_key')
-        kwargs.pop('ssh_key')
+    for key in ('ssh_key', 'cmdline'):
+        obj = kwargs.get(key)
+        if obj:
+            path = os.path.join(private_data_dir, 'env')
+            dump_artifact(str(kwargs[key]), path, key)
+            kwargs.pop(key)
 
 
 class OutputEventFilter(object):

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -32,6 +32,7 @@ Note that not everything is required. Defaults will be used or values will be om
     │   ├── envvars
     │   ├── extravars
     │   ├── passwords
+    │   ├── cmdline
     │   ├── settings
     │   └── ssh_key
     ├── inventory
@@ -103,6 +104,18 @@ by providing a yaml or json formatted file with a regular expression and a value
   ---
   "^SSH [pP]assword:$": "some_password"
   "^BECOME [pP]assword:$": "become_password"
+
+``env/cmdline``
+---------------
+
+.. note::
+    
+    For an example see `the demo cmdline <https://github.com/ansible/ansible-runner/blob/master/demo/env/cmdline>`_
+
+.. warning::
+
+    Current **Ansible Runner** does not validate the command line arguments passed using this method so it is up to the playbook writer to provide a valid set of options
+    The command line options provided by this method are lower priority than the ones set by **Ansible Runner**.  For instance, this will not override `inventory` or `limit` values.
 
 ``env/ssh_key``
 ---------------

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -160,3 +160,16 @@ def test_dump_artifacts_ssh_key():
         assert fp == '/tmp/env'
         assert fn == 'ssh_key'
         assert 'ssh_key' not in kwargs
+
+
+def test_dump_artifacts_cmdline():
+    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
+        cmdline = '--tags foo --skip-tags'
+        kwargs = {'private_data_dir': '/tmp', 'cmdline': cmdline}
+        dump_artifacts(kwargs)
+        assert mock_dump_artifact.call_count == 1
+        data, fp, fn = mock_dump_artifact.call_args[0]
+        assert data == cmdline
+        assert fp == '/tmp/env'
+        assert fn == 'cmdline'
+        assert 'cmdline' not in kwargs


### PR DESCRIPTION
This change adds a new experimental feature to `ansible-runner` to
manage command line options passed to the `ansible-playbook` executable.
This feature does not validate the command line options so it is up to
the playbook writer to make sure to include the correct values.

In order to use the command line options create a new file in the `env/`
folder called `cmdline` and put the command line string into the file.

```
env/cmdline

--tags one,two --skip-tags three -u ansible --become
```

This change updates the docs as well

This PR will fix #63 