### PR TITLE
Add demo cmdline

### DIFF
--- a/demo/env/cmdline
+++ b/demo/env/cmdline
@@ -1,1 +1,0 @@
---tags one,two --skip-tags three -u ansible --become

--- a/demo/env/cmdline
+++ b/demo/env/cmdline
@@ -1,0 +1,1 @@
+--tags one,two --skip-tags three -u ansible --become

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -108,14 +108,14 @@ by providing a yaml or json formatted file with a regular expression and a value
 ``env/cmdline``
 ---------------
 
-.. note::
-    
-    For an example see `the demo cmdline <https://github.com/ansible/ansible-runner/blob/master/demo/env/cmdline>`_
-
 .. warning::
 
     Current **Ansible Runner** does not validate the command line arguments passed using this method so it is up to the playbook writer to provide a valid set of options
     The command line options provided by this method are lower priority than the ones set by **Ansible Runner**.  For instance, this will not override `inventory` or `limit` values.
+
+**Ansible Runner** gathers command line options provided here as a string and supplies them to the **Ansible Process** itself. This file should contain the arguments to be added, for example::
+
+  --tags one,two --skip-tags three -u ansible --become
 
 ``env/ssh_key``
 ---------------


### PR DESCRIPTION
I noticed that the [docs](https://ansible-runner.readthedocs.io/en/latest/intro.html#env-cmdline) linked to https://github.com/ansible/ansible-runner/blob/master/demo/env/cmdline but no such file exists. This creates one from what I saw in #70 