### PR TITLE
Adds jsonfile fact caching

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -116,6 +116,9 @@ def run(**kwargs):
     :param process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
     :param process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
     :param process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
+    :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
+                       This is only used for 'jsonfile' type fact caches.
+    :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -141,6 +144,8 @@ def run(**kwargs):
     :type process_isolation_hide_paths: str or list
     :type process_isolation_show_paths: str or list
     :type process_isolation_ro_paths: str or list
+    :type fact_cache: str
+    :type fact_cache_type: str
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -297,3 +297,27 @@ class Runner(object):
                 os.kill(pid, signal.SIGKILL)
             except (OSError):
                 pass
+
+    def get_fact_cache(self, host):
+        '''
+        Get the entire fact cache only if the fact_cache_type is 'jsonfile'
+        '''
+        if self.config.fact_cache_type != 'jsonfile':
+            raise Exception('Unsupported fact cache type.  Only "jsonfile" is supported for reading and writing facts from ansible-runner')
+        fact_cache = os.path.join(self.config.fact_cache, host)
+        if os.path.exists(fact_cache):
+            with open(fact_cache) as f:
+                return json.loads(f.read())
+        return {}
+
+    def set_fact_cache(self, host, data):
+        '''
+        Set the entire fact cache data only if the fact_cache_type is 'jsonfile'
+        '''
+        if self.config.fact_cache_type != 'jsonfile':
+            raise Exception('Unsupported fact cache type.  Only "jsonfile" is supported for reading and writing facts from ansible-runner')
+        fact_cache = os.path.join(self.config.fact_cache, host)
+        if not os.path.exists(os.path.dirname(fact_cache)):
+            os.makedirs(os.path.dirname(fact_cache))
+        with open(fact_cache, 'w') as f:
+            return f.write(json.dumps(data))

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -132,16 +132,16 @@ This file should contain the ssh private key used to connect to the host(s). **R
 ``env/settings`` - Settings for Runner itself
 ---------------------------------------------
 
-The **settings** file is a little different than the other files provided in this section in that its contents are meant to control **Runner** directly::
+The **settings** file is a little different than the other files provided in this section in that its contents are meant to control **Runner** directly.
 
-  ---
-  idle_timeout: 600 # If no output is detected from ansible in this number of seconds the execution will be terminated.
-  job_timeout: 3600 # The maximum amount of time to allow the job to run for, exceeding this and the execution will be terminated.
-  pexpect_timeout: 10 # Number of seconds for the internal pexpect command to wait to block on input before continuing
-  pexpect_use_poll: True # Use poll() function for communication with child processes instead of select(). select() is used when
-                         # the value is set to ``False``. select() has a known limitation of using only up to 1024 file descriptors.
+* ``idle_timeout``: ``600`` If no output is detected from ansible in this number of seconds the execution will be terminated.
+* ``job_timeout``: ``3600`` The maximum amount of time to allow the job to run for, exceeding this and the execution will be terminated.
+* ``pexpect_timeout``: ``10`` Number of seconds for the internal pexpect command to wait to block on input before continuing
+* ``pexpect_use_poll``: ``True`` Use ``poll()`` function for communication with child processes instead of ``select()``. ``select()`` is used when the value is set to ``False``. ``select()`` has a known limitation of using only up to 1024 file descriptors.
 
-  suppress_ansible_output: False # Allow output from ansible to not be printed to the screen
+* ``suppress_ansible_output``: ``False`` Allow output from ansible to not be printed to the screen
+* ``fact_cache``: ``'fact_cache'`` The directory relative to ``artifacts`` where ``jsonfile`` fact caching will be stored.  Defaults to ``fact_cache``.  This is ignored if ``fact_cache_type`` is different than ``jsonfile``.
+* ``fact_cache_type``: ``'jsonfile'`` The type of fact cache to use.  Defaults to ``jsonfile``.
 
 Inventory
 ---------

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -193,3 +193,37 @@ def test_run_command_ansible_rotate_artifacts(rc):
     status, exitcode = runner.run()
     assert status == 'successful'
     assert exitcode == 0
+
+
+def test_get_fact_cache(rc):
+    assert os.path.basename(rc.fact_cache) == 'fact_cache'
+    rc.module = "setup"
+    rc.host_pattern = "localhost"
+    rc.prepare()
+    runner = Runner(config=rc)
+    status, exitcode = runner.run()
+    assert status == 'successful'
+    assert exitcode == 0
+    print(rc.cwd)
+    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache'))
+    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache', 'localhost'))
+    data = runner.get_fact_cache('localhost')
+    assert data
+
+
+def test_set_fact_cache(rc):
+    assert os.path.basename(rc.fact_cache) == 'fact_cache'
+    rc.module = "debug"
+    rc.module_args = "var=message"
+    rc.host_pattern = "localhost"
+    rc.prepare()
+    runner = Runner(config=rc)
+    runner.set_fact_cache('localhost', dict(message='hello there'))
+    status, exitcode = runner.run()
+    assert status == 'successful'
+    assert exitcode == 0
+    print(rc.cwd)
+    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache'))
+    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache', 'localhost'))
+    data = runner.get_fact_cache('localhost')
+    assert data['message'] == 'hello there'


### PR DESCRIPTION
Adds fact caching to runner using the `jsonfile` plugin.  This adds setter and getter methods that read and write the JSON fact cache from the `Runner` instance.   This adds a new setting to `RunnerConfig` named 'fact_cache' which can be provided using `env/settings` or setting it on the `RunnerConfig` instance.

The default behavior is to create the fact cache in the `project/fact_cache` directory. The location of the directory can be changed using the `fact_cache` setting or argument to `RunnerConfig`.