### PR TITLE
add unit tests for AnsibleRunner.run and fix a hang in pexpect.spawn

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -7,6 +7,7 @@ import signal
 import codecs
 import collections
 
+import six
 import pexpect
 import psutil
 
@@ -81,6 +82,12 @@ class Runner(object):
             expect_passwords = collections.OrderedDict(self.config.expect_passwords)
         password_patterns = list(expect_passwords.keys())
         password_values = list(expect_passwords.values())
+
+        # pexpect needs all env vars to be utf-8 encoded strings
+        # https://github.com/pexpect/pexpect/issues/512
+        for k, v in self.config.env.items():
+            if k != 'PATH' and isinstance(v, six.text_type):
+                self.config.env[k] = v.encode('utf-8')
 
         self.status = 'running'
         child = pexpect.spawn(

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+import codecs
+import os
+import re
+
+import mock
+import pexpect
+import pytest
+import six
+
+from ansible_runner import Runner
+from ansible_runner.exceptions import CallbackError
+from ansible_runner.runner_config import RunnerConfig
+
+HERE, FILENAME = os.path.split(__file__)
+
+
+@pytest.fixture(scope='function')
+def rc(request, tmpdir):
+    rc = RunnerConfig(str(tmpdir))
+    rc.suppress_ansible_output = True
+    rc.expect_passwords = {
+        pexpect.TIMEOUT: None,
+        pexpect.EOF: None
+    }
+    rc.cwd = str(tmpdir)
+    rc.env = {}
+    rc.job_timeout = .1
+    rc.idle_timeout = 0
+    rc.pexpect_timeout = .1
+    return rc
+
+
+@pytest.fixture(autouse=True)
+def mock_sleep(request):
+    # the handle_termination process teardown mechanism uses `time.sleep` to
+    # wait on processes to respond to SIGTERM; these are tests and don't care
+    # about being nice
+    m = mock.patch('time.sleep')
+    m.start()
+    request.addfinalizer(m.stop)
+
+
+def test_simple_spawn(rc):
+    rc.command = ['ls', '-la']
+    status, exitcode = Runner(config=rc).run()
+    assert status == 'successful'
+    assert exitcode == 0
+
+
+def test_error_code(rc):
+    rc.command = ['ls', '-nonsense']
+    status, exitcode = Runner(config=rc).run()
+    assert status == 'failed'
+    assert exitcode > 0
+
+
+def test_password_prompt(rc):
+    rc.command = ['python', '-c' 'import time; print raw_input("Password: "); time.sleep(.05)']
+    rc.expect_passwords[re.compile(r'Password:\s*?$', re.M)] = 'secret123'
+    status, exitcode = Runner(config=rc).run()
+    assert status == 'successful'
+    assert exitcode == 0
+    with open(os.path.join(rc.artifact_dir, 'stdout')) as f:
+        assert 'secret123' in f.read()
+
+
+def test_job_timeout(rc):
+    rc.command = ['python', '-c', 'import time; time.sleep(5)']
+    runner = Runner(config=rc)
+    status, exitcode = runner.run()
+    assert status == 'failed'
+    assert runner.timed_out is True
+
+
+def test_cancel_callback(rc):
+    rc.command = ['python', '-c', 'print raw_input("Password: ")']
+    status, exitcode = Runner(config=rc, cancel_callback=lambda: True).run()
+    assert status == 'canceled'
+
+
+def test_cancel_callback_error(rc):
+    def kaboom():
+        raise Exception('kaboom')
+
+    rc.command = ['python', '-c', 'print raw_input("Password: ")']
+    with pytest.raises(CallbackError):
+        Runner(config=rc, cancel_callback=kaboom).run()
+
+
+@pytest.mark.parametrize('value', ['abc123', six.u('Iñtërnâtiônàlizætiøn')])
+def test_env_vars(rc, value):
+    rc.command = ['python', '-c', 'import os; print os.getenv("X_MY_ENV")']
+    rc.env = {'X_MY_ENV': value}
+    status, exitcode = Runner(config=rc).run()
+    assert status == 'successful'
+    assert exitcode == 0
+    with codecs.open(os.path.join(rc.artifact_dir, 'stdout'), 'r', encoding='utf-8') as f:
+        assert value in f.read()

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = flake8-py3, py27, py36
 
 [testenv]
 deps = pipenv
+       mock
 commands=
     pipenv install --ignore-pipfile --dev
     pipenv run py.test test


### PR DESCRIPTION
ansible-runner is susceptible to a bug in `pexpect`/`ptyprocess` that can cause the `pexpect.spawn()` call to hang indefinitely:

https://github.com/pexpect/pexpect/issues/512

This PR forcibly encodes environment variables and also adds a bunch of unit tests to `AnsibleRunner.run()`.