### PR TITLE
WIP: Adding external event_handler and overriding logging behavior

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -145,7 +145,7 @@ def main():
                 role['vars'] = role_vars
 
             kwargs = dict(private_data_dir=args.private_data_dir,
-                          json_mode=args.json)
+                          json_mode=args.json, ignore_logging=False)
             if args.artifact_dir:
                 kwargs['artifact_dir'] = args.artifact_dir
 
@@ -247,6 +247,7 @@ def main():
                                playbook=args.playbook,
                                verbosity=args.v,
                                quiet=args.quiet,
+                               ignore_logging=False,
                                json_mode=args.json)
 
             if args.hosts is not None:

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -89,6 +89,7 @@ def run(**kwargs):
     :param quiet: Disable all output
     :param artifact_dir: The path to the directory where artifacts should live
     :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself
+    :param cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -104,6 +105,7 @@ def run(**kwargs):
     :type quiet: bool
     :type verbosity: int
     :type event_handler: function
+    :type cancel_callback: function
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''
@@ -122,6 +124,5 @@ def run_async(**kwargs):
     '''
     r = init_runner(**kwargs)
     runner_thread = threading.Thread(target=r.run)
-    #runner_thread.daemon = True
     runner_thread.start()
     return runner_thread, r

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -38,20 +38,23 @@ def init_runner(**kwargs):
     '''
     dump_artifacts(kwargs)
 
-    output.configure()
-
     debug = kwargs.pop('debug', None)
-    if debug in (True, False):
-        output.set_debug('enable' if debug is True else 'disable')
-
     logfile = kwargs.pop('logfile', None)
-    if logfile:
-        output.set_logfile(logfile)
+
+    if not kwargs.pop("ignore_logging", False):
+        output.configure()
+        if debug in (True, False):
+            output.set_debug('enable' if debug is True else 'disable')
+
+        if logfile:
+            output.set_logfile(logfile)
+
+    event_callback_handler = kwargs.pop('event_handler', None)
 
     rc = RunnerConfig(**kwargs)
     rc.prepare()
 
-    return Runner(rc)
+    return Runner(rc, event_handler=event_callback_handler)
 
 
 def run(**kwargs):
@@ -84,6 +87,7 @@ def run(**kwargs):
     :param verbosity: Control how verbose the output of ansible-playbook is
     :param quiet: Disable all output
     :param artifact_dir: The path to the directory where artifacts should live
+    :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -98,6 +102,7 @@ def run(**kwargs):
     :type cmdline: str
     :type quiet: bool
     :type verbosity: int
+    :type event_handler: function
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''
@@ -116,5 +121,6 @@ def run_async(**kwargs):
     '''
     r = init_runner(**kwargs)
     runner_thread = threading.Thread(target=r.run)
+    #runner_thread.daemon = True
     runner_thread.start()
     return runner_thread, r

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -41,7 +41,7 @@ def init_runner(**kwargs):
     debug = kwargs.pop('debug', None)
     logfile = kwargs.pop('logfile', None)
 
-    if not kwargs.pop("ignore_logging", False):
+    if not kwargs.pop("ignore_logging", True):
         output.configure()
         if debug in (True, False):
             output.set_debug('enable' if debug is True else 'disable')

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -51,11 +51,15 @@ def init_runner(**kwargs):
 
     event_callback_handler = kwargs.pop('event_handler', None)
     cancel_callback = kwargs.pop('cancel_callback', None)
+    finished_callback = kwargs.pop('finished_callback',  None)
 
     rc = RunnerConfig(**kwargs)
     rc.prepare()
 
-    return Runner(rc, event_handler=event_callback_handler, cancel_callback=cancel_callback)
+    return Runner(rc,
+                  event_handler=event_callback_handler,
+                  cancel_callback=cancel_callback,
+                  finished_callback=finished_callback)
 
 
 def run(**kwargs):
@@ -90,6 +94,7 @@ def run(**kwargs):
     :param artifact_dir: The path to the directory where artifacts should live
     :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself
     :param cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
+    :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -106,6 +111,7 @@ def run(**kwargs):
     :type verbosity: int
     :type event_handler: function
     :type cancel_callback: function
+    :type finished_callback: function
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -19,10 +19,11 @@ from ansible_runner.output import debug
 
 class Runner(object):
 
-    def __init__(self, config, cancel_callback=None, remove_partials=True, event_handler=None):
+    def __init__(self, config, cancel_callback=None, remove_partials=True, event_handler=None, finished_callback=None):
         self.config = config
         self.cancel_callback = cancel_callback
         self.event_handler = event_handler
+        self.finished_callback = finished_callback
         self.canceled = False
         self.timed_out = False
         self.errored = False
@@ -119,11 +120,11 @@ class Runner(object):
             if self.cancel_callback:
                 try:
                     self.canceled = self.cancel_callback()
-                except Exception:
+                except Exception as e:
                     # TODO: logger.exception('Could not check cancel callback - cancelling immediately')
                     #if isinstance(extra_update_fields, dict):
                     #    extra_update_fields['job_explanation'] = "System error during job execution, check system logs"
-                    raise CallbackError("Exception in Cancel Callback")
+                    raise CallbackError("Exception in Cancel Callback: {}".format(e))
             if not self.canceled and self.config.job_timeout != 0 and (time.time() - job_start) > self.config.job_timeout:
                 self.timed_out = True
                 # if isinstance(extra_update_fields, dict):
@@ -152,6 +153,11 @@ class Runner(object):
                 os.close(os.open(artifact_path, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
             with open(artifact_path, 'w') as f:
                 f.write(str(data))
+        if self.finished_callback is not None:
+            try:
+                self.finished_callback(self)
+            except Exception as e:
+                raise CallbackError("Exception in Finished Callback: {}".format(e))
         return self.status, self.rc
 
     @property

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -1,4 +1,5 @@
 import os
+import re
 import stat
 import time
 import json
@@ -207,8 +208,12 @@ class Runner(object):
         if not os.path.exists(event_path):
             raise AnsibleRunnerException("events missing")
         dir_events = os.listdir(event_path)
-        dir_events.sort(key=lambda filenm: int(filenm.split("-", 1)[0]))
-        for event_file in dir_events:
+        dir_events_actual = []
+        for each_file in dir_events:
+            if re.match("^[0-9]+\-.+json$", each_file):
+                dir_events_actual.append(each_file)
+        dir_events_actual.sort(key=lambda filenm: int(filenm.split("-", 1)[0]))
+        for event_file in dir_events_actual:
             with codecs.open(os.path.join(event_path, event_file), 'r', encoding='utf-8') as event_file_actual:
                 event = json.load(event_file_actual)
             yield event

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -18,9 +18,10 @@ from ansible_runner.output import debug
 
 class Runner(object):
 
-    def __init__(self, config, cancel_callback=None, remove_partials=True):
+    def __init__(self, config, cancel_callback=None, remove_partials=True, event_handler=None):
         self.config = config
         self.cancel_callback = cancel_callback
+        self.event_handler = event_handler
         self.canceled = False
         self.timed_out = False
         self.errored = False
@@ -50,6 +51,8 @@ class Runner(object):
                     json.dump(event_data, write_file)
                 if self.remove_partials:
                     os.remove(partial_filename)
+                if self.event_handler is not None:
+                    self.event_handler(event_data)
             except IOError as e:
                 debug("Failed writing event data: {}".format(e))
 

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -64,6 +64,18 @@ handle containing the ``stdout`` of the **Ansible** process.
 ``Runner.host_events``
 :meth:`ansible_runner.runner.Runner.host_events` is a method that, given a hostname, will return a list of only **Ansible** event data executed on that Host.
 
+``Runner.event_handler``
+------------------------
+
+A function passed to `__init__` of :class:`Runner <ansible_runner.runner.Runner>`, this is invoked every time an Ansible event is received. You can use this to
+inspect/process/handle events as they come out of Ansible.
+
+``Runner.cancel_callback``
+--------------------------
+
+A function passed to ``_init__`` of :class:`Runner <ansible_runner.runner.Runner>`, this function will be called for every iteration of the :meth:`ansible_runner.interface.run`
+event loop and should return `True` to inform **Runner** cancel and shutdown the **Ansible** process or `False` to allow it to continue.
+
 Usage examples
 --------------
 .. code-block:: python

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -73,8 +73,15 @@ inspect/process/handle events as they come out of Ansible.
 ``Runner.cancel_callback``
 --------------------------
 
-A function passed to ``_init__`` of :class:`Runner <ansible_runner.runner.Runner>`, this function will be called for every iteration of the :meth:`ansible_runner.interface.run`
-event loop and should return `True` to inform **Runner** cancel and shutdown the **Ansible** process or `False` to allow it to continue.
+A function passed to ``__init__`` of :class:`Runner <ansible_runner.runner.Runner>`, and to the :meth:`ansible_runner.interface.run` interface functions.
+This function will be called for every iteration of the :meth:`ansible_runner.interface.run` event loop and should return `True`
+to inform **Runner** cancel and shutdown the **Ansible** process or `False` to allow it to continue.
+
+``Runner.finished_callback``
+----------------------------
+
+A function passed to ``__init__`` of :class:`Runner <ansible_runner.runner.Runner>`, and to the :meth:`ansible_runner.interface.run` interface functions.
+This function will be called immediately before the **Runner** event loop finishes once **Ansible** has been shut down.
 
 Usage examples
 --------------


### PR DESCRIPTION
This represents work items needed for my integration of Runner into the Ansible Jupyter kernel: https://github.com/ansible/ansible-jupyter-kernel

Specifically this branch: https://github.com/matburt/ansible-jupyter-kernel/tree/ansible_runner_backend

while working on this integration I also found this: https://github.com/ansible/ansible-runner/issues/92

This features likely will/would also be enjoyed by other module interface consumers:
* An event callback handler can now be passed down into the Runner to
  get callbacks related to events that Runner processes
* Adds an option to the interface helpers to completely
  override/bypass Runner's logging initialization
* A `finished` callback event option