### PR TITLE
Keep the callback provided in the environment variable

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -176,7 +176,7 @@ class RunnerConfig(object):
         python_path = self.env.get('PYTHONPATH', os.getenv('PYTHONPATH', ''))
         if python_path and not python_path.endswith(':'):
             python_path += ':'
-        self.env['ANSIBLE_CALLBACK_PLUGINS'] = callback_dir
+        self.env['ANSIBLE_CALLBACK_PLUGINS'] = ':'.join(filter(None,(self.env.get('ANSIBLE_CALLBACK_PLUGINS'), callback_dir)))
         if 'AD_HOC_COMMAND_ID' in self.env:
             self.env['ANSIBLE_STDOUT_CALLBACK'] = 'minimal'
         else:

--- a/test/integration/callback/other_callback.py
+++ b/test/integration/callback/other_callback.py
@@ -1,0 +1,14 @@
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'aggregate'
+    CALLBACK_NAME = 'other_callback'
+
+    def v2_playbook_on_play_start(self, play):
+        pass
+
+    def v2_runner_on_ok(self, result):
+        pass
+

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -12,17 +12,21 @@ from ansible_runner.interface import init_runner
 import pytest
 
 
+HERE = os.path.abspath(os.path.dirname(__file__))
+
 @pytest.fixture()
 def executor(tmpdir, request):
     private_data_dir = six.text_type(tmpdir.mkdir('foo'))
 
     playbooks = request.node.callspec.params.get('playbook')
     playbook = list(playbooks.values())[0]
+    envvars = request.node.callspec.params.get('envvars')
+    envvars = envvars.update({"ANSIBLE_DEPRECATION_WARNINGS": "False"}) if envvars is not None else {"ANSIBLE_DEPRECATION_WARNINGS": "False"}
 
     r = init_runner(
         private_data_dir=private_data_dir,
         inventory="localhost ansible_connection=local",
-        envvars={"ANSIBLE_DEPRECATION_WARNINGS": "False"},
+        envvars=envvars,
         playbook=yaml.safe_load(playbook)
     )
 
@@ -57,7 +61,11 @@ def executor(tmpdir, request):
         var: results
 '''},  # noqa
 ])
-def test_callback_plugin_receives_events(executor, event, playbook):
+@pytest.mark.parametrize('envvars', [
+    {'ANSIBLE_CALLBACK_PLUGINS': os.path.join(HERE, 'callback')},
+    {'ANSIBLE_CALLBACK_PLUGINS': ''}
+])
+def test_callback_plugin_receives_events(executor, event, playbook, envvars):
     executor.run()
     assert len(list(executor.events))
     assert event in [task['event'] for task in executor.events]

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -11,8 +11,8 @@ from ansible_runner.interface import init_runner
 
 import pytest
 
-
 HERE = os.path.abspath(os.path.dirname(__file__))
+
 
 @pytest.fixture()
 def executor(tmpdir, request):


### PR DESCRIPTION
When the environment variable ANSIBLE_STDOUT_CALLBACK is set, it was ignored when calling ansible as only the callback_dir was passed.