### PR TITLE
Implement directory isolation during Runner ansible execution

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -72,7 +72,10 @@ def role_manager(args):
         if args.artifact_dir:
             kwargs.artifact_dir = args.artifact_dir
 
-        project_path = os.path.join(args.private_data_dir, 'project')
+        if args.project_dir:
+            project_path = kwargs.project_dir = args.project_dir
+        else:
+            project_path = os.path.join(args.private_data_dir, 'project')
         project_exists = os.path.exists(project_path)
 
         env_path = os.path.join(args.private_data_dir, 'env')
@@ -191,8 +194,12 @@ def main(sys_args=None):
 
     parser.add_argument("--role-skip-facts", action="store_true", default=False,
                         help="Disable fact collection when executing a role directly")
+
     parser.add_argument("--artifact-dir",
                         help="Optional Path for the artifact root directory, by default it is located inside the private data dir")
+
+    parser.add_argument("--project-dir",
+                        help="Optional Path for the location of the playbook content directory, by default this is 'project' inside the private data dir")
 
     parser.add_argument("--inventory",
                         help="Override the default inventory location in private_data_dir")
@@ -234,6 +241,9 @@ def main(sys_args=None):
 
     parser.add_argument("--process-isolation-ro-paths", dest='process_isolation_ro_paths',
                         help="List of paths on the system that should be exposed to the playbook run as read-only")
+
+    parser.add_argument("--directory-isolation-base-path", dest='directory_isolation_base_path',
+                        help="Copies the project directory to a location in this directory to prevent multiple simultaneous executions from conflicting")
 
     args = parser.parse_args(sys_args)
 
@@ -300,7 +310,8 @@ def main(sys_args=None):
                                    process_isolation_path=args.process_isolation_path,
                                    process_isolation_hide_paths=args.process_isolation_hide_paths,
                                    process_isolation_show_paths=args.process_isolation_show_paths,
-                                   process_isolation_ro_paths=args.process_isolation_ro_paths)
+                                   process_isolation_ro_paths=args.process_isolation_ro_paths,
+                                   directory_isolation_base_path=args.directory_isolation_base_path)
                 if args.cmdline:
                     run_options['cmdline'] = args.cmdline
 

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -68,6 +68,7 @@ def role_manager(args):
         kwargs.update(private_data_dir=args.private_data_dir,
                       json_mode=args.json,
                       ignore_logging=False,
+                      project_dir=args.project_dir,
                       rotate_artifacts=args.rotate_artifacts)
         if args.artifact_dir:
             kwargs.artifact_dir = args.artifact_dir
@@ -76,6 +77,7 @@ def role_manager(args):
             project_path = kwargs.project_dir = args.project_dir
         else:
             project_path = os.path.join(args.private_data_dir, 'project')
+
         project_exists = os.path.exists(project_path)
 
         env_path = os.path.join(args.private_data_dir, 'env')
@@ -304,6 +306,7 @@ def main(sys_args=None):
                                    ignore_logging=False,
                                    json_mode=args.json,
                                    inventory=args.inventory,
+                                   project_dir=args.project_dir,
                                    roles_path=[args.roles_path] if args.roles_path else None,
                                    process_isolation=args.process_isolation,
                                    process_isolation_executable=args.process_isolation_executable,

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -105,7 +105,8 @@ def run(**kwargs):
     :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param verbosity: Control how verbose the output of ansible-playbook is
     :param quiet: Disable all output
-    :param artifact_dir: The path to the directory where artifacts should live
+    :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
+    :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
     :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself
     :param cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
@@ -117,6 +118,8 @@ def run(**kwargs):
     :param process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
     :param process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
     :param process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
+    :param directory_isolation_base_path: An optional path will be used as the base path to create a temp directory, the project contents will be
+                                          copied to this location which will then be used as the working directory during playbook execution.
     :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
                        This is only used for 'jsonfile' type fact caches.
     :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
@@ -131,6 +134,7 @@ def run(**kwargs):
     :type settings: dict
     :type ssh_key: str
     :type artifact_dir: str
+    :type project_dir: str
     :type rotate_artifacts: int
     :type cmdline: str
     :type quiet: bool
@@ -145,6 +149,7 @@ def run(**kwargs):
     :type process_isolation_hide_paths: str or list
     :type process_isolation_show_paths: str or list
     :type process_isolation_ro_paths: str or list
+    :type directory_isolation_base_path: str
     :type fact_cache: str
     :type fact_cache_type: str
 

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -183,7 +183,7 @@ class Runner(object):
                 os.close(os.open(artifact_path, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
             with open(artifact_path, 'w') as f:
                 f.write(str(data))
-        if self.config.directory_isolation_path:
+        if self.config.directory_isolation_path and self.config.directory_isolation_cleanup:
             shutil.rmtree(self.config.directory_isolation_path)
         if self.finished_callback is not None:
             try:

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -5,6 +5,7 @@ import time
 import json
 import errno
 import signal
+import shutil
 import codecs
 import collections
 
@@ -182,6 +183,8 @@ class Runner(object):
                 os.close(os.open(artifact_path, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
             with open(artifact_path, 'w') as f:
                 f.write(str(data))
+        if self.config.directory_isolation_path:
+            shutil.rmtree(self.config.directory_isolation_path)
         if self.finished_callback is not None:
             try:
                 self.finished_callback(self)

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -233,6 +233,7 @@ class RunnerConfig(object):
 
         self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
         self.suppress_ansible_output = self.settings.get('suppress_ansible_output', self.quiet)
+        self.directory_isolation_cleanup = bool(self.settings.get('directory_isolation_cleanup', True))
 
         if 'AD_HOC_COMMAND_ID' in self.env or not os.path.exists(self.project_dir):
             self.cwd = self.private_data_dir

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -30,10 +30,7 @@ try:
 except ImportError:
     from collections import Mapping
 
-try:
-    from distutils import copy_tree
-except ImportError:
-    from distutils.dir_util import copy_tree
+from distutils.dir_util import copy_tree
 
 from six import iteritems, string_types
 
@@ -140,7 +137,7 @@ class RunnerConfig(object):
             if os.path.exists(self.project_dir):
                 output.debug("Copying directory tree from {} to {} for working directory isolation".format(self.project_dir,
                                                                                                            self.directory_isolation_path))
-                copy_tree(self.project_dir, self.directory_isolation_path)
+                copy_tree(self.project_dir, self.directory_isolation_path, preserve_symlinks=True)
 
         self.prepare_inventory()
         self.prepare_env()

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -85,6 +85,17 @@ list of arguments accepted by ``ansible-runner``::
 
   $ ansible-runner --help
 
+Running with Directory Isolation
+--------------------------------
+
+If you need to be able to execute multiple tasks in parallel that might conflict with each other or if you want to make sure a single invocation of
+Ansible/Runner doesn't pollute or overwrite the playbook content you can give a base path::
+
+  $ ansible-runner --directory-isoltaion-base-path /tmp/runner
+
+**Runner** will copy the project directory to a temporary directory created under that path, set it as the working directory, and execute from that location.
+After running that temp directory will be cleaned up and removed.
+
 Outputting json (raw event data) to the console instead of normal output
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
This helps prevent two simultaneously running tasks from clobbering
each other in the same working directory. This also allows any local
changes made by playbooks to be discarded preventing rogue playbooks
from making changes to the underlying automation.

This also adds an optional `project dir` parameter to allow localizing
the playbook content somewhere other than the private data dir.

Fixes #112 