### PR TITLE
Add script that writes test playbook inputs to files

### DIFF
--- a/utils/generate_callback_playbooks.py
+++ b/utils/generate_callback_playbooks.py
@@ -1,0 +1,40 @@
+import os
+import imp
+
+
+"""
+This script allows creating a directory structure that corresponds to the
+parameterized inputs present in the file test/integration/test_display_callback.py
+Run this from the root of the ansible-runner directory
+It will write these files to a folder named "callback-testing-playbooks"
+"""
+
+
+callback_tests = imp.load_source('test.integration.test_display_callback', 'test/integration/test_display_callback.py')
+
+
+BASE_DIR = 'callback-testing-playbooks'
+names = [test_name for test_name in dir(callback_tests) if test_name.startswith('test_')]
+for name in names:
+
+    print('')
+    print('Processing test {}'.format(name))
+
+    bare_name = name[len('test_callback_plugin_'):]
+    if not os.path.exists('{}/{}'.format(BASE_DIR, bare_name)):
+        os.makedirs('{}/{}'.format(BASE_DIR, bare_name))
+    the_test = getattr(callback_tests, name)
+    for test_marker in the_test.pytestmark:
+        if test_marker.name == 'parametrize':
+            inputs = test_marker.args[1]
+            break
+    else:
+        raise Exception('Test {} not parameterized in expected way.'.format(the_test))
+
+    for input in inputs:
+        for k, v in input.items():
+            filename = '{}/{}/{}'.format(BASE_DIR, bare_name, k)
+            print('  Writing file {}'.format(filename))
+            if not os.path.exists(filename):
+                with open(filename, 'w') as f:
+                    f.write(v)


### PR DESCRIPTION
This is a dinky script which I originally developed here:

https://github.com/AlanCoding/callback-testing-playbooks

Motivation:

Users of Tower need cannot test playbook content inside of Tower itself unless that content is written to file and committed to source control. This is a basic script that will scrape the playbook parameterizations inside of one of the test files and put them in a format which is ready to commit to source, to use in Tower.

Since those tests are living here, I thought it'll make sense for the script to live here as well.

Result:

```
(ansible-runner) bash-3.2$ tree callback-testing-playbooks/
callback-testing-playbooks/
├── censoring_does_not_overwrite
│   └── loop_with_no_log.yml
├── log
│   └── no_log_module_with_var.yml
├── no_log_filters
│   ├── async_no_log.yml
│   ├── loop.yml
│   ├── no_log_on_fail.yml
│   ├── no_log_on_ok.yml
│   ├── no_log_on_play.yml
│   ├── no_log_on_skip.yml
│   └── with_items.yml
├── receives_events
│   ├── helloworld.yml
│   └── results_included.yml
├── records_notify_events
│   ├── handle_playbook_on_notify.yml
│   ├── helloworld.yml
│   └── results_included.yml
├── saves_custom_stats
│   └── custom_set_stat.yml
├── strips_task_environ_variables
│   └── strip_env_vars.yml
└── task_args_leak
    └── no_log_on_ok.yml

8 directories, 17 files
```

and a playbook:

```
(ansible-runner) bash-3.2$ cat callback-testing-playbooks/saves_custom_stats/custom_set_stat.yml 

- name: custom set_stat calls should persist to the local disk so awx can save them
  connection: local
  hosts: all
  tasks:
    - set_stats:
        data:
          foo: "bar"
```