### PR TITLE
Fix extra output in stdout play (#182)

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -262,11 +262,6 @@ class OutputEventFilter(object):
                 self._handle.flush()
 
             self._last_chunk = remainder
-        else:
-            if not self.suppress_ansible_output:
-                sys.stdout.write(data + '\n')
-            self._handle.write(data + '\n')
-            self._handle.flush()
 
     def close(self):
         value = self._buffer.getvalue()


### PR DESCRIPTION
I'm not sure why this modification resolves the issue, other than thoses lines were responsible for the extra output I was seeing.

This should closes #182.

Feel free to close this if it is not relevant.