### PR TITLE
Add bindep.txt file for zuul jobs

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,7 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+gcc-c++ [test platform:rpm]
+python3-devel [test !platform:centos-7 platform:rpm]
+python3 [test !platform:centos-7 platform:rpm]
+python36 [test !platform:centos-7 !platform:fedora-28]


### PR DESCRIPTION
We use bindep.txt to manage OS package dependencies that jobs use.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>