### PR TITLE
unify data passed to status_handler

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -71,12 +71,11 @@ class Runner(object):
 
     def status_callback(self, status):
         self.status = status
+        status_data = dict(status=status, runner_ident=str(self.config.ident))
         for plugin in ansible_runner.plugins:
-            ansible_runner.plugins[plugin].status_handler(self.config,
-                                                          dict(status=status,
-                                                               runner_ident=str(self.config.ident)))
+            ansible_runner.plugins[plugin].status_handler(self.config, status_data)
         if self.status_handler is not None:
-            self.status_handler(status)
+            self.status_handler(status_data)
 
     def run(self):
         '''

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -109,5 +109,5 @@ def test_status_callback_interface(rc):
     runner.status_handler = mock.Mock()
     runner.status_callback("running")
     assert runner.status_handler.call_count == 1
-    runner.status_handler.assert_called_with('running')
+    runner.status_handler.assert_called_with(dict(status='running', runner_ident=str(rc.ident)))
     assert runner.status == 'running'


### PR DESCRIPTION
- pass the same data/payload to status_handler, no matter if it has
been defined via plugin or via callback to the runner
- this fixes #141