### PR TITLE
allow PYTHONPATH to be overwritten

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -128,13 +128,13 @@ class RunnerConfig(object):
             self.command = self.wrap_args_with_ssh_agent(self.command, self.ssh_key_path)
 
         # Use local callback directory
-        callback_dir = os.getenv('AWX_LIB_DIRECTORY')
+        callback_dir = self.env.get('AWX_LIB_DIRECTORY', os.getenv('AWX_LIB_DIRECTORY'))
         if callback_dir is None:
             callback_dir = os.path.join(os.path.split(os.path.abspath(__file__))[0],
                                         "callbacks")
-        python_path = os.getenv('PYTHONPATH', '')
-        if python_path:
-            python_path += ":"
+        python_path = self.env.get('PYTHONPATH', os.getenv('PYTHONPATH', ''))
+        if python_path and not python_path.endswith(':'):
+            python_path += ':'
         self.env['ANSIBLE_CALLBACK_PLUGINS'] = callback_dir
         if 'AD_HOC_COMMAND_ID' in self.env:
             self.env['ANSIBLE_STDOUT_CALLBACK'] = 'minimal'
@@ -144,7 +144,7 @@ class RunnerConfig(object):
         self.env['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
         self.env['AWX_ISOLATED_DATA_DIR'] = self.artifact_dir
 
-        self.env['PYTHONPATH'] = python_path + callback_dir + ':'
+        self.env['PYTHONPATH'] = python_path + callback_dir
         if self.roles_path:
             self.env['ANSIBLE_ROLES_PATH'] = ':'.join(self.roles_path)
 

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -289,7 +289,8 @@ def test_prepare():
     rc.env = {}
     rc.playbook = 'main.yaml'
 
-    os.environ['AWX_LIB_DIRECTORY'] = '/'
+    os.environ['PYTHONPATH'] = '/python_path_via_environ'
+    os.environ['AWX_LIB_DIRECTORY'] = '/awx_lib_directory_via_environ'
 
     rc.prepare()
 
@@ -304,11 +305,14 @@ def test_prepare():
     assert rc.env['ANSIBLE_RETRY_FILES_ENABLED'] == 'False'
     assert rc.env['ANSIBLE_HOST_KEY_CHECKING'] == 'False'
     assert rc.env['AWX_ISOLATED_DATA_DIR'] == '/'
-    assert rc.env['PYTHONPATH'] == '/:'
+    assert rc.env['PYTHONPATH'] == '/python_path_via_environ:/awx_lib_directory_via_environ', \
+        "PYTHONPATH is the union of the env PYTHONPATH and AWX_LIB_DIRECTORY"
 
-    os.environ['PYTHONPATH'] = "/foo/bar"
+    del rc.env['PYTHONPATH']
+    os.environ['PYTHONPATH'] = "/foo/bar/python_path_via_environ"
     rc.prepare()
-    assert rc.env['PYTHONPATH'] == "/foo/bar:/:"
+    assert rc.env['PYTHONPATH'] == "/foo/bar/python_path_via_environ:/awx_lib_directory_via_environ", \
+        "PYTHONPATH is the union of the explicit env['PYTHONPATH'] override and AWX_LIB_DIRECTORY"
 
 
 def test_prepare_with_ssh_key():


### PR DESCRIPTION
* Allow PYTHONPATH to be specified via envvars interface and append
runner environment.