### PR TITLE
DNM - Example tox job using ephemeral node

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,17 @@
+- job:
+    name: tox-all
+    parent: tox
+    vars:
+      tox_envlist: ALL
+    nodeset:
+      nodes:
+        - name: fedora-28
+          label: ansible-fedora-28-1vcpu
+
+- project:
+    check:
+      jobs:
+        - tox-all
+    gate:
+      jobs:
+        - tox-all

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see http://docs.openstack.org/infra/bindep/ for additional information.
+
+gcc-c++ [test platform:rpm]


### PR DESCRIPTION
Today we have fedora-28-1vcpu in 2 providers (4 regions), which will
offer redundancy to infrastructure failures.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>