### PR TITLE
[utils.py] Fix currupt json stdout with large events

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -292,13 +292,6 @@ class OutputEventFilter(object):
 
             self._last_chunk = remainder
         else:
-            if not self.suppress_ansible_output:
-                sys.stdout.write(
-                    data.encode('utf-8') if PY2 else data
-                )
-            self._handle.write(data)
-            self._handle.flush()
-
             # Verbose stdout outside of event data context
             if data and '\n' in data and self._current_event_data is None:
                 # emit events for all complete lines we know about
@@ -310,6 +303,12 @@ class OutputEventFilter(object):
                 # emit all complete lines
                 for line in lines:
                     self._emit_event(line)
+                    if not self.suppress_ansible_output:
+                        sys.stdout.write(
+                            line.encode('utf-8') if PY2 else line
+                        )
+                    self._handle.write(line)
+                    self._handle.flush()
                 self._buffer = StringIO()
                 # put final partial line back on buffer
                 if remainder:

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -15,9 +15,12 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 @pytest.fixture()
-def executor(tmpdir, request):
-    private_data_dir = six.text_type(tmpdir.mkdir('foo'))
+def private_data_dir(tmpdir):
+    return six.text_type(tmpdir.mkdir('foo'))
 
+
+@pytest.fixture()
+def executor(request, private_data_dir):
     playbooks = request.node.callspec.params.get('playbook')
     playbook = list(playbooks.values())[0]
     envvars = request.node.callspec.params.get('envvars')
@@ -311,3 +314,27 @@ def test_module_level_no_log(executor, playbook):
     assert len(list(executor.events))
     assert 'john-jacob-jingleheimer-schmidt' in json.dumps(list(executor.events))
     assert 'SENSITIVE' not in json.dumps(list(executor.events))
+
+
+def test_output_when_given_invalid_playbook(private_data_dir):
+    # As shown in the following issue:
+    #
+    #   https://github.com/ansible/ansible-runner/issues/29
+    #
+    # There was a lack of output by runner when a playbook that doesn't exist
+    # is provided.  This was fixed in this PR:
+    #
+    #   https://github.com/ansible/ansible-runner/pull/34
+    #
+    # But no test validated it.  This does that.
+    executor = init_runner(
+        private_data_dir=private_data_dir,
+        inventory="localhost ansible_connection=local",
+        envvars={"ANSIBLE_DEPRECATION_WARNINGS": "False"},
+        playbook=os.path.join(private_data_dir, 'fake_playbook.yml')
+    )
+
+    executor.run()
+    stdout = executor.stdout.read()
+    assert "ERROR! the playbook:" in stdout
+    assert "could not be found" in stdout


### PR DESCRIPTION
When using the `--json` output with `ansible-runner`, it is possible to over fill `pexpect`'s `maxread` default of 2000, which ends up causing the `else` of the `while` loop in the `OutputEventFilter.write` method to get triggered, and that will indiscriminately push raw output to the stdout handle.  This output is also a partial event at this point as well, and shouldn't be pushed to STDOUT until a full event has been processed and breaks the expectation of 1 line of JSON per line.

The intent of this section of the `else` is to provide some feedback to the user if something goes wrong (for example, you provide a playbook path that does not exist), as shown in the issue and pull request (fix) where they originate from:

- https://github.com/ansible/ansible-runner/issues/29
- https://github.com/ansible/ansible-runner/pull/34

This tries to keep with the spirit of those fixes, but does so after the main spawned process loop has completed, and not while still in progress.