### PR TITLE
Update utils.py

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -100,6 +100,7 @@ def dump_artifact(obj, path, filename=None):
                 f.write(str(obj))
         finally:
             fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
             os.remove(lock_fp)
 
     return fn


### PR DESCRIPTION
Close dump_artifact lock file before removing file to avoid orphaning descriptor.