### PR TITLE
add runner config to status_handler callback

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -79,7 +79,7 @@ class Runner(object):
         for plugin in ansible_runner.plugins:
             ansible_runner.plugins[plugin].status_handler(self.config, status_data)
         if self.status_handler is not None:
-            self.status_handler(status_data)
+            self.status_handler(status_data, runner_config=self.config)
 
     def run(self):
         '''

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -118,5 +118,5 @@ def test_status_callback_interface(rc):
     runner.status_handler = mock.Mock()
     runner.status_callback("running")
     assert runner.status_handler.call_count == 1
-    runner.status_handler.assert_called_with(dict(status='running', runner_ident=str(rc.ident)))
+    runner.status_handler.assert_called_with(dict(status='running', runner_ident=str(rc.ident)), runner_config=runner.config)
     assert runner.status == 'running'


### PR DESCRIPTION
* Do so using a named parameter so that we remain backword compat to the
existing users of status_handler