### PR TITLE
Remove bubblewrap from RPM spec file

### DIFF
--- a/packaging/rpm/ansible-runner.spec.j2
+++ b/packaging/rpm/ansible-runner.spec.j2
@@ -12,7 +12,6 @@ BuildArch: noarch
 BuildRequires: python-setuptools
 
 Requires: ansible
-Requires: bubblewrap
 Requires: bzip2
 Requires: openssh
 Requires: openssh-clients


### PR DESCRIPTION
This was a mistake. Bubblewrap is not a hard requirement.