### PR TITLE
Upgrade tox to latest version

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
+# to the latest version
+sudo pip install -U tox


### PR DESCRIPTION
Using the distro version of tox on centos-7 is too old. This overrides
all distro packages to install the latest version.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>