### PR TITLE
rm ansible requirement for rpm

### DIFF
--- a/packaging/rpm/ansible-runner.spec.j2
+++ b/packaging/rpm/ansible-runner.spec.j2
@@ -11,7 +11,6 @@ Url: http://ansible.com
 BuildArch: noarch
 BuildRequires: python-setuptools
 
-Requires: ansible
 Requires: bzip2
 Requires: openssh
 Requires: openssh-clients


### PR DESCRIPTION
We do not intend to require the ansible package explicitly when installing ansible-runner via an rpm.  This removes that requirement.  