### PR TITLE
WIP: embed base64 encoded event data in the pty itself

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -22,8 +22,8 @@ from ansible_runner.output import debug
 
 class Runner(object):
 
-    def __init__(self, config, cancel_callback=None, remove_partials=True,
-                 event_handler=None, finished_callback=None, status_handler=None):
+    def __init__(self, config, cancel_callback=None, event_handler=None,
+                 finished_callback=None, status_handler=None):
         self.config = config
         self.cancel_callback = cancel_callback
         self.event_handler = event_handler
@@ -34,7 +34,6 @@ class Runner(object):
         self.errored = False
         self.status = "unstarted"
         self.rc = None
-        self.remove_partials = remove_partials
 
     def event_callback(self, event_data):
         '''
@@ -46,24 +45,11 @@ class Runner(object):
         if not os.path.exists(job_events_path):
             os.mkdir(job_events_path, 0o700)
         if 'uuid' in event_data:
-            filename = '{}-partial.json'.format(event_data['uuid'])
-            partial_filename = os.path.join(self.config.artifact_dir,
-                                            'job_events',
-                                            filename)
-            full_filename = os.path.join(self.config.artifact_dir,
-                                         'job_events',
+            full_filename = os.path.join(job_events_path,
                                          '{}-{}.json'.format(event_data['counter'],
                                                              event_data['uuid']))
             try:
                 event_data.update(dict(runner_ident=str(self.config.ident)))
-                try:
-                    with codecs.open(partial_filename, 'r', encoding='utf-8') as read_file:
-                        partial_event_data = json.load(read_file)
-                    event_data.update(partial_event_data)
-                    if self.remove_partials:
-                        os.remove(partial_filename)
-                except IOError:
-                    debug("Failed to open ansible stdout callback plugin partial data file {}".format(partial_filename))
                 if self.event_handler is not None:
                     should_write = self.event_handler(event_data)
                 else:

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -346,7 +346,6 @@ def test_prepare():
     assert rc.env['ANSIBLE_STDOUT_CALLBACK'] == 'awx_display'
     assert rc.env['ANSIBLE_RETRY_FILES_ENABLED'] == 'False'
     assert rc.env['ANSIBLE_HOST_KEY_CHECKING'] == 'False'
-    assert rc.env['AWX_ISOLATED_DATA_DIR'] == '/'
     assert rc.env['PYTHONPATH'] == '/python_path_via_environ:/awx_lib_directory_via_environ', \
         "PYTHONPATH is the union of the env PYTHONPATH and AWX_LIB_DIRECTORY"
 


### PR DESCRIPTION
this removes the `-partial.json` IPC mechanism for passing event data
from ansible to the runner process