### PR TITLE
fixes a minor bug that would leak output when --quiet is used

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -229,7 +229,8 @@ class OutputEventFilter(object):
 
             self._last_chunk = remainder
         else:
-            sys.stdout.write(data + '\n')
+            if not self.suppress_ansible_output:
+                sys.stdout.write(data + '\n')
             self._handle.write(data + '\n')
 
     def close(self):


### PR DESCRIPTION
This change fixes a minor bug that allows output to leak out when the
quiet argument is in effect in some cases.  This fix will now check if
quiet is enabled in all cases and suppress all output.