### PR TITLE
add process isolation to settings file interface

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -242,6 +242,13 @@ class RunnerConfig(object):
         self.job_timeout = self.settings.get('job_timeout', None)
         self.pexpect_timeout = self.settings.get('pexpect_timeout', 5)
 
+        self.process_isolation = self.settings.get('process_isolation', self.process_isolation)
+        self.process_isolation_executable = self.settings.get('process_isolation_executable', self.process_isolation_executable)
+        self.process_isolation_path = self.settings.get('process_isolation_path', self.process_isolation_path)
+        self.process_isolation_hide_paths = self.settings.get('process_isolation_hide_paths', self.process_isolation_hide_paths)
+        self.process_isolation_show_paths = self.settings.get('process_isolation_show_paths', self.process_isolation_show_paths)
+        self.process_isolation_ro_paths = self.settings.get('process_isolation_ro_paths', self.process_isolation_ro_paths)
+
         self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
         self.suppress_ansible_output = self.settings.get('suppress_ansible_output', self.quiet)
         self.directory_isolation_cleanup = bool(self.settings.get('directory_isolation_cleanup', True))

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -143,6 +143,18 @@ The **settings** file is a little different than the other files provided in thi
 * ``fact_cache``: ``'fact_cache'`` The directory relative to ``artifacts`` where ``jsonfile`` fact caching will be stored.  Defaults to ``fact_cache``.  This is ignored if ``fact_cache_type`` is different than ``jsonfile``.
 * ``fact_cache_type``: ``'jsonfile'`` The type of fact cache to use.  Defaults to ``jsonfile``.
 
+Process Isolatiton Settings for Runner
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The process isolation settings are meant to control the process isolation feature of **Runner**.
+
+* ``process_isolation``: ``False`` Enable limiting what directories on the filesystem the playbook run has access to.
+* ``process_isolation_executable``: ``bwrap`` Path to the executable that will be used to provide filesystem isolation.
+* ``process_isolation_path``: ``/tmp`` Path that an isolated playbook run will use for staging.
+* ``process_isolation_hide_paths``: ``None`` Path or list of paths on the system that should be hidden from the playbook run.
+* ``process_isolation_show_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run.
+* ``process_isolation_ro_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run as read-only.
+
 Inventory
 ---------
 


### PR DESCRIPTION
Requested by @chrismeyersfsu for easier creation of runner instances without having to pass in long strings of command line arguments.