### PR TITLE
Adding roles_path to python interface

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -78,6 +78,7 @@ def run(**kwargs):
       - Path to the inventory file in the ``private_data_dir``
       - Native python dict supporting the YAML/json inventory structure
       - A text INI formatted string
+    :param roles_path: Directory or list of directories to assign to ANSIBLE_ROLES_PATH
     :param envvars: Environment variables to be used when running Ansible. Environment variables will also be
                     read from ``env/envvars`` in ``private_data_dir``
     :param extravars: Extra variables to be passed to Ansible at runtime using ``-e``. Extra vars will also be

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -55,7 +55,7 @@ class RunnerConfig(object):
 
     def __init__(self,
                  private_data_dir=None, playbook=None, ident=uuid4(),
-                 inventory=None, limit=None, module=None, module_args=None,
+                 inventory=None, roles_path=None, limit=None, module=None, module_args=None,
                  verbosity=None, quiet=False, json_mode=False, artifact_dir=None,
                  rotate_artifacts=0):
         self.private_data_dir = os.path.abspath(private_data_dir)
@@ -63,6 +63,7 @@ class RunnerConfig(object):
         self.json_mode = json_mode
         self.playbook = playbook
         self.inventory = inventory
+        self.roles_path = roles_path
         self.limit = limit
         self.module = module
         self.module_args = module_args
@@ -124,6 +125,8 @@ class RunnerConfig(object):
         self.env['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
         self.env['AWX_ISOLATED_DATA_DIR'] = self.artifact_dir
         self.env['PYTHONPATH'] = self.env.get('PYTHONPATH', '') + callback_dir + ':'
+        if self.roles_path:
+            self.env['ANSIBLE_ROLES_PATH'] = ':'.join(roles_path)
 
     def prepare_inventory(self):
         """


### PR DESCRIPTION
When invoking ansible_runner via importing python modules there is not
a way to override the roles path. This allows the roles_path parameter
to override ANSIBLE_ROLES_PATH the same way that --roles-path does on
the cli.