### PR TITLE
Fix up and expand inventory inputs

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -281,11 +281,6 @@ def main(sys_args=None):
 
         with context:
             with role_manager(args) as args:
-                if args.inventory:
-                    with open(args.inventory) as f:
-                        inventory_data = f.read()
-                else:
-                    inventory_data = None
                 run_options = dict(private_data_dir=args.private_data_dir,
                                    ident=args.ident,
                                    binary=args.binary,
@@ -298,7 +293,7 @@ def main(sys_args=None):
                                    rotate_artifacts=args.rotate_artifacts,
                                    ignore_logging=False,
                                    json_mode=args.json,
-                                   inventory=inventory_data,
+                                   inventory=args.inventory,
                                    roles_path=[args.roles_path] if args.roles_path else None,
                                    process_isolation=args.process_isolation,
                                    process_isolation_executable=args.process_isolation_executable,

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -90,6 +90,7 @@ def run(**kwargs):
       - Path to the inventory file in the ``private_data_dir``
       - Native python dict supporting the YAML/json inventory structure
       - A text INI formatted string
+      - A list of inventory sources, or an empty list to disable passing inventory
     :param roles_path: Directory or list of directories to assign to ANSIBLE_ROLES_PATH
     :param envvars: Environment variables to be used when running Ansible. Environment variables will also be
                     read from ``env/envvars`` in ``private_data_dir``

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -262,8 +262,13 @@ class RunnerConfig(object):
         except ConfigurationError:
             pass
 
-        exec_list.append("-i")
-        exec_list.append(self.inventory)
+        if isinstance(self.inventory, list):
+            for i in self.inventory:
+                exec_list.append("-i")
+                exec_list.append(i)
+        else:
+            exec_list.append("-i")
+            exec_list.append(self.inventory)
 
         if self.limit is not None:
             exec_list.append("--limit")

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -171,6 +171,9 @@ def test_prepare_inventory():
     rc.inventory = '/tmp/inventory'
     rc.prepare_inventory()
     assert rc.inventory == '/tmp/inventory'
+    rc.inventory = 'localhost,anotherhost,'
+    rc.prepare_inventory()
+    assert rc.inventory == 'localhost,anotherhost,'
 
 
 def test_generate_ansible_command():
@@ -193,7 +196,21 @@ def test_generate_ansible_command():
         assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', 'main.yaml']
     rc.extra_vars = None
 
+    rc.inventory = "localhost,"
+    cmd = rc.generate_ansible_command()
+    assert cmd == ['ansible-playbook', '-i', 'localhost,', 'main.yaml']
+
+    rc.inventory = ['thing1', 'thing2']
+    cmd = rc.generate_ansible_command()
+    assert cmd == ['ansible-playbook', '-i', 'thing1', '-i', 'thing2', 'main.yaml']
+
+    rc.inventory = []
+    cmd = rc.generate_ansible_command()
+    assert cmd == ['ansible-playbook', 'main.yaml']
+    rc.inventory = None
+
     rc.verbosity = 3
+    rc.prepare_inventory()
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', '-vvv', 'main.yaml']
     rc.verbosity = None


### PR DESCRIPTION
* Fix an issue where we would always attempt to load inventory as a
  file if passed as an argument to Runner cli
* Add the ability to pass a list as a module argument to generate
  multiple -i ansible arguments
* Passing an empty list [] will disable passing the -i argument to
  ansible entirely

Fixes #179 