### PR TITLE
Set pexpect_use_poll for unittests

### DIFF
--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -29,6 +29,7 @@ def rc(request, tmpdir):
     rc.job_timeout = .1
     rc.idle_timeout = 0
     rc.pexpect_timeout = .1
+    rc.pexpect_use_poll = True
     return rc
 
 


### PR DESCRIPTION
This is a follow-up patch for issue/90 which broke unittests.