### PR TITLE
Implement a plugin architecture for emitting events

### DIFF
--- a/ansible_runner/__init__.py
+++ b/ansible_runner/__init__.py
@@ -1,5 +1,13 @@
+import pkg_resources
 
 from .interface import run, run_async # noqa
 from .exceptions import AnsibleRunnerException, ConfigurationError, CallbackError # noqa
 from .runner_config import RunnerConfig # noqa
 from .runner import Runner # noqa
+
+plugins = {
+    entry_point.name: entry_point.load()
+    for entry_point
+    in pkg_resources.iter_entry_points('ansible_runner.plugins')
+}
+

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -100,6 +100,7 @@ def run(**kwargs):
     :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself
     :param cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
     :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
+    :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -118,6 +119,7 @@ def run(**kwargs):
     :type event_handler: function
     :type cancel_callback: function
     :type finished_callback: function
+    :type status_handler: function
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -98,7 +98,7 @@ class RunnerConfig(object):
             raise ConfigurationError("Runner Base Directory is not defined")
         if self.module is None and self.playbook is None: # TODO: ad-hoc mode, module and args
             raise ConfigurationError("Runner playbook or module is not defined")
-        if len(filter(None, [self.module, self.playbook])) > 1:
+        if self.module and self.playbook:
             raise ConfigurationError("Only one of playbook and module options are allowed")
         if not os.path.exists(self.artifact_dir):
             os.makedirs(self.artifact_dir)
@@ -129,7 +129,7 @@ class RunnerConfig(object):
         self.env['AWX_ISOLATED_DATA_DIR'] = self.artifact_dir
         self.env['PYTHONPATH'] = self.env.get('PYTHONPATH', '') + callback_dir + ':'
         if self.roles_path:
-            self.env['ANSIBLE_ROLES_PATH'] = ':'.join(roles_path)
+            self.env['ANSIBLE_ROLES_PATH'] = ':'.join(self.roles_path)
 
     def prepare_inventory(self):
         """

--- a/docs/external_interface.rst
+++ b/docs/external_interface.rst
@@ -1,0 +1,78 @@
+.. _externalintf:
+
+Sending Runner Status and Events to External Systems
+====================================================
+
+**Runner** can store event and status data locally for retrieval, it can also emit this information via callbacks provided to the module interface.
+
+Alternatively **Runner** can be configured to send events to an external system via installable plugins, there are currently two available
+
+.. _plugineventstructure:
+
+Event Structure
+---------------
+
+There are two types of events that are emitted via plugins:
+
+* status events:
+
+  These are sent whenever Runner's status changes (see :ref:`runnerstatushandler`) for example::
+
+    {"status": "running", "runner_ident": "XXXX" }
+
+* ansible events:
+
+  These are sent during playbook execution for every event received from **Ansible** (see :ref:`Playbook and Host Events<artifactevents>`) for example::
+
+    {"runner_ident": "XXXX", <rest of event structure }
+
+.. _httpemitterplugin:
+
+HTTP Status/Event Emitter Plugin
+--------------------------------
+
+This sends status and event data to a URL in the form of json encoded POST requests.
+
+This plugin is available from the `ansible-runner-http github repo <https://github.com/ansible/ansible-runner-http>`_ and is also available to be installed from
+pip::
+
+  $ pip install ansible-runner-http
+
+In order to configure it, you can provide details in the Runner Settings file (see :ref:`runnersettings`):
+
+* `runner_http_url`: The url to receive the ``POST``
+* `runner_http_headers`: Headers to send along with the request.
+
+The plugin also supports unix file-based sockets with:
+
+* `runner_http_url`: The path to the unix socket
+* `runner_http_path`: The path that will be included as part of the request to the socket
+
+Some of these settings are also available as environment variables:
+
+* RUNNER_HTTP_URL
+* RUNNER_HTTP_PATH
+
+.. _zmqemitterplugin:
+
+ZeroMQ Status/Event Emitter Plugin
+----------------------------------
+
+TODO
+
+Writing your own Plugin
+-----------------------
+
+In order to write your own plugin interface and have it be picked up and used by **Runner** there are a few things that you'll need to do.
+
+* Declare the module as a Runner entrypoint in your setup file
+  (`ansible-runner-http has a good example of this <https://github.com/ansible/ansible-runner-http/blob/master/setup.py>`_)::
+
+    entry_points=('ansible_runner.plugins': 'modname = your_python_package_name'),
+
+* Implement the ``status_handler()`` and ``event_handler()`` functions at the top of your package, for example see
+  `ansible-runner-http events.py <https://github.com/ansible/ansible-runner-http/blob/master/ansible_runner_http/events.py>`_ and the ``__init__``
+  import `at the top of the module package <https://github.com/ansible/ansible-runner-http/blob/master/ansible_runner_http/__init__.py>`_
+
+After installing this, **Runner** will see the plugin and invoke the functions when status and events are sent. If there are any errors in your plugin
+they will be raised immediately and **Runner** will fail.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,8 @@ Ansible Runner
 
 Ansible Runner is a tool and python library that helps when interfacing with Ansible directly or as part of another system
 whether that be through a container image interface, as a standalone tool, or as a Python module that can be imported. The goal
-is to provide a stable and consistent interface abstraction to Ansible.
+is to provide a stable and consistent interface abstraction to Ansible. This allows **Ansible** to be embedded into other systems that don't
+want to manage the complexities of the interface on their own (such as CI/CD platforms, Jenkins, or other automated tooling).
 
 **Ansible Runner** represents the modularization of the part of `Ansible Tower/AWX <https://github.com/ansible/awx>`_ that is responsible
 for running ``ansible`` and ``ansible-playbook`` tasks and gathers the output from it. It does this by presenting a common interface that doesn't
@@ -23,6 +24,13 @@ There are 3 primary ways of interacting with **Runner**
 * A reference container image that can be used as a base for your own images and will work as a standalone container or running in
   Openshift or Kubernetes
 * A python module - library interface
+
+**Ansible Runner** can also be configured to send status and event data to other systems using a plugin interface, see :ref:`externalintf`.
+
+Examples of this could include:
+
+* Sending status to Ansible Tower/AWX
+* Sending events to an external logging service
 
 
 .. toctree::

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -209,7 +209,7 @@ The **status** file contains one of three statuses suitable for displaying:
 
 * success: The **Ansible** process finished successfully
 * failed: The **Ansible** process failed
-* timeout: The **Runner** timeout (see :ref:`runnersettings`)`
+* timeout: The **Runner** timeout (see :ref:`runnersettings`)
 
 The **stdout** file contains the actual stdout as it appears at that moment.
 

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -83,6 +83,20 @@ to inform **Runner** cancel and shutdown the **Ansible** process or `False` to a
 A function passed to ``__init__`` of :class:`Runner <ansible_runner.runner.Runner>`, and to the :meth:`ansible_runner.interface.run` interface functions.
 This function will be called immediately before the **Runner** event loop finishes once **Ansible** has been shut down.
 
+.. _runnerstatushandler:
+
+``Runner.status_handler``
+-------------------------
+
+A function passed to ``__init__`` of :class:`Runner <ansible_runner.runner.Runner>` and to the :meth:`ansible_runner.interface.run` interface functions.
+This function will be called any time the ``status`` changes, expected values are:
+
+* `starting`: Preparing to start but hasn't started running yet
+* `running`: The **Ansible** task is running
+* `canceled`: The task was manually canceled either via callback or the cli
+* `timeout`: The timeout configured in Runner Settings was reached (see :ref:`runnersettings`)
+* `failed`: The **Ansible** process failed
+
 Usage examples
 --------------
 .. code-block:: python

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -52,7 +52,7 @@ An example invocation using ``demo`` as private directory::
   $ ansible-runner --playbook test.yml run demo
 
 Running Modules Directly
-----------------------
+------------------------
 
 An example invocating the ``debug`` module with ``demo`` as a private directory::
 


### PR DESCRIPTION
* Implemented using package entry points
* Adds a status_handler standalone callback for when Runner is invoked
  as a module.
* Fixed an issue checking playbook vs ad-hoc where len(filter())
  doesn't work on python3