### PR TITLE
Keep the callback provided in the environment variable

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -214,9 +214,6 @@ def main(sys_args=None):
     parser.add_argument("-j", "--json", action="store_true",
                         help="Output the json event structure to stdout instead of Ansible output")
 
-    parser.add_argument("-k", "--ask-pass", action="store_true",
-                        help="Ask for connection password")
-
     parser.add_argument("-v", action="count",
                         help="Increase the verbosity with multiple v's (up to 5) of the ansible-playbook output")
 
@@ -316,7 +313,6 @@ def main(sys_args=None):
                                    json_mode=args.json,
                                    inventory=args.inventory,
                                    forks=args.forks,
-                                   ask_pass=args.ask_pass,
                                    project_dir=args.project_dir,
                                    roles_path=[args.roles_path] if args.roles_path else None,
                                    process_isolation=args.process_isolation,

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -222,6 +222,7 @@ def main(sys_args=None):
 
     parser.add_argument("--cmdline",
                         help="Command line options to pass to ansible-playbook at execution time")
+
     parser.add_argument("--debug", action="store_true",
                         help="Enable Runner debug output logging")
 

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -214,6 +214,9 @@ def main(sys_args=None):
     parser.add_argument("-j", "--json", action="store_true",
                         help="Output the json event structure to stdout instead of Ansible output")
 
+    parser.add_argument("-k", "--ask-pass", action="store_true",
+                        help="Ask for connection password")
+
     parser.add_argument("-v", action="count",
                         help="Increase the verbosity with multiple v's (up to 5) of the ansible-playbook output")
 
@@ -313,6 +316,7 @@ def main(sys_args=None):
                                    json_mode=args.json,
                                    inventory=args.inventory,
                                    forks=args.forks,
+                                   ask_pass=args.ask_pass,
                                    project_dir=args.project_dir,
                                    roles_path=[args.roles_path] if args.roles_path else None,
                                    process_isolation=args.process_isolation,

--- a/ansible_runner/display_callback/module.py
+++ b/ansible_runner/display_callback/module.py
@@ -169,7 +169,7 @@ class BaseCallbackModule(CallbackBase):
 
     def v2_playbook_on_vars_prompt(self, varname, private=True, prompt=None,
                                    encrypt=None, confirm=False, salt_size=None,
-                                   salt=None, default=None):
+                                   salt=None, default=None, unsafe=None):
         event_data = dict(
             varname=varname,
             private=private,
@@ -179,6 +179,7 @@ class BaseCallbackModule(CallbackBase):
             salt_size=salt_size,
             salt=salt,
             default=default,
+            unsafe=unsafe,
         )
         with self.capture_event_data('playbook_on_vars_prompt', **event_data):
             super(BaseCallbackModule, self).v2_playbook_on_vars_prompt(

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -104,7 +104,6 @@ def run(**kwargs):
     :param cmdline: Commnad line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
     :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param forks: Control Ansible parallel concurrency
-    :param ask_pass: Ask for connection password
     :param verbosity: Control how verbose the output of ansible-playbook is
     :param quiet: Disable all output
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
@@ -141,7 +140,6 @@ def run(**kwargs):
     :type cmdline: str
     :type limit: str
     :type forks: int
-    :type ask_pass: bool
     :type quiet: bool
     :type verbosity: int
     :type event_handler: function

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -104,6 +104,7 @@ def run(**kwargs):
     :param cmdline: Commnad line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
     :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param forks: Control Ansible parallel concurrency
+    :param ask_pass: Ask for connection password
     :param verbosity: Control how verbose the output of ansible-playbook is
     :param quiet: Disable all output
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
@@ -140,6 +141,7 @@ def run(**kwargs):
     :type cmdline: str
     :type limit: str
     :type forks: int
+    :type ask_pass: bool
     :type quiet: bool
     :type verbosity: int
     :type event_handler: function

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -221,7 +221,18 @@ class Runner(object):
         if self.config.directory_isolation_path and self.config.directory_isolation_cleanup:
             shutil.rmtree(self.config.directory_isolation_path)
         if self.config.process_isolation and self.config.process_isolation_path_actual:
-            shutil.rmtree(self.config.process_isolation_path_actual)
+            def _delete(retries=15):
+                try:
+                    shutil.rmtree(self.config.process_isolation_path_actual)
+                except OSError as e:
+                    res = False
+                    if e.errno == 16 and retries > 0:
+                        time.sleep(1)
+                        res = _delete(retries=retries - 1)
+                    if not res:
+                        raise
+                return True
+            _delete()
         if self.finished_callback is not None:
             try:
                 self.finished_callback(self)

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -220,6 +220,8 @@ class Runner(object):
                 f.write(str(data))
         if self.config.directory_isolation_path and self.config.directory_isolation_cleanup:
             shutil.rmtree(self.config.directory_isolation_path)
+        if self.config.process_isolation and self.config.process_isolation_path_actual:
+            shutil.rmtree(self.config.process_isolation_path_actual)
         if self.finished_callback is not None:
             try:
                 self.finished_callback(self)

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -81,7 +81,7 @@ class RunnerConfig(object):
                  process_isolation=False, process_isolation_executable=None, process_isolation_path=None,
                  process_isolation_hide_paths=None, process_isolation_show_paths=None, process_isolation_ro_paths=None,
                  tags=None, skip_tags=None, fact_cache_type='jsonfile', fact_cache=None, project_dir=None,
-                 directory_isolation_base_path=None, envvars=None, forks=None):
+                 directory_isolation_base_path=None, envvars=None, forks=None, cmdline=None):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = ident
         self.json_mode = json_mode
@@ -123,6 +123,7 @@ class RunnerConfig(object):
         self.execution_mode = ExecutionMode.NONE
         self.envvars = envvars
         self.forks = forks
+        self.cmdline_args = cmdline
 
     def prepare(self):
         """
@@ -306,7 +307,10 @@ class RunnerConfig(object):
         exec_list = [base_command]
 
         try:
-            cmdline_args = self.loader.load_file('env/cmdline', string_types, encoding=None)
+            if self.cmdline_args:
+                cmdline_args = self.cmdline_args
+            else:
+                cmdline_args = self.loader.load_file('env/cmdline', string_types, encoding=None)
             args = shlex.split(cmdline_args)
             exec_list.extend(args)
         except ConfigurationError:

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -332,15 +332,20 @@ class RunnerConfig(object):
 
         if self.loader.isfile('env/extravars'):
             exec_list.extend(['-e', '@{}'.format(self.loader.abspath('env/extravars'))])
-        if isinstance(self.extra_vars, dict) and self.extra_vars:
-            exec_list.extend(
-                [
-                    '-e',
-                    '%s' % ' '.join(
-                        ["{}=\"{}\"".format(k, self.extra_vars[k]) for k in self.extra_vars]
-                    )
-                ]
-            )
+
+        if self.extra_vars:
+            if isinstance(self.extra_vars, dict) and self.extra_vars:
+                exec_list.extend(
+                    [
+                        '-e',
+                        '%s' % ' '.join(
+                            ["{}=\"{}\"".format(k, self.extra_vars[k]) for k in self.extra_vars]
+                        )
+                    ]
+                )
+            elif self.loader.isfile(self.extra_vars):
+                exec_list.extend(['-e', '@{}'.format(self.loader.abspath(self.extra_vars))])
+
         if self.verbosity:
             v = 'v' * self.verbosity
             exec_list.append('-{}'.format(v))

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -201,7 +201,7 @@ class RunnerConfig(object):
         """
         Prepares the inventory default under ``private_data_dir`` if it's not overridden by the constructor.
         """
-        if self.inventory is None:
+        if self.inventory is None and os.path.exists(os.path.join(self.private_data_dir, "inventory")):
             self.inventory  = os.path.join(self.private_data_dir, "inventory")
 
     def prepare_env(self):
@@ -316,7 +316,9 @@ class RunnerConfig(object):
         except ConfigurationError:
             pass
 
-        if isinstance(self.inventory, list):
+        if self.inventory is None:
+            pass
+        elif isinstance(self.inventory, list):
             for i in self.inventory:
                 exec_list.append("-i")
                 exec_list.append(i)

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -176,7 +176,7 @@ class RunnerConfig(object):
         python_path = self.env.get('PYTHONPATH', os.getenv('PYTHONPATH', ''))
         if python_path and not python_path.endswith(':'):
             python_path += ':'
-        self.env['ANSIBLE_CALLBACK_PLUGINS'] = ':'.join(filter(None,(self.env['ANSIBLE_CALLBACK_PLUGINS'], callback_dir)))
+        self.env['ANSIBLE_CALLBACK_PLUGINS'] = ':'.join(filter(None,(self.env.get('ANSIBLE_CALLBACK_PLUGINS'), callback_dir)))
         if 'AD_HOC_COMMAND_ID' in self.env:
             self.env['ANSIBLE_STDOUT_CALLBACK'] = 'minimal'
         else:

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -16,13 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import atexit
 import os
 import re
 import pexpect
 import stat
 import shlex
-import shutil
 import tempfile
 import logging
 
@@ -104,6 +102,7 @@ class RunnerConfig(object):
         self.process_isolation = process_isolation
         self.process_isolation_executable = process_isolation_executable
         self.process_isolation_path = process_isolation_path
+        self.process_isolation_path_actual = None
         self.process_isolation_hide_paths = process_isolation_hide_paths
         self.process_isolation_show_paths = process_isolation_show_paths
         self.process_isolation_ro_paths = process_isolation_ro_paths
@@ -381,7 +380,6 @@ class RunnerConfig(object):
         '''
         path = tempfile.mkdtemp(prefix='ansible_runner_pi_', dir=self.process_isolation_path)
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
-        atexit.register(shutil.rmtree, path)
         return path
 
     def wrap_args_with_process_isolation(self, args):
@@ -390,7 +388,7 @@ class RunnerConfig(object):
          - self.process_isolation_path (generally, /tmp) (except for own /tmp files)
         '''
         cwd = os.path.realpath(self.cwd)
-        pi_temp_dir = self.build_process_isolation_temp_dir()
+        self.process_isolation_path_actual = self.build_process_isolation_temp_dir()
         new_args = [self.process_isolation_executable or 'bwrap', '--unshare-pid', '--dev-bind', '/', '/', '--proc', '/proc']
 
         for path in sorted(set(self.process_isolation_hide_paths or [])):
@@ -399,10 +397,10 @@ class RunnerConfig(object):
                 continue
             path = os.path.realpath(path)
             if os.path.isdir(path):
-                new_path = tempfile.mkdtemp(dir=pi_temp_dir)
+                new_path = tempfile.mkdtemp(dir=self.process_isolation_path_actual)
                 os.chmod(new_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
             else:
-                handle, new_path = tempfile.mkstemp(dir=pi_temp_dir)
+                handle, new_path = tempfile.mkstemp(dir=self.process_isolation_path_actual)
                 os.close(handle)
                 os.chmod(new_path, stat.S_IRUSR | stat.S_IWUSR)
             new_args.extend(['--bind', '{0}'.format(new_path), '{0}'.format(path)])

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -176,7 +176,7 @@ class RunnerConfig(object):
         python_path = self.env.get('PYTHONPATH', os.getenv('PYTHONPATH', ''))
         if python_path and not python_path.endswith(':'):
             python_path += ':'
-        self.env['ANSIBLE_CALLBACK_PLUGINS'] = callback_dir
+        self.env['ANSIBLE_CALLBACK_PLUGINS'] = ':'.join(filter(None,(self.env['ANSIBLE_CALLBACK_PLUGINS'], callback_dir)))
         if 'AD_HOC_COMMAND_ID' in self.env:
             self.env['ANSIBLE_STDOUT_CALLBACK'] = 'minimal'
         else:

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -225,11 +225,7 @@ class OutputEventFilter(object):
         self.suppress_ansible_output = suppress_ansible_output
 
     def flush(self):
-        # pexpect wants to flush the file it writes to, but we're not
-        # actually capturing stdout to a raw file; we're just
-        # implementing a custom `write` method to discover and emit events from
-        # the stdout stream
-        pass
+        self._handle.flush()
 
     def write(self, data):
         self._buffer.write(data)
@@ -302,6 +298,7 @@ class OutputEventFilter(object):
             self._emit_event(value)
             self._buffer = StringIO()
         self._event_callback(dict(event='EOF'))
+        self._handle.close()
 
     def _emit_event(self, buffered_stdout, next_event_data=None):
         next_event_data = next_event_data or {}

--- a/test/integration/callback/other_callback.py
+++ b/test/integration/callback/other_callback.py
@@ -1,0 +1,13 @@
+from ansible.plugins.callback import CallbackBase
+
+class CallbackModule(CallbackBase):
+  CALLBACK_VERSION = 2.0
+  CALLBACK_TYPE = 'aggregate'
+  CALLBACK_NAME = 'other_callback'
+
+  def v2_playbook_on_play_start(self, play):
+    pass
+
+  def v2_runner_on_ok(self, result):
+    pass
+

--- a/test/integration/callback/other_callback.py
+++ b/test/integration/callback/other_callback.py
@@ -1,13 +1,14 @@
 from ansible.plugins.callback import CallbackBase
 
+
 class CallbackModule(CallbackBase):
-  CALLBACK_VERSION = 2.0
-  CALLBACK_TYPE = 'aggregate'
-  CALLBACK_NAME = 'other_callback'
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'other_callback'
 
-  def v2_playbook_on_play_start(self, play):
-    pass
+    def v2_playbook_on_play_start(self, play):
+        pass
 
-  def v2_runner_on_ok(self, result):
-    pass
+    def v2_runner_on_ok(self, result):
+        pass
 

--- a/test/integration/test___main__.py
+++ b/test/integration/test___main__.py
@@ -220,3 +220,24 @@ def test_cmdline_playbook_hosts():
         shutil.rmtree(private_data_dir)
 
 
+def test_cmdline_cmdline_override():
+    try:
+        private_data_dir = tempfile.mkdtemp()
+        play = [{'hosts': 'all', 'tasks': [{'debug': {'msg': random_string()}}]}]
+
+        path = os.path.join(private_data_dir, 'project')
+        os.makedirs(path)
+
+        playbook = os.path.join(path, 'main.yaml')
+        with open(playbook, 'w') as f:
+            f.write(json.dumps(play))
+        path = os.path.join(private_data_dir, 'inventory')
+        os.makedirs(path)
+
+        inventory = os.path.join(path, 'hosts')
+        with open(inventory, 'w') as f:
+            f.write('[all]\nlocalhost ansible_connection=local')
+        cmdline('run', private_data_dir, '-p', playbook, '--hosts', 'all', '--cmdline', '-e foo=bar')
+        assert main() == 0
+    finally:
+        shutil.rmtree(private_data_dir)

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -20,7 +20,7 @@ def executor(tmpdir, request):
     playbooks = request.node.callspec.params.get('playbook')
     playbook = list(playbooks.values())[0]
     envvars = request.node.callspec.params.get('envvars')
-    envvars.update({"ANSIBLE_DEPRECATION_WARNINGS": "False"})
+    envvars = envvars.update({"ANSIBLE_DEPRECATION_WARNINGS": "False"}) if envvars is not None else {"ANSIBLE_DEPRECATION_WARNINGS": "False"}
 
     r = init_runner(
         private_data_dir=private_data_dir,

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -13,6 +13,7 @@ import pytest
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
+
 @pytest.fixture()
 def executor(tmpdir, request):
     private_data_dir = six.text_type(tmpdir.mkdir('foo'))
@@ -61,8 +62,8 @@ def executor(tmpdir, request):
 '''},  # noqa
 ])
 @pytest.mark.parametrize('envvars', [
-{'ANSIBLE_CALLBACK_PLUGINS': os.path.join(HERE, 'callback')},
-{'ANSIBLE_CALLBACK_PLUGINS': ''}
+    {'ANSIBLE_CALLBACK_PLUGINS': os.path.join(HERE, 'callback')},
+    {'ANSIBLE_CALLBACK_PLUGINS': ''}
 ])
 def test_callback_plugin_receives_events(executor, event, playbook, envvars):
     executor.run()

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -223,6 +223,9 @@ def test_generate_ansible_command():
     with patch.object(rc.loader, 'isfile', side_effect=lambda x: True):
         cmd = rc.generate_ansible_command()
         assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', 'test="key"', 'main.yaml']
+        rc.extra_vars = '/tmp/extravars.yml'
+        cmd = rc.generate_ansible_command()
+        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '@/tmp/extravars.yml', 'main.yaml']
         rc.extra_vars = None
         cmd = rc.generate_ansible_command()
         assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', 'main.yaml']

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
+# to the latest version
+sudo pip install -U tox


### PR DESCRIPTION
When the environment variable `ANSIBLE_STDOUT_CALLBACK` is set, it was ignored when calling ansible as only the callback_dir was passed.