### PR TITLE
Don't build sdist using tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 envlist = linters, py27, py3
+skipsdist = true
 
 [testenv]
+usedevelop = true
 deps = pipenv
        mock
        ansible


### PR DESCRIPTION
We are able to do this now, as we have a job that will validate we can
build an sdist / wheel. We also set usedevelop so we can modify the
local source tree without doing pip install again.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>