### PR TITLE
Rename lint to linters for tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py27, py3
+envlist = linters, py27, py3
 
 [testenv]
 deps = pipenv
@@ -9,7 +9,7 @@ commands=
     pipenv install --dev #--ignore-pipfile --dev
     pipenv run py.test -v test
 
-[testenv:lint]
+[testenv:linters]
 basepython = python3
 commands=
     pipenv install --dev


### PR DESCRIPTION
This is allows us to consume the ansible-tox-linters jobs for
zuul.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>