### PR TITLE
Adopt modified upstream packaging

### DIFF
--- a/packaging/rpm/ansible-runner.spec.j2
+++ b/packaging/rpm/ansible-runner.spec.j2
@@ -1,39 +1,124 @@
-Name: ansible-runner
-Version: {{ version }}
-Release: {{ release }}%{?dist}
-Summary: Package for interfacing with Ansible
-Source0: https://github.com/ansible/%{name}/archive/%{version}.tar.gz?/%{name}-%{version}-{{ release }}.tar.gz
+%global pypi_name ansible-runner
 
-Group: Development/Libraries
-License: ASL 2.0
-Url: http://ansible.com
+%if 0%{?fedora} || 0%{?rhel} > 7
+%bcond_with    python2
+%bcond_without python3
+%else
+%bcond_without python2
+%bcond_with    python3
+%endif
 
-BuildArch: noarch
-BuildRequires: python-setuptools
+Name:           %{pypi_name}
+Version:        {{ version }}
+Release:        {{ release }}%{?dist}
+Summary:        A tool and python library to interface with Ansible
 
-Requires: bzip2
-Requires: openssh
-Requires: openssh-clients
-Requires: python-daemon
-Requires: python-pexpect
-Requires: python-psutil
+License:        ASL 2.0
+URL:            https://github.com/ansible/ansible-runner
+Source0:        https://github.com/ansible/%{name}/archive/%{version}.tar.gz?/%{name}-%{version}-{{ release }}.tar.gz
+BuildArch:      noarch
+
+%if 0%{?fedora} || 0%{?rhel} > 7
+Requires: python3-%{pypi_name}
+%else
+Requires: python2-%{pypi_name}
+BuildRequires: python-rpm-macros
+%endif
+
+%if %{with python2}
+BuildRequires:  python-setuptools
+%endif
+
+%if %{with python3}
+BuildRequires:  python3-setuptools
+%endif
 
 %description
-A CLI and Python library that helps interfacing with Ansible from other systems
+Ansible Runner is a tool and python library that helps when interfacing with
+Ansible from other systems whether through a container image interface, as a
+standalone tool, or imported into a python project.
+
+%if %{with python2}
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       python-daemon
+%if 0%{?el7}
+Requires:       pexpect >= 4.6
+Requires:       python-psutil
+Requires:       PyYAML
+Requires:       python-six
+%else
+Requires:       %{py2_dist pexpect} >= 4.6
+Requires:       %{py2_dist psutil}
+Requires:       %{py2_dist PyYAML}
+Requires:       %{py2_dist six}
+%endif
+
+%description -n python2-%{pypi_name}
+Ansible Runner is a tool and python library that helps when interfacing with
+Ansible from other systems whether through a container image interface, as a
+standalone tool, or imported into a python project.
+%endif
+
+%if %{with python3}
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3-daemon
+Requires:       python3dist(pexpect) >= 4.6
+Requires:       python3dist(psutil)
+
+%description -n python3-%{pypi_name}
+Ansible Runner is a tool and python library that helps when interfacing with
+Ansible from other systems whether through a container image interface, as a
+standalone tool, or imported into a python project.
+%endif
 
 %prep
-%setup -q -n %{name}-%{version}
+%autosetup -n %{pypi_name}-%{version}
+# Remove bundled egg-info
+rm -rf %{pypi_name}.egg-info
+
+%global py_setup setup.py
 
 %build
-# Disable debuginfo packages
-%define _enable_debug_package 0
-%define debug_package %{nil}
-
+%if %{with python2}
 %{__python} setup.py build
+%endif
+%if %{with python3}
+%py3_build
+%endif
 
 %install
+# Must do the subpackages' install first because the scripts in /usr/bin are
+# overwritten with every setup.py install.
+
+%if %{with python2}
 %{__python} setup.py install -O1 --skip-build --root %{buildroot}
+%endif
+
+%if %{with python3}
+%py3_install
+%endif
 
 %files
-%{_bindir}/ansible-runner
+%defattr(-,root,root)
+
+%if %{with python2}
+%files -n python2-%{pypi_name}
 %{python_sitelib}/*
+%endif
+
+%if %{with python3}
+%files -n python3-%{pypi_name}
+%{python3_sitelib}/*
+%endif
+%{_bindir}/ansible-runner
+
+%changelog
+* Wed Apr 24 2019 Shane McDonald <shanemcd@redhat.com> - 1.3.4-1
+- Ansible Runner 1.3.4-1
+- Adopted modified upstream spec file for python3 support


### PR DESCRIPTION
This supports python3 on platforms where it is the default.
