### PR TITLE
Enhance the logging and display output

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -17,12 +17,12 @@
 # under the License.
 #
 import threading
-import os
 import logging
 
+from ansible_runner import output
 from ansible_runner.runner_config import RunnerConfig
 from ansible_runner.runner import Runner
-from ansible_runner.utils import dump_artifacts, configure_logging
+from ansible_runner.utils import dump_artifacts
 
 logging.getLogger('ansible-runner').addHandler(logging.NullHandler())
 
@@ -38,13 +38,15 @@ def init_runner(**kwargs):
     '''
     dump_artifacts(kwargs)
 
+    output.configure()
+
     debug = kwargs.pop('debug', None)
+    if debug in (True, False):
+        output.set_debug('enable' if debug is True else 'disable')
 
-    logfile = None
-    if debug:
-        logfile = os.path.join(kwargs['private_data_dir'], 'debug.log')
-
-    configure_logging(filename=logfile, debug=debug)
+    logfile = kwargs.pop('logfile', None)
+    if logfile:
+        output.set_logfile(logfile)
 
     rc = RunnerConfig(**kwargs)
     rc.prepare()

--- a/ansible_runner/output.py
+++ b/ansible_runner/output.py
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import sys
+import logging
+
+DEBUG_ENABLED = False
+TRACEBACK_ENABLED = True
+
+_display_logger = logging.getLogger('ansible-runner.display')
+_debug_logger = logging.getLogger('ansible-runner.debug')
+
+
+def display(msg, log_only=False):
+    if not log_only:
+        _display_logger.log(70, msg)
+    _debug_logger.log(10, msg)
+
+
+def debug(msg):
+    if DEBUG_ENABLED:
+        if isinstance(msg, Exception):
+            if TRACEBACK_ENABLED:
+                _debug_logger.exception(msg)
+            display(msg.message)
+        else:
+            display(msg)
+
+
+def set_logfile(filename):
+    handlers = [h.get_name() for h in _debug_logger.handlers]
+    if 'logfile' not in handlers:
+        logfile_handler = logging.FileHandler(filename)
+        logfile_handler.set_name('logfile')
+        formatter = logging.Formatter('%(asctime)s: %(message)s')
+        logfile_handler.setFormatter(formatter)
+        _debug_logger.addHandler(logfile_handler)
+
+
+def set_debug(value):
+    global DEBUG_ENABLED
+    if value.lower() not in ('enable', 'disable'):
+        raise ValueError('value must be one of `enable` or `disable`, got %s' % value)
+    DEBUG_ENABLED = value.lower() == 'enable'
+
+
+def set_traceback(value):
+    global TRACEBACK_ENABLED
+    if value.lower() not in ('enable', 'disable'):
+        raise ValueError('value must be one of `enable` or `disable`, got %s' % value)
+    TRACEBACK_ENABLED = value.lower() == 'enable'
+
+
+def configure():
+    '''
+    Configures the logging facility
+
+    This function will setup an initial logging facility for handling display
+    and debug outputs.  The default facility will send display messages to
+    stdout and the default debug facility will do nothing.
+
+    :returns: None
+    '''
+    root_logger = logging.getLogger()
+    root_logger.addHandler(logging.NullHandler())
+    root_logger.setLevel(99)
+
+    _display_logger.setLevel(70)
+    _debug_logger.setLevel(10)
+
+    display_handlers = [h.get_name() for h in _display_logger.handlers]
+
+    if 'stdout' not in display_handlers:
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.set_name('stdout')
+        formatter = logging.Formatter('%(message)s')
+        stdout_handler.setFormatter(formatter)
+        _display_logger.addHandler(stdout_handler)

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -6,18 +6,16 @@ import errno
 import signal
 import codecs
 import collections
-import logging
 
 import pexpect
 import psutil
 
 from .utils import OutputEventFilter
 from .exceptions import CallbackError, AnsibleRunnerException
+from ansible_runner.output import debug
 
 
 class Runner(object):
-
-    logger = logging.getLogger('ansible-runner')
 
     def __init__(self, config, cancel_callback=None, remove_partials=True):
         self.config = config
@@ -52,7 +50,7 @@ class Runner(object):
                 if self.remove_partials:
                     os.remove(partial_filename)
             except IOError as e:
-                self.logger.exception("Failed writing event data: {}".format(e))
+                debug("Failed writing event data: {}".format(e))
 
     def run(self):
         '''

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -21,7 +21,6 @@ import re
 import pipes
 import threading
 import pexpect
-import logging
 import stat
 
 from uuid import uuid4
@@ -29,9 +28,9 @@ from collections import Mapping
 
 from six import iteritems, string_types
 
+from ansible_runner import output
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.loader import ArtifactLoader
-from ansible_runner.utils import display
 
 
 class RunnerConfig(object):
@@ -51,8 +50,6 @@ class RunnerConfig(object):
     >>> r.run()
 
     """
-
-    logger = logging.getLogger('ansible-runner')
 
     def __init__(self,
                  private_data_dir=None, playbook=None, ident=uuid4(),
@@ -74,10 +71,6 @@ class RunnerConfig(object):
 
         self.extra_vars = None
         self.verbosity = verbosity
-
-        self.logger.info('private_data_dir: %s' % self.private_data_dir)
-        self.logger.info('artifact_dir: %s' % self.private_data_dir)
-
         self.loader = ArtifactLoader(self.private_data_dir)
 
     def prepare(self):
@@ -143,8 +136,7 @@ class RunnerConfig(object):
                 for pattern, password in iteritems(passwords)
             }
         except ConfigurationError as exc:
-            self.logger.debug(exc)
-            display('Not loading passwords')
+            output.display('Not loading passwords')
             self.expect_passwords = dict()
         self.expect_passwords[pexpect.TIMEOUT] = None
         self.expect_passwords[pexpect.EOF] = None
@@ -156,8 +148,7 @@ class RunnerConfig(object):
             if envvars:
                 self.env.update({k:str(v) for k, v in envvars.items()})
         except ConfigurationError as exc:
-            self.logger.debug(exc)
-            display("Not loading environment vars")
+            output.display("Not loading environment vars")
             # Still need to pass default environment to pexpect
             self.env = os.environ.copy()
 
@@ -167,15 +158,13 @@ class RunnerConfig(object):
         try:
             self.settings = self.loader.load_file('env/settings', Mapping)
         except ConfigurationError as exc:
-            self.logger.debug(exc)
-            print("Not loading settings")
+            output.display("Not loading settings")
             self.settings = dict()
 
         try:
             self.ssh_key_data = self.loader.load_file('env/ssh_key', string_types)
         except ConfigurationError as exc:
-            self.logger.debug(exc)
-            print("Not loading ssh key")
+            output.display("Not loading ssh key")
             self.ssh_key_data = None
 
         self.idle_timeout = self.settings.get('idle_timeout', 120)

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -6,61 +6,11 @@ import os
 import fcntl
 import tempfile
 import hashlib
-import logging
 import stat
 
-from functools import partial
 from collections import Iterable, Mapping
 from io import StringIO
 from six import string_types
-
-
-STDOUT_MSG_FORMAT = '%(message)s'
-DEBUG_MSG_FORMAT = '%(asctime)s:[%(module)s.%(funcName)s:%(lineno)s]: %(message)s'
-
-LOGGER = logging.getLogger('ansible-runner')
-
-
-display = partial(LOGGER.log, 60)
-
-
-def configure_logging(filename=None, debug=False):
-    '''
-    Configures the logging facility
-
-    Args:
-        filename (string): The name of the file to log debug messages to.  If
-            this argument is None, then file logging is disabled.
-
-        debug (string): Specifies if debug should be sent to stdout.  If the
-            value of this argument is True, debug messages are sent to
-            stdout.  If this value is False, only display messages (level 60)
-            are sent ot stdout.
-
-    Returns:
-        None
-    '''
-    root_logger = logging.getLogger('')
-    root_logger.setLevel(logging.DEBUG)
-
-    # Set up logging to a file
-    if filename:
-        file_handler = logging.FileHandler(filename)
-        formatter = logging.Formatter(DEBUG_MSG_FORMAT)
-        file_handler.setFormatter(formatter)
-        root_logger.addHandler(file_handler)
-
-    stdout_handler = logging.StreamHandler(sys.stdout)
-
-    if debug:
-        stdout_handler.setLevel(10)
-        formatter = logging.Formatter(DEBUG_MSG_FORMAT)
-    else:
-        stdout_handler.setLevel(60)
-        formatter = logging.Formatter(STDOUT_MSG_FORMAT)
-
-    stdout_handler.setFormatter(formatter)
-    root_logger.addHandler(stdout_handler)
 
 
 def isplaybook(obj):

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -32,7 +32,6 @@ def test_runner_config_init_defaults():
     assert rc.module is None
     assert rc.module_args is None
     assert rc.artifact_dir == os.path.join('/artifacts/%s' % rc.ident)
-    assert rc.logger is not None
     assert isinstance(rc.loader, ArtifactLoader)
 
 
@@ -51,7 +50,6 @@ def test_runner_config_init_with_ident():
     assert rc.module is None
     assert rc.module_args is None
     assert rc.artifact_dir == os.path.join('/artifacts/test')
-    assert rc.logger is not None
     assert isinstance(rc.loader, ArtifactLoader)
 
 


### PR DESCRIPTION
This change provides a significant refactoring of the logging and
display facility to better provide output and debug functions.  It moves
the logging capabilities from utils into a separate singleton module
'output' and exposes methods to configure and produce output.

This change updates the entry points for both cli and api operation to
configuring the output.  To send output to there are two convience
functions available: `display` and `debug`.  The `display` function will
send output to `stdout` and to a log file (if enabled).  The `debug`
function will only produce output of the `--debug` option is specified
or the `debug=True` is set from the api interface.

Additionally all logging can be sent to a logfile using the `--logfile`
cli option or `logfile=<path>` for the api interface.