### PR TITLE
Use Ansible encoder for dumping event data

### DIFF
--- a/ansible_runner/display_callback/events.py
+++ b/ansible_runner/display_callback/events.py
@@ -43,6 +43,8 @@ class AnsibleJSONEncoderLocal(json.JSONEncoder):
     def default(self, o):
         if getattr(o, 'yaml_tag', None) == '!vault':
             return o.data
+        elif isinstance(o, (datetime.date, datetime.datetime)):
+            return o.isoformat()
         return super(AnsibleJSONEncoderLocal, self).default(o)
 
 

--- a/ansible_runner/display_callback/events.py
+++ b/ansible_runner/display_callback/events.py
@@ -28,6 +28,9 @@ import stat
 import threading
 import uuid
 
+# Ansible
+from ansible.parsing.ajson import AnsibleJSONEncoder
+
 __all__ = ['event_context']
 
 
@@ -48,7 +51,7 @@ class IsolatedFileWrite:
             os.mkdir(os.path.join(self.private_data_dir, 'job_events'), 0o700)
         dropoff_location = os.path.join(self.private_data_dir, 'job_events', filename)
         write_location = '.'.join([dropoff_location, 'tmp'])
-        partial_data = json.dumps(value)
+        partial_data = json.dumps(value, cls=AnsibleJSONEncoder)
         with os.fdopen(os.open(write_location, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR), 'w') as f:
             f.write(partial_data)
         os.rename(write_location, dropoff_location)

--- a/ansible_runner/display_callback/events.py
+++ b/ansible_runner/display_callback/events.py
@@ -42,7 +42,10 @@ class AnsibleJSONEncoderLocal(json.JSONEncoder):
 
     def default(self, o):
         if getattr(o, 'yaml_tag', None) == '!vault':
-            return o.data
+            encrypted_form = o._ciphertext
+            if isinstance(encrypted_form, bytes):
+                encrypted_form = encrypted_form.decode('utf-8')
+            return {'__ansible_vault': encrypted_form}
         elif isinstance(o, (datetime.date, datetime.datetime)):
             return o.isoformat()
         return super(AnsibleJSONEncoderLocal, self).default(o)


### PR DESCRIPTION
Connect https://github.com/ansible/ansible-runner/issues/330

See: https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/callback/json.py#L38

I think we can import Ansible here???

```
ansible-runner --playbook test.yml run alan 
Vault password: 

PLAY [localhost] ***************************************************************

TASK [set_fact] ****************************************************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "msg": "My password value is hell workld111"
}

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```