### PR TITLE
add missing handling of status_handler-parameter

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -50,6 +50,7 @@ def init_runner(**kwargs):
             output.set_logfile(logfile)
 
     event_callback_handler = kwargs.pop('event_handler', None)
+    status_callback_handler = kwargs.pop('status_handler', None)
     cancel_callback = kwargs.pop('cancel_callback', None)
     finished_callback = kwargs.pop('finished_callback',  None)
 
@@ -58,6 +59,7 @@ def init_runner(**kwargs):
 
     return Runner(rc,
                   event_handler=event_callback_handler,
+                  status_handler=status_callback_handler,
                   cancel_callback=cancel_callback,
                   finished_callback=finished_callback)
 


### PR DESCRIPTION
Hello,

While playing around with ansible-runner, I noticed the `RunnerConfig` raises a TypeError *"__init__() got an unexpected keyword argument 'status_handler'"* when passing `status_handler` as advertised in `ansible_runner.run`'s documentation. 

I think my simple fix solves the problem — it did at least for my use case. I did not find any tests covering the *init_runner*, so I hope this PR is ok without tests. Otherwise I'll rework this PR and try to add a test…