### PR TITLE
Add missing lockfile RPM dependency

### DIFF
--- a/packaging/rpm/ansible-runner.spec.j2
+++ b/packaging/rpm/ansible-runner.spec.j2
@@ -49,11 +49,13 @@ Requires:       pexpect >= 4.6
 Requires:       python-psutil
 Requires:       PyYAML
 Requires:       python-six
+Requires:       python-lockfile
 %else
 Requires:       %{py2_dist pexpect} >= 4.6
 Requires:       %{py2_dist psutil}
 Requires:       %{py2_dist PyYAML}
 Requires:       %{py2_dist six}
+Requires:       %{py2_dist lockfile}
 %endif
 
 %description -n python2-%{pypi_name}
@@ -70,6 +72,7 @@ Summary:        %{summary}
 Requires:       python3-daemon
 Requires:       python3dist(pexpect) >= 4.6
 Requires:       python3dist(psutil)
+Requires:       python3dist(lockfile)
 
 %description -n python3-%{pypi_name}
 Ansible Runner is a tool and python library that helps when interfacing with


### PR DESCRIPTION
This was not listed in the old spec file so I’m not sure why this is failing now. It was likely broken for some time, but was not caught since our internal tests have been installing from pip.