### PR TITLE
Fix initialization race in awx_display_callback (#168)

### DIFF
--- a/ansible_runner/display_callback/events.py
+++ b/ansible_runner/display_callback/events.py
@@ -65,6 +65,7 @@ class EventContext(object):
 
     def __init__(self):
         self.display_lock = multiprocessing.RLock()
+        self._local = threading.local()
         if os.getenv('AWX_ISOLATED_DATA_DIR', False):
             self.cache = IsolatedFileWrite()
         # TODO: Solve for Tower
@@ -73,15 +74,13 @@ class EventContext(object):
         #     self.cache = memcache.Client([cache_actual], debug=0)
 
     def add_local(self, **kwargs):
-        if not hasattr(self, '_local'):
-            self._local = threading.local()
-            self._local._ctx = {}
-        self._local._ctx.update(kwargs)
+        tls = vars(self._local)
+        ctx = tls.setdefault('_ctx', {})
+        ctx.update(kwargs)
 
     def remove_local(self, **kwargs):
-        if hasattr(self, '_local'):
-            for key in kwargs.keys():
-                self._local._ctx.pop(key, None)
+        for key in kwargs.keys():
+            self._local._ctx.pop(key, None)
 
     @contextlib.contextmanager
     def set_local(self, **kwargs):


### PR DESCRIPTION
##### SUMMARY

When thread A and B compete to execute set_local() for the first time, no synchronization occurs on creation of the threading.local() object, resulting in an easy to hit sequence like:

```
  add_local():
    A: if not hasattr(self, '_local')
    B: if not hasattr(self, '_local')
    A: self._local = threading.local()
    A: self._local._ctx = {}
    B: self._local = threading.local()  # new TLS key! A's _ctx discarded
    B: self._local._ctx = {}

  remove_local():
    B: self._local._ctx.pop(key, None)  # succeeds
    A: self._local._ctx.pop(key, None)  # AttributeError
```

The fix is simple: local() object construction is not magically thread safe, only attribute and `__dict__` access are thread-safe. So move local() construction to the (single-threaded) EventContext constructor.

This is easily triggered by Mitogen running with -vvv, where multiple threads can generate display.*() calls.

See: https://github.com/dw/mitogen/issues/400

Closes #168.


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

 - Display Callback


##### ADDITIONAL INFORMATION

To reproduce:

1. Configure Mitogen
2. Run job with -vvv
3. Notice job crashes with AttributeError.

