### PR TITLE
Add support for outputting json instead of raw ansible

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -75,6 +75,8 @@ def main():
                         help="Variables to pass to the role at runtime")
 
     parser.add_argument("--inventory")
+    parser.add_argument("-j", "--json", action="store_true",
+                        help="Output the json event structure to stdout instead of Ansible output")
 
     parser.add_argument("-v", action="count",
                         help="Increase the verbosity with multiple v's (up to 5) of the ansible-playbook output")
@@ -108,7 +110,8 @@ def main():
                     role_vars[key] = value
                 role['vars'] = role_vars
 
-            kwargs = {'private_data_dir': args.private_data_dir}
+            kwargs = dict(private_data_dir=args.private_data_dir,
+                          json_mode=args.json)
 
             playbook = None
             tmpvars = None
@@ -178,7 +181,8 @@ def main():
             run_options = dict(private_data_dir=args.private_data_dir,
                                ident=args.ident,
                                playbook=args.playbook,
-                               verbosity=args.v)
+                               verbosity=args.v,
+                               json_mode=args.json)
             if args.hosts is not None:
                 run_options.update(inventory=args.hosts)
             run(**run_options)

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -60,6 +60,7 @@ def run(**kwargs):
                              module. Output artifacts will also be stored here for later consumption.
     :param ident: The run identifier for this invocation of Runner. Will be used to create and name
                   the artifact directory holding the results of the invocation.
+    :param json_mode: Store event data in place of stdout on the console and in the stdout file
     :param playbook: The playbook (either supplied here as a list or string... or as a path relative to
                      ``private_data_dir/project``) that will be invoked by runner when executing Ansible.
     :param inventory: Overridees the inventory directory/file (supplied at ``private_data_dir/inventory``) with
@@ -80,6 +81,7 @@ def run(**kwargs):
     :param verbosity: Control how verbose the output of ansible-playbook is
     :type private_data_dir: str
     :type ident: str
+    :type json_mode: bool
     :type playbook: str or filename or list
     :type inventory: str or dict or list
     :type envvars: dict

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -72,7 +72,7 @@ class Runner(object):
                 raise
 
         stdout_handle = codecs.open(stdout_filename, 'w', encoding='utf-8')
-        stdout_handle = OutputEventFilter(stdout_handle, self.event_callback)
+        stdout_handle = OutputEventFilter(stdout_handle, self.event_callback, output_json=self.config.json_mode)
 
         if not isinstance(self.config.expect_passwords, collections.OrderedDict):
             # We iterate over `expect_passwords.keys()` and

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -56,10 +56,11 @@ class RunnerConfig(object):
 
     def __init__(self,
                  private_data_dir=None, playbook=None, ident=uuid4(),
-                 inventory=None, limit=None,
-                 module=None, module_args=None, verbosity=None):
+                 inventory=None, limit=None, module=None, module_args=None,
+                 verbosity=None, json_mode=False):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = ident
+        self.json_mode = json_mode
         self.playbook = playbook
         self.inventory = inventory
         self.limit = limit

--- a/docs/container.rst
+++ b/docs/container.rst
@@ -39,3 +39,11 @@ Gathering output from the reference container image
 ---------------------------------------------------
 
 **TODO**
+
+Changing the console output to emit raw events
+----------------------------------------------
+
+This can be useful when directing task-level event data to an external system by means of the container's console output.
+
+See :ref:`outputjson`
+

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -59,3 +59,15 @@ An example invocation using ``demo`` as private directory and ``localhost`` as t
   $ ansible-runner --role testrole --hosts localhost run demo
 
 Ansible roles directory can be provided with ``--roles-path`` option. Role variables can be passed with ``--role-vars`` at runtime.
+
+.. _outputjson:
+
+Outputting json (raw event data) to the console instead of normal output
+------------------------------------------------------------------------
+
+**Runner** supports outputting json event data structure directly to the console (and stdout file) instead of the standard **Ansible** output, thus
+mimicing the behavior of the ``json`` output plugin. This is in addition to the event data that's already present in the artifact directory. All that is needed
+is to supply the ``-j`` argument on the command line::
+
+  $ ansible-runner ... -j ...
+


### PR DESCRIPTION
This fixes/implements https://github.com/ansible/ansible-runner/issues/4

* This mimics the behavior of the Ansible json output plugin, but
  without being so heavy
* Also contains the extra Runner event data
* Update normal docs and programmatic docs