### PR TITLE
ensure verbose events get a uuid

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -12,6 +12,7 @@ import subprocess
 import base64
 import threading
 import pipes
+import uuid
 
 from collections import Iterable, Mapping
 from io import StringIO
@@ -290,6 +291,8 @@ class OutputEventFilter(object):
             stdout_chunks = []
 
         for stdout_chunk in stdout_chunks:
+            if event_data.get('event') == 'verbose':
+                event_data['uuid'] = str(uuid.uuid4())
             self._counter += 1
             event_data['counter'] = self._counter
             event_data['stdout'] = stdout_chunk[:-2] if len(stdout_chunk) > 2 else ""


### PR DESCRIPTION
If they don't have a uuid, then the callback won't call the registered event callback.