### PR TITLE
handle extravars passed to RunnerConfig via interface

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -238,7 +238,7 @@ class RunnerConfig(object):
             exec_list.append("--limit")
             exec_list.append(self.limit)
 
-        if type(self.extra_vars) == dict:
+        if (type(self.extra_vars) == dict) and self.extra_vars:
             exec_list.extend(
                 [
                     '-e',

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -238,7 +238,7 @@ class RunnerConfig(object):
             exec_list.append("--limit")
             exec_list.append(self.limit)
 
-        if (type(self.extra_vars) == dict) and self.extra_vars:
+        if isinstance(self.extra_vars, dict) and self.extra_vars:
             exec_list.extend(
                 [
                     '-e',

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -215,6 +215,7 @@ def test_generate_ansible_command():
     assert cmd == ['ansible', '-i', '/inventory', '-m', 'setup', '-a', 'test=string']
     rc.module_args = None
 
+
 def test_generate_ansible_command_with_api_extravars():
     rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo":"bar"})
     rc.prepare_inventory()

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -215,6 +215,13 @@ def test_generate_ansible_command():
     assert cmd == ['ansible', '-i', '/inventory', '-m', 'setup', '-a', 'test=string']
     rc.module_args = None
 
+def test_generate_ansible_command_with_api_extravars():
+    rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo":"bar"})
+    rc.prepare_inventory()
+
+    cmd = rc.generate_ansible_command()
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '\'foo="bar"\'', 'main.yaml']
+
 
 def test_generate_ansible_command_with_cmdline_args():
     rc = RunnerConfig(private_data_dir='/', playbook='main.yaml')
@@ -226,7 +233,6 @@ def test_generate_ansible_command_with_cmdline_args():
     with patch.object(rc.loader, 'load_file', side_effect=cmdline_side_effect):
         cmd = rc.generate_ansible_command()
         assert cmd == ['ansible-playbook', '--tags', 'foo', '--skip-tags', '-i', '/inventory', 'main.yaml']
-
 
 
 def test_prepare_command_defaults():


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

Currently the docstring for `ansible_runner.run` claims you can pass a dict parameter `extravars`, but it's not implemented and passing that param causes `Error: __init__() got an unexpected keyword argument 'extravars'.`
