### PR TITLE
close stdout handler

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -157,6 +157,9 @@ class Runner(object):
                 child.close(True)
                 self.timed_out = True
 
+        stdout_handle.flush()
+        stdout_handle.close()
+
         if self.canceled:
             self.status_callback('canceled')
         elif child.exitstatus == 0 and not self.timed_out:


### PR DESCRIPTION
* After child process terminates, close stdout handler, giving it a
chance to flush any remaining output.