### PR TITLE
Don't show unnecessary tracebacks in the logs

### DIFF
--- a/ansible_runner/loader.py
+++ b/ansible_runner/loader.py
@@ -166,7 +166,6 @@ class ArtifactLoader(object):
             contents = self.get_contents(path)
             parsed_data = contents.encode(encoding)
         except ConfigurationError as exc:
-            self.logger.exception(exc)
             raise
         except UnicodeEncodeError as exc:
             self.logger.exception(exc)

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -141,7 +141,7 @@ class RunnerConfig(object):
                 for pattern, password in iteritems(passwords)
             }
         except ConfigurationError as exc:
-            self.logger.exception(exc)
+            self.logger.debug(exc)
             display('Not loading passwords')
             self.expect_passwords = dict()
         self.expect_passwords[pexpect.TIMEOUT] = None
@@ -154,7 +154,7 @@ class RunnerConfig(object):
             if envvars:
                 self.env.update({k:str(v) for k, v in envvars.items()})
         except ConfigurationError as exc:
-            self.logger.exception(exc)
+            self.logger.debug(exc)
             display("Not loading environment vars")
             # Still need to pass default environment to pexpect
             self.env = os.environ.copy()
@@ -165,14 +165,14 @@ class RunnerConfig(object):
         try:
             self.settings = self.loader.load_file('env/settings', Mapping)
         except ConfigurationError as exc:
-            self.logger.exception(exc)
+            self.logger.debug(exc)
             print("Not loading settings")
             self.settings = dict()
 
         try:
             self.ssh_key_data = self.loader.load_file('env/ssh_key', string_types)
         except ConfigurationError as exc:
-            self.logger.exception(exc)
+            self.logger.debug(exc)
             print("Not loading ssh key")
             self.ssh_key_data = None
 


### PR DESCRIPTION
There are a few parameters at runner config that are optional
but when such parameter is not used a traceback is shown in the logs.
This is a red herring in case one tries to debug the runner.

This patch puts the messages about missing file into a debug level.