### PR TITLE
Accept option for custom artifacts dir

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -76,6 +76,8 @@ def main():
 
     parser.add_argument("--role-skip-facts", action="store_true", default=False,
                         help="Disable fact collection when executing a role directly")
+    parser.add_argument("--artifact-dir",
+                        help="Path for the artifact root directory")
 
     parser.add_argument("--inventory")
     parser.add_argument("-j", "--json", action="store_true",
@@ -115,6 +117,8 @@ def main():
 
             kwargs = dict(private_data_dir=args.private_data_dir,
                           json_mode=args.json)
+            if args.artifact_dir:
+                kwargs['artifact_dir'] = args.artifact_dir
 
             playbook = None
             tmpvars = None

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -79,6 +79,7 @@ def run(**kwargs):
     :param ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param verbosity: Control how verbose the output of ansible-playbook is
+    :param artifact_dir: The path to the directory where artifacts should live
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -90,6 +91,7 @@ def run(**kwargs):
     :type settings: dict
     :type ssh_key: str
     :type verbosity: int
+    :type artifact_dir: str
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -57,7 +57,7 @@ class RunnerConfig(object):
     def __init__(self,
                  private_data_dir=None, playbook=None, ident=uuid4(),
                  inventory=None, limit=None, module=None, module_args=None,
-                 verbosity=None, json_mode=False):
+                 verbosity=None, json_mode=False, artifact_dir=None):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = ident
         self.json_mode = json_mode
@@ -66,15 +66,17 @@ class RunnerConfig(object):
         self.limit = limit
         self.module = module
         self.module_args = module_args
+        self.artifact_dir = artifact_dir or self.private_data_dir
         if self.ident is None:
-            self.artifact_dir = os.path.join(self.private_data_dir, "artifacts")
+            self.artifact_dir = os.path.join(self.artifact_dir, "artifacts")
         else:
-            self.artifact_dir = os.path.join(self.private_data_dir, "artifacts", "{}".format(self.ident))
+            self.artifact_dir = os.path.join(self.artifact_dir, "artifacts", "{}".format(self.ident))
 
         self.extra_vars = None
         self.verbosity = verbosity
 
         self.logger.info('private_data_dir: %s' % self.private_data_dir)
+        self.logger.info('artifact_dir: %s' % self.private_data_dir)
 
         self.loader = ArtifactLoader(self.private_data_dir)
 

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -36,6 +36,11 @@ def test_runner_config_init_defaults():
     assert isinstance(rc.loader, ArtifactLoader)
 
 
+def test_runner_config_with_artifact_dir():
+    rc = RunnerConfig('/', artifact_dir='/this-is-some-dir')
+    assert rc.artifact_dir == os.path.join('/this-is-some-dir', 'artifacts/%s' % rc.ident)
+
+
 def test_runner_config_init_with_ident():
     rc = RunnerConfig('/', ident='test')
     assert rc.private_data_dir == '/'


### PR DESCRIPTION
As required at https://github.com/ansible/ansible-runner/issues/10, I added the option on RunnerConfig to accept a custom artifact_dir argument. Is this aligned with what you had in mind with your issue @matburt ?
I tested this on the python interface. Will this need to be added somewhere else to be supported by the cli tool?