### PR TITLE
expose utility functions

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -18,8 +18,6 @@
 #
 import os
 import re
-import pipes
-import threading
 import pexpect
 import stat
 import shlex
@@ -35,6 +33,10 @@ from six import iteritems, string_types
 from ansible_runner import output
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.loader import ArtifactLoader
+from ansible_runner.utils import (
+    open_fifo_write,
+    args2cmdline,
+)
 
 logger = logging.getLogger('ansible-runner')
 
@@ -124,7 +126,7 @@ class RunnerConfig(object):
         # write the SSH key data into a fifo read by ssh-agent
         if self.ssh_key_data:
             self.ssh_key_path = os.path.join(self.artifact_dir, 'ssh_key_data')
-            self.open_fifo_write(self.ssh_key_path, self.ssh_key_data)
+            open_fifo_write(self.ssh_key_path, self.ssh_key_data)
             self.command = self.wrap_args_with_ssh_agent(self.command, self.ssh_key_path)
 
         # Use local callback directory
@@ -352,29 +354,15 @@ class RunnerConfig(object):
         necessary calls to ``ssh-agent``
         """
         if ssh_key_path:
-            ssh_add_command = self.args2cmdline('ssh-add', ssh_key_path)
+            ssh_add_command = args2cmdline('ssh-add', ssh_key_path)
             if silence_ssh_add:
                 ssh_add_command = ' '.join([ssh_add_command, '2>/dev/null'])
             cmd = ' && '.join([ssh_add_command,
-                               self.args2cmdline('rm', '-f', ssh_key_path),
-                               self.args2cmdline(*args)])
+                               args2cmdline('rm', '-f', ssh_key_path),
+                               args2cmdline(*args)])
             args = ['ssh-agent']
             if ssh_auth_sock:
                 args.extend(['-a', ssh_auth_sock])
             args.extend(['sh', '-c', cmd])
         return args
 
-
-    def open_fifo_write(self, path, data):
-        # TODO: Switch to utility function
-        '''open_fifo_write opens the fifo named pipe in a new thread.
-        This blocks the thread until an external process (such as ssh-agent)
-        reads data from the pipe.
-        '''
-        os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
-        threading.Thread(target=lambda p, d: open(p, 'wb').write(d),
-                         args=(path, data)).start()
-
-    def args2cmdline(self, *args):
-        # TODO: switch to utility function
-        return ' '.join([pipes.quote(a) for a in args])

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -10,6 +10,8 @@ import hashlib
 import tempfile
 import subprocess
 import base64
+import threading
+import pipes
 
 from collections import Iterable, Mapping
 from io import StringIO
@@ -302,3 +304,17 @@ class OutputEventFilter(object):
         else:
             self._current_event_data = None
         return event_data
+
+
+def open_fifo_write(path, data):
+    '''open_fifo_write opens the fifo named pipe in a new thread.
+    This blocks the thread until an external process (such as ssh-agent)
+    reads data from the pipe.
+    '''
+    os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
+    threading.Thread(target=lambda p, d: open(p, 'wb').write(d),
+                     args=(path, data)).start()
+
+
+def args2cmdline(*args):
+    return ' '.join([pipes.quote(a) for a in args])

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -311,7 +311,8 @@ def test_prepare():
     assert rc.env['PYTHONPATH'] == "/foo/bar:/:"
 
 
-def test_prepare_with_ssh_key():
+@patch('ansible_runner.runner_config.open_fifo_write')
+def test_prepare_with_ssh_key(open_fifo_write_mock):
     rc = RunnerConfig('/')
 
     rc.prepare_inventory = Mock()
@@ -319,7 +320,6 @@ def test_prepare_with_ssh_key():
     rc.prepare_command = Mock()
 
     rc.wrap_args_with_ssh_agent = Mock()
-    rc.open_fifo_write = Mock()
 
     rc.ssh_key_data = None
     rc.artifact_dir = '/'
@@ -334,7 +334,7 @@ def test_prepare_with_ssh_key():
 
     assert rc.ssh_key_path == '/ssh_key_data'
     assert rc.wrap_args_with_ssh_agent.called
-    assert rc.open_fifo_write.called
+    assert open_fifo_write_mock.called
 
 
 def test_wrap_args_with_ssh_agent_defaults():
@@ -353,16 +353,6 @@ def test_wrap_args_with_ssh_agent_silent():
     rc = RunnerConfig('/')
     res = rc.wrap_args_with_ssh_agent(['ansible-playbook', 'main.yaml'], '/tmp/sshkey', silence_ssh_add=True)
     assert res == ['ssh-agent', 'sh', '-c', 'ssh-add /tmp/sshkey 2>/dev/null && rm -f /tmp/sshkey && ansible-playbook main.yaml']
-
-
-def test_fifo_write():
-    pass
-
-
-def test_args2cmdline():
-    rc = RunnerConfig('/')
-    res = rc.args2cmdline('ansible', '-m', 'setup', 'localhost')
-    assert res == 'ansible -m setup localhost'
 
 
 def test_process_isolation_defaults():

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -5,8 +5,12 @@ import tempfile
 from pytest import raises
 from mock import patch
 
-from ansible_runner.utils import isplaybook, isinventory
-from ansible_runner.utils import dump_artifacts
+from ansible_runner.utils import (
+    isplaybook,
+    isinventory,
+    dump_artifacts,
+    args2cmdline,
+)
 
 
 def test_isplaybook():
@@ -199,3 +203,13 @@ def test_dump_artifacts_cmdline():
         assert fp == '/tmp/env'
         assert fn == 'cmdline'
         assert 'cmdline' not in kwargs
+
+
+def test_fifo_write():
+    pass
+
+
+def test_args2cmdline():
+    res = args2cmdline('ansible', '-m', 'setup', 'localhost')
+    assert res == 'ansible -m setup localhost'
+


### PR DESCRIPTION
* args2cmdline and open_fifo_write are needed by awx/tower. Move them to
be utility functions instead of private runner_config functions.