### PR TITLE
Converts a relative path in artifact_dir to an absolute one

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -81,7 +81,7 @@ class RunnerConfig(object):
         self.host_pattern = host_pattern
         self.binary = binary
         self.rotate_artifacts = rotate_artifacts
-        self.artifact_dir = artifact_dir or self.private_data_dir
+        self.artifact_dir = os.path.abspath(artifact_dir or self.private_data_dir)
         if self.ident is None:
             self.artifact_dir = os.path.join(self.artifact_dir, "artifacts")
         else:


### PR DESCRIPTION
This might address #206 where the fact_cache was in a different location than expected. 