### PR TITLE
respect ansible display_args_to_stdout setting

### DIFF
--- a/ansible_runner/display_callback/module.py
+++ b/ansible_runner/display_callback/module.py
@@ -24,6 +24,7 @@ import uuid
 from copy import copy
 
 # Ansible
+from ansible import constants as C
 from ansible.plugins.callback import CallbackBase
 from ansible.plugins.callback.default import CallbackModule as DefaultCallbackModule
 
@@ -123,16 +124,18 @@ class BaseCallbackModule(CallbackBase):
             task=(task.name or task.action),
             task_uuid=str(task._uuid),
             task_action=task.action,
+            task_args='',
         )
         try:
             task_ctx['task_path'] = task.get_path()
         except AttributeError:
             pass
-        if task.no_log:
-            task_ctx['task_args'] = "the output has been hidden due to the fact that 'no_log: true' was specified for this result"
-        else:
-            task_args = ', '.join(('%s=%s' % a for a in task.args.items()))
-            task_ctx['task_args'] = task_args
+        if C.DISPLAY_ARGS_TO_STDOUT:
+            if task.no_log:
+                task_ctx['task_args'] = "the output has been hidden due to the fact that 'no_log: true' was specified for this result"
+            else:
+                task_args = ', '.join(('%s=%s' % a for a in task.args.items()))
+                task_ctx['task_args'] = task_args
         if getattr(task, '_role', None):
             task_role = task._role._role_name
         else:


### PR DESCRIPTION
* ansible no_log feature tells modules to not output sensitive
information. By logging raw task arguments we operate counter to no_log
intent. The ansible tunable display_args_to_stdout is False by default
to prevent exposing parameters passed into modules. This change respects
the value of display_args_to_stdout.