### PR TITLE
Fix extravar loader behavior

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -197,10 +197,6 @@ class RunnerConfig(object):
             # Still need to pass default environment to pexpect
             self.env = os.environ.copy()
 
-        # extravars dict passed in via the interface API takes precedence over on-disk
-        if not self.extra_vars and self.loader.isfile('env/extravars'):
-            self.extra_vars = self.loader.abspath('env/extravars')
-
         try:
             self.settings = self.loader.load_file('env/settings', Mapping)
         except ConfigurationError:
@@ -271,6 +267,8 @@ class RunnerConfig(object):
             exec_list.append("--limit")
             exec_list.append(self.limit)
 
+        if self.loader.isfile('env/extravars'):
+            exec_list.extend(['-e', '@{}'.format(self.loader.abspath('env/extravars'))])
         if isinstance(self.extra_vars, dict) and self.extra_vars:
             exec_list.extend(
                 [
@@ -280,8 +278,6 @@ class RunnerConfig(object):
                     )
                 ]
             )
-        elif self.extra_vars:
-            exec_list.extend(['-e', '@%s' % self.extra_vars])
         if self.verbosity:
             v = 'v' * self.verbosity
             exec_list.append('-%s' % v)

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -188,14 +188,14 @@ def dump_artifacts(kwargs):
 
     for key in ('envvars', 'extravars', 'passwords', 'settings'):
         obj = kwargs.get(key)
-        if obj:
+        if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
             path = os.path.join(private_data_dir, 'env')
             dump_artifact(json.dumps(obj), path, key)
             kwargs.pop(key)
 
     for key in ('ssh_key', 'cmdline'):
         obj = kwargs.get(key)
-        if obj:
+        if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
             path = os.path.join(private_data_dir, 'env')
             dump_artifact(str(kwargs[key]), path, key)
             kwargs.pop(key)


### PR DESCRIPTION
Our documentation makes it clear that extra vars passed in via the
programmatic interface are additive. In the presence of the
env/extravars file we should load that and then apply any extra vars
given in the parameterization afterwards.

Also, we were persisting some module-loaded data to disk which would
have the effect of writing the data out to files which is unexpected.

For a group of files (env/extravars, env/envvars, env/passwords,
env/settings, ssh_key, cmdline) if these files exist already then they
will not be overridden.

Fixes #172 