### PR TITLE
Fix platform-specific test fail, cleanup error

### DIFF
--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -418,7 +418,8 @@ def test_process_isolation_defaults():
 @patch('shutil.copytree', return_value=True)
 @patch('tempfile.mkdtemp', return_value="/tmp/dirisolation/foo")
 @patch('os.chmod', return_value=True)
-def test_process_isolation_and_directory_isolation(mock_makedirs, mock_copytree, mock_mkdtemp, mock_chmod):
+@patch('shutil.rmtree', return_value=True)
+def test_process_isolation_and_directory_isolation(mock_makedirs, mock_copytree, mock_mkdtemp, mock_chmod, mock_rmtree):
     rc = RunnerConfig('/')
     rc.artifact_dir = '/tmp/artifacts'
     rc.directory_isolation_path = '/tmp/dirisolation'
@@ -433,7 +434,7 @@ def test_process_isolation_and_directory_isolation(mock_makedirs, mock_copytree,
         '--dev-bind', '/', '/',
         '--proc', '/proc',
         '--bind', '/', '/',
-        '--chdir', '/tmp/dirisolation/foo',
+        '--chdir', os.path.realpath(rc.directory_isolation_path),
         'ansible-playbook', '-i', '/inventory', 'main.yaml',
     ]
 


### PR DESCRIPTION
Before this change:

```
(ansible-runner) arominge-OSX:ansible-runner alancoding$ py.test test/
=============================================================================== test session starts ================================================================================
platform darwin -- Python 3.6.5, pytest-4.4.0, py-1.8.0, pluggy-0.9.0
rootdir: /Users/alancoding/Documents/repos/ansible-runner
collected 127 items                                                                                                                                                                

test/integration/test___main__.py ........                                                                                                                                   [  6%]
test/integration/test_events.py ..s.                                                                                                                                         [  9%]
test/integration/test_interface.py ..                                                                                                                                        [ 11%]
test/integration/test_main.py .....................                                                                                                                          [ 27%]
test/integration/test_runner.py .......................                                                                                                                      [ 45%]
test/unit/test_event_filter.py ......                                                                                                                                        [ 50%]
test/unit/test_loader.py ...........                                                                                                                                         [ 59%]
test/unit/test_runner.py ..........                                                                                                                                          [ 66%]
test/unit/test_runner_config.py ...........................F.                                                                                                                [ 89%]
test/unit/test_utils.py .............                                                                                                                                        [100%]

===================================================================================== FAILURES =====================================================================================
__________________________________________________________________ test_process_isolation_and_directory_isolation __________________________________________________________________

mock_makedirs = <MagicMock name='chmod' id='4375028624'>, mock_copytree = <MagicMock name='mkdtemp' id='4375038272'>, mock_mkdtemp = <MagicMock name='copytree' id='4375058192'>
mock_chmod = <MagicMock name='makedirs' id='4375035072'>

    @patch('os.makedirs', return_value=True)
    @patch('shutil.copytree', return_value=True)
    @patch('tempfile.mkdtemp', return_value="/tmp/dirisolation/foo")
    @patch('os.chmod', return_value=True)
    def test_process_isolation_and_directory_isolation(mock_makedirs, mock_copytree, mock_mkdtemp, mock_chmod):
        rc = RunnerConfig('/')
        rc.artifact_dir = '/tmp/artifacts'
        rc.directory_isolation_path = '/tmp/dirisolation'
        rc.playbook = 'main.yaml'
        rc.command = 'ansible-playbook'
        rc.process_isolation = True
        rc.prepare()
    
>       assert rc.command == [
            'bwrap',
            '--unshare-pid',
            '--dev-bind', '/', '/',
            '--proc', '/proc',
            '--bind', '/', '/',
            '--chdir', '/tmp/dirisolation/foo',
            'ansible-playbook', '-i', '/inventory', 'main.yaml',
        ]
E       AssertionError: assert ['bwrap', '--...'--proc', ...] == ['bwrap', '--u...'--proc', ...]
E         At index 11 diff: '/private/tmp/dirisolation/foo' != '/tmp/dirisolation/foo'
E         Use -v to get the full diff

test/unit/test_runner_config.py:437: AssertionError
================================================================= 1 failed, 125 passed, 1 skipped in 79.40 seconds =================================================================
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/ansible-runner-s2qgvMXw/lib/python3.6/shutil.py", line 469, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/dirisolation/foo'
```

After this change:

```
(ansible-runner) arominge-OSX:ansible-runner alancoding$ py.test test/
=============================================================================== test session starts ================================================================================
platform darwin -- Python 3.6.5, pytest-4.4.0, py-1.8.0, pluggy-0.9.0
rootdir: /Users/alancoding/Documents/repos/ansible-runner
collected 127 items                                                                                                                                                                

test/integration/test___main__.py ........                                                                                                                                   [  6%]
test/integration/test_events.py ..s.                                                                                                                                         [  9%]
test/integration/test_interface.py ..                                                                                                                                        [ 11%]
test/integration/test_main.py .....................                                                                                                                          [ 27%]
test/integration/test_runner.py .......................                                                                                                                      [ 45%]
test/unit/test_event_filter.py ......                                                                                                                                        [ 50%]
test/unit/test_loader.py ...........                                                                                                                                         [ 59%]
test/unit/test_runner.py ..........                                                                                                                                          [ 66%]
test/unit/test_runner_config.py .............................                                                                                                                [ 89%]
test/unit/test_utils.py .............                                                                                                                                        [100%]

====================================================================== 126 passed, 1 skipped in 78.35 seconds ======================================================================
```

realpath is used in forming the arguments here:

https://github.com/ansible/ansible-runner/blob/a7f06898477cf3b676baac5f78ea8aa71c501508/ansible_runner/runner_config.py#L422

Thus the discrepancy.

Also, since we mocked the creation of the tempdirs, we should mock their removal as well, which is related to the latter traceback.