### PR TITLE
Fix an issue where the ssh sock path could be too long

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+1.1.2 (soon)
+++++++++++++
+
+- Fix an issue where ssh sock path could be too long
+
 1.1.1 (2018-09-13)
 ++++++++++++++++++
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ADD utils/entrypoint.sh /entrypoint.sh
 ADD demo/project /runner/project
 ADD demo/env /runner/env
 ADD demo/inventory /runner/inventory
-ADD dist/ansible_runner-1.1.0-py2.py3-none-any.whl /ansible_runner-1.1.0-py2.py3-none-any.whl
+ADD dist/ansible_runner-1.1.1-py2.py3-none-any.whl /ansible_runner-1.1.1-py2.py3-none-any.whl
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN chmod 755 /entrypoint.sh && chmod -R g+w /runner && chgrp -R root /runner && \

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -111,9 +111,8 @@ class RunnerConfig(object):
         # write the SSH key data into a fifo read by ssh-agent
         if self.ssh_key_data:
             self.ssh_key_path = os.path.join(self.artifact_dir, 'ssh_key_data')
-            self.ssh_auth_sock = os.path.join(self.artifact_dir, 'ssh_auth.sock')
             self.open_fifo_write(self.ssh_key_path, self.ssh_key_data)
-            self.command = self.wrap_args_with_ssh_agent(self.command, self.ssh_key_path, self.ssh_auth_sock)
+            self.command = self.wrap_args_with_ssh_agent(self.command, self.ssh_key_path)
 
         # Use local callback directory
         callback_dir = os.getenv('AWX_LIB_DIRECTORY')

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -291,7 +291,6 @@ def test_prepare():
     assert rc.prepare_command.called
 
     assert not hasattr(rc, 'ssh_key_path')
-    assert not hasattr(rc, 'ssh_auth_sock')
     assert not hasattr(rc, 'command')
 
     assert rc.env['ANSIBLE_STDOUT_CALLBACK'] == 'awx_display'
@@ -327,7 +326,6 @@ def test_prepare_with_ssh_key():
     rc.prepare()
 
     assert rc.ssh_key_path == '/ssh_key_data'
-    assert rc.ssh_auth_sock == '/ssh_auth.sock'
     assert rc.wrap_args_with_ssh_agent.called
     assert rc.open_fifo_write.called
 


### PR DESCRIPTION
A long time ago in Tower/AWX we defined our own ssh sock path due to the
way it interacted negatively with proot. bwrap doesn't seem to have the same issue.

ref: #136 