### PR TITLE
Fix extra_vars parsing in RunnerConfig

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -327,7 +327,7 @@ class RunnerConfig(object):
             exec_list.extend(
                 [
                     '-e',
-                    '\'%s\'' % ' '.join(
+                    '%s' % ' '.join(
                         ["{}=\"{}\"".format(k, self.extra_vars[k]) for k in self.extra_vars]
                     )
                 ]

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -233,3 +233,16 @@ def test_set_fact_cache(rc):
     assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache', 'localhost'))
     data = runner.get_fact_cache('localhost')
     assert data['message'] == 'hello there'
+
+
+def test_set_extra_vars(rc):
+    rc.module = "debug"
+    rc.module_args = "var=test_extra_vars"
+    rc.host_pattern = "localhost"
+    rc.extra_vars = dict(test_extra_vars='hello there')
+    rc.prepare()
+    runner = Runner(config=rc)
+    status, exitcode = runner.run()
+    with open(os.path.join(rc.artifact_dir, 'stdout')) as f:
+        assert 'hello there' in f.read()
+

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -209,11 +209,11 @@ def test_generate_ansible_command():
 
     rc.extra_vars = dict(test="key")
     cmd = rc.generate_ansible_command()
-    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '\'test="key"\'', 'main.yaml']
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', 'test="key"', 'main.yaml']
 
     with patch.object(rc.loader, 'isfile', side_effect=lambda x: True):
         cmd = rc.generate_ansible_command()
-        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '\'test="key"\'', 'main.yaml']
+        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', 'test="key"', 'main.yaml']
         rc.extra_vars = None
         cmd = rc.generate_ansible_command()
         assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', 'main.yaml']
@@ -265,7 +265,7 @@ def test_generate_ansible_command_with_api_extravars():
     rc.prepare_inventory()
 
     cmd = rc.generate_ansible_command()
-    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '\'foo="bar"\'', 'main.yaml']
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', 'foo="bar"', 'main.yaml']
 
 
 def test_generate_ansible_command_with_cmdline_args():


### PR DESCRIPTION
extra_vars were not being properly parsed previously. There were
some extraneous quotes being used when building the AnsiblePlaybook
command-line arguments which caused Ansible to not recognize the
variables being passed into the runtime. Additionally there were
no functional tests to ensure that extra_vars could be passed to
the RunnerConfig object and consumed in an Ansible Playbook.