### PR TITLE
Add new playbook stats fields (ignored, rescued)

### DIFF
--- a/ansible_runner/display_callback/module.py
+++ b/ansible_runner/display_callback/module.py
@@ -304,8 +304,10 @@ class BaseCallbackModule(CallbackBase):
             changed=stats.changed,
             dark=stats.dark,
             failures=stats.failures,
+            ignored=getattr(stats, 'ignored', 0),
             ok=stats.ok,
             processed=stats.processed,
+            rescued=getattr(stats, 'rescued', 0),
             skipped=stats.skipped,
             artifact_data=stats.custom.get('_run', {}) if hasattr(stats, 'custom') else {}
         )

--- a/ansible_runner/loader.py
+++ b/ansible_runner/loader.py
@@ -166,7 +166,7 @@ class ArtifactLoader(object):
         except ConfigurationError as exc:
             debug(exc)
             raise
-        except UnicodeEncodeError as exc:
+        except UnicodeEncodeError:
             raise ConfigurationError('unable to encode file contents')
 
         if objtype is not string_types:

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -59,7 +59,7 @@ class Runner(object):
                     event_data.update(partial_event_data)
                     if self.remove_partials:
                         os.remove(partial_filename)
-                except IOError as e:
+                except IOError:
                     debug("Failed to open ansible stdout callback plugin partial data file {}".format(partial_filename))
                 if self.event_handler is not None:
                     should_write = self.event_handler(event_data)
@@ -248,7 +248,7 @@ class Runner(object):
         dir_events = os.listdir(event_path)
         dir_events_actual = []
         for each_file in dir_events:
-            if re.match("^[0-9]+\-.+json$", each_file):
+            if re.match("^[0-9]+-.+json$", each_file):
                 dir_events_actual.append(each_file)
         dir_events_actual.sort(key=lambda filenm: int(filenm.split("-", 1)[0]))
         for event_file in dir_events_actual:

--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -47,6 +47,7 @@ def test_runner_on_start(rc):
                                       r.events)]
     assert len(start_events) == 1
 
+
 def test_playbook_on_stats_summary_fields(rc):
     tdir = tempfile.mkdtemp()
     r = run(private_data_dir=tdir,

--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -46,3 +46,16 @@ def test_runner_on_start(rc):
     start_events = [x for x in filter(lambda x: 'event' in x and x['event'] == 'runner_on_start',
                                       r.events)]
     assert len(start_events) == 1
+
+def test_playbook_on_stats_summary_fields(rc):
+    tdir = tempfile.mkdtemp()
+    r = run(private_data_dir=tdir,
+            inventory="localhost ansible_connection=local",
+            playbook=[{'hosts': 'all', 'gather_facts': False, 'tasks': [{'debug': {'msg': "test"}}]}])
+    stats_events = [x for x in filter(lambda x: 'event' in x and x['event'] == 'playbook_on_stats',
+                                      r.events)]
+    assert len(stats_events) == 1
+
+    EXPECTED_SUMMARY_FIELDS = ('changed', 'dark', 'failures', 'ignored', 'ok', 'rescued', 'skipped')
+    fields = stats_events[0]['event_data'].keys()
+    assert set(fields) >= set(EXPECTED_SUMMARY_FIELDS)


### PR DESCRIPTION
Ports changes made in https://github.com/ansible/awx/pull/3272 to runner

New Ansible Playbook fields:
- https://github.com/ansible/ansible/pull/48418

Verified that test passes with both devel ansible and 2.7.8.