### PR TITLE
Use select() instead of poll()

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -98,7 +98,7 @@ class Runner(object):
             ignore_sighup=True,
             encoding='utf-8',
             echo=False,
-            use_poll=True,
+            use_poll=self.config.pexpect_use_poll,
         )
         child.logfile_read = stdout_handle
         last_stdout_update = time.time()

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -172,6 +172,8 @@ class RunnerConfig(object):
         self.idle_timeout = self.settings.get('idle_timeout', 120)
         self.job_timeout = self.settings.get('job_timeout', 120)
         self.pexpect_timeout = self.settings.get('pexpect_timeout', 5)
+
+        self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
         self.suppress_ansible_output = self.settings.get('suppress_ansible_output', self.quiet)
 
         if 'AD_HOC_COMMAND_ID' in self.env:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -136,6 +136,9 @@ The **settings** file is a little different than the other files provided in thi
   idle_timeout: 600 # If no output is detected from ansible in this number of seconds the execution will be terminated.
   job_timeout: 3600 # The maximum amount of time to allow the job to run for, exceeding this and the execution will be terminated.
   pexpect_timeout: 10 # Number of seconds for the internal pexpect command to wait to block on input before continuuing
+  pexpect_use_poll: True # Use poll() function for communication with child processes instead of select(). select() is used when
+                         # the value is set to ``False``. select() has a known limitation of using only up to 1024 file descriptors.
+
   suppress_ansible_output: False # Allow output from ansible to not be printed to the screen
 
 Inventory


### PR DESCRIPTION
poll() is not compatible with eventlet >= 0.20.0. This patch switches
ansible runner to use select() when communicating with child processes.
The disadvantage is that select() supports only 1024 file descriptors
but for runner it should be enough.

Fixes issue: #90