### PR TITLE
ansible-runner raises an uncaught exception when reading `env/envvars` that contain unicode

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 import logging
 
+import six
 from uuid import uuid4
 try:
     from collections.abc import Mapping
@@ -224,9 +225,9 @@ class RunnerConfig(object):
             self.env = os.environ.copy()
             envvars = self.loader.load_file('env/envvars', Mapping)
             if envvars:
-                self.env.update({k:str(v) for k, v in envvars.items()})
+                self.env.update({k:six.text_type(v) for k, v in envvars.items()})
             if self.envvars and isinstance(self.envvars, dict):
-                self.env.update({k:str(v) for k, v in self.envvars.items()})
+                self.env.update({k:six.text_type(v) for k, v in self.envvars.items()})
         except ConfigurationError:
             output.debug("Not loading environment vars")
             # Still need to pass default environment to pexpect


### PR DESCRIPTION
```python
.tox/py27/lib/python2.7/site-packages/ansible_runner/__main__.py:329: in main
    res = run(**run_options)
.tox/py27/lib/python2.7/site-packages/ansible_runner/interface.py:161: in run
    r = init_runner(**kwargs)
.tox/py27/lib/python2.7/site-packages/ansible_runner/interface.py:65: in init_runner
    rc.prepare()
.tox/py27/lib/python2.7/site-packages/ansible_runner/runner_config.py:154: in prepare
    self.prepare_env()
.tox/py27/lib/python2.7/site-packages/ansible_runner/runner_config.py:228: in prepare_env
    self.env.update({k:str(v) for k, v in envvars.items()})
```