### PR TITLE
Add runner ident to event data structure

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -51,6 +51,7 @@ class Runner(object):
                                          '{}-{}.json'.format(event_data['counter'],
                                                              event_data['uuid']))
             try:
+                event_data.update(dict(runner_ident=str(self.config.ident)))
                 with codecs.open(partial_filename, 'r', encoding='utf-8') as read_file:
                     partial_event_data = json.load(read_file)
                 event_data.update(partial_event_data)

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -61,11 +61,8 @@ class Runner(object):
                     should_write = self.event_handler(event_data)
                 else:
                     should_write = True
-                if ansible_runner.plugins:
-                    plugin_event = dict(runner_ident=str(self.config.ident))
-                    plugin_event.update(event_data)
                 for plugin in ansible_runner.plugins:
-                    ansible_runner.plugins[plugin].event_handler(self.config, plugin_event)
+                    ansible_runner.plugins[plugin].event_handler(self.config, event_data)
                 if should_write:
                     with codecs.open(full_filename, 'w', encoding='utf-8') as write_file:
                         json.dump(event_data, write_file)

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -9,16 +9,11 @@ import pexpect
 import pytest
 import six
 
-from StringIO import StringIO
-
 from ansible_runner import Runner
 from ansible_runner.exceptions import CallbackError
 from ansible_runner.runner_config import RunnerConfig
 
 HERE, FILENAME = os.path.split(__file__)
-
-
-# TODO: callback data structure verification
 
 
 @pytest.fixture(scope='function')

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -15,6 +15,9 @@ from ansible_runner.runner_config import RunnerConfig
 HERE, FILENAME = os.path.split(__file__)
 
 
+# TODO: callback data structure verification
+
+
 @pytest.fixture(scope='function')
 def rc(request, tmpdir):
     rc = RunnerConfig(str(tmpdir))


### PR DESCRIPTION
ref #131 

If a system is attempting to track multiple simultaneous jobs this
will make it easier to distinguish events and associate them with the
actual work, rather then the system needing to hold a context to the
Runner object itself