### PR TITLE
Added --display-callback and scrubber

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -40,6 +40,7 @@ from ansible_runner import output
 from ansible_runner.utils import dump_artifact, Bunch
 from ansible_runner.runner import Runner
 from ansible_runner.exceptions import AnsibleRunnerException
+from ansible_runner import display_callback
 
 VERSION = pkg_resources.require("ansible_runner")[0].version
 
@@ -255,6 +256,13 @@ def main(sys_args=None):
     parser.add_argument("--limit",
                         help="Matches ansible's ``--limit`` parameter to further constrain the inventory to be used")
 
+    valid_callbacks = []
+    for cls_name in display_callback.__all__:
+        valid_callbacks.append(getattr(display_callback, cls_name).CALLBACK_NAME)
+    parser.add_argument('--display-callback', dest='display_callback',
+                        choices=valid_callbacks,
+                        help="Specify a display callback to use. Defaults to minimal for ad-hoc or default for anything else")
+
     args = parser.parse_args(sys_args)
 
     output.configure()
@@ -321,7 +329,9 @@ def main(sys_args=None):
                                    process_isolation_show_paths=args.process_isolation_show_paths,
                                    process_isolation_ro_paths=args.process_isolation_ro_paths,
                                    directory_isolation_base_path=args.directory_isolation_base_path,
-                                   limit=args.limit)
+                                   limit=args.limit,
+                                   display_callback=args.display_callback
+                                   )
                 if args.cmdline:
                     run_options['cmdline'] = args.cmdline
 

--- a/ansible_runner/callbacks/scrubber.py
+++ b/ansible_runner/callbacks/scrubber.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 Ansible by Red Hat, Inc.
+# Copyright (c) 2017 Ansible by Red Hat
 #
 # This file is part of Ansible Tower, but depends on code imported from Ansible.
 #
@@ -17,9 +17,14 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-# AWX Display Callback
-from . import cleanup  # noqa (registers control persistent cleanup)
-from . import display  # noqa (wraps ansible.display.Display methods)
-from .module import AWXDefaultCallbackModule, AWXMinimalCallbackModule, AWXScrubberCallbackModule
+# Python
+import os
+import sys
 
-__all__ = ['AWXDefaultCallbackModule', 'AWXMinimalCallbackModule', 'AWXScrubberCallbackModule']
+# Add awx/lib to sys.path.
+awx_lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if awx_lib_path not in sys.path:
+    sys.path.insert(0, awx_lib_path)
+
+# Tower Display Callback
+from display_callback import AWXScrubberCallbackModule as CallbackModule  # noqa

--- a/ansible_runner/display_callback/scrubber.py
+++ b/ansible_runner/display_callback/scrubber.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2016 Ansible by Red Hat, Inc.
+#
+# This file is part of Ansible Tower, but depends on code imported from Ansible.
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+
+# Python
+import functools
+import sys
+import uuid
+
+# Ansible
+from ansible.utils.display import Display
+
+# Tower Display Callback
+from .events import event_context
+
+__all__ = []
+
+
+def with_context(**context):
+    global event_context
+
+    def wrap(f):
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            with event_context.set_local(**context):
+                return f(*args, **kwargs)
+        return wrapper
+    return wrap
+
+
+for attr in dir(Display):
+    if attr.startswith('_') or 'cow' in attr or 'prompt' in attr:
+        continue
+    if attr in ('display', 'v', 'vv', 'vvv', 'vvvv', 'vvvvv', 'vvvvvv', 'verbose'):
+        continue
+    if not callable(getattr(Display, attr)):
+        continue
+    setattr(Display, attr, with_context(**{attr: True})(getattr(Display, attr)))
+
+
+def with_verbosity(f):
+    global event_context
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        host = args[2] if len(args) >= 3 else kwargs.get('host', None)
+        caplevel = args[3] if len(args) >= 4 else kwargs.get('caplevel', 2)
+        context = dict(verbose=True, verbosity=(caplevel + 1))
+        if host is not None:
+            context['remote_addr'] = host
+        with event_context.set_local(**context):
+            return f(*args, **kwargs)
+    return wrapper
+
+
+Display.verbose = with_verbosity(Display.verbose)
+
+
+def display_with_context(f):
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        log_only = args[5] if len(args) >= 6 else kwargs.get('log_only', False)
+        stderr = args[3] if len(args) >= 4 else kwargs.get('stderr', False)
+        event_uuid = event_context.get().get('uuid', None)
+        with event_context.display_lock:
+            # If writing only to a log file or there is already an event UUID
+            # set (from a callback module method), skip dumping the event data.
+            if log_only or event_uuid:
+                return f(*args, **kwargs)
+            try:
+                fileobj = sys.stderr if stderr else sys.stdout
+                event_context.add_local(uuid=str(uuid.uuid4()))
+                event_context.dump_begin(fileobj)
+                return f(*args, **kwargs)
+            finally:
+                event_context.dump_end(fileobj)
+                event_context.remove_local(uuid=None)
+
+    return wrapper
+
+
+Display.display = display_with_context(Display.display)

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -124,6 +124,7 @@ def run(**kwargs):
     :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
                        This is only used for 'jsonfile' type fact caches.
     :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
+    :param display_callback: Which display callback to use
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -155,6 +156,7 @@ def run(**kwargs):
     :type directory_isolation_base_path: str
     :type fact_cache: str
     :type fact_cache_type: str
+    :type display_callback: str
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -81,7 +81,7 @@ class RunnerConfig(object):
                  process_isolation=False, process_isolation_executable=None, process_isolation_path=None,
                  process_isolation_hide_paths=None, process_isolation_show_paths=None, process_isolation_ro_paths=None,
                  tags=None, skip_tags=None, fact_cache_type='jsonfile', fact_cache=None, project_dir=None,
-                 directory_isolation_base_path=None, envvars=None, forks=None):
+                 directory_isolation_base_path=None, envvars=None, forks=None, display_callback=None):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = ident
         self.json_mode = json_mode
@@ -123,6 +123,7 @@ class RunnerConfig(object):
         self.execution_mode = ExecutionMode.NONE
         self.envvars = envvars
         self.forks = forks
+        self.display_callback = display_callback
 
     def prepare(self):
         """
@@ -177,7 +178,9 @@ class RunnerConfig(object):
         if python_path and not python_path.endswith(':'):
             python_path += ':'
         self.env['ANSIBLE_CALLBACK_PLUGINS'] = callback_dir
-        if 'AD_HOC_COMMAND_ID' in self.env:
+        if self.display_callback:
+            self.env['ANSIBLE_STDOUT_CALLBACK'] = self.display_callback
+        elif 'AD_HOC_COMMAND_ID' in self.env:
             self.env['ANSIBLE_STDOUT_CALLBACK'] = 'minimal'
         else:
             self.env['ANSIBLE_STDOUT_CALLBACK'] = 'awx_display'
@@ -259,6 +262,7 @@ class RunnerConfig(object):
         self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
         self.suppress_ansible_output = self.settings.get('suppress_ansible_output', self.quiet)
         self.directory_isolation_cleanup = bool(self.settings.get('directory_isolation_cleanup', True))
+        self.display_callback = self.settings.get('display_callback', self.display_callback)
 
         if 'AD_HOC_COMMAND_ID' in self.env or not os.path.exists(self.project_dir):
             self.cwd = self.private_data_dir


### PR DESCRIPTION
**Purpose**
This PR allows the specification of a display callback to be used for output via the cmd line parameter --display-callback.

In addition, it adds a scrubber display callback. This callback attempts to mask strings in the output from Ansible with '******'.

**Scrubber details**
It will mask any values from the following environment variables:
- ANSIBLE_NET_AUTHORIZE
- ANSIBLE_NET_AUTH_PASS
- ANSIBLE_NET_PASSWORD
- ANSIBLE_NET_SSH_KEYFILE
- AWS_ACCESS_KEY_ID
- AWS_SECURITY_TOKEN
- AZURE_PASSWORD
- AZURE_SECRET
- CLOUDSCALE_API_TOKEN
- DO_API_KEY
- DO_API_TOKEN
- DO_OAUTH_TOKEN
- F5_PASSWORD
- HEROKU_API_KEY
- MERAKI_KEY
- NETSCALER_NITRO_PASS
- OAUTH_TOKEN
- ONLINE_API_KEY
- ONLINE_API_TOKEN
- ONLINE_OAUTH_TOKEN
- ONLINE_TOKEN
- SCW_API_KEY
- SCW_API_TOKEN
- SCW_OAUTH_TOKEN
- SCW_TOKEN
- TF_VAR_HEROKU_API_KEY
- VDIRECT_PASSWORD
- VMWARE_PASSWORD

Additional environment variables can be added to the list of the environment variables via the ansible variable ar_scrub_additional_env in the env/extravars. For example, if you had a custom credential type from Tower that created a env variable MY_CUSTOM_PASS you could capture the value of MY_CUSTOM_PASS with this in env/extravars:
```
ar_scrub_additional_env:
  - MY_CUSTOM_PASS
```

Any strings in the array ar_scrub_terms in env/extravars will also be scrubbed. For example, if you never wanted to see the term "root" in the output you could set this in env/extravars:
```
ar_scrub_terms:
  - "root"
```

Any strings listed in ar_scrub_additional_vars in env/extravars will be searched for as variables in env/extravars and, if found, their value will be added to the list of items to be scrubbed. For example with this env/extravars:
```
ar_scrub_additional_vars:
  - "my_var"
my_var: "Something"
```
Any instance of the term "Something" in the output will be masked.

Any value in env/passwords file will be added to the list to scrub.

Finally, if it finds an add_host task and there is an ansible_ssh_password in the output of add host that string will be added to the items to scrub.

**Limitations**
The callback does not know about vaulted passwords (other than the vault password itself) and it does not do variable expansion inside the variables. i.e. if env/extravars contains:
```
ar_scrb_additional_vars:
  - my_var
my_var: "{{ another_var }}"
```
The scrubber call back would end up looking for the string "{{ another_var }}".

Attached is a .tar.gz of a working directory with some example usage.
[work_dir.tar.gz](https://github.com/ansible/ansible-runner/files/3163756/work_dir.tar.gz)
