### PR TITLE
fixes use of --artifact-dir optional argument

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -74,6 +74,7 @@ def role_manager(args):
                       ignore_logging=False,
                       project_dir=args.project_dir,
                       rotate_artifacts=args.rotate_artifacts)
+
         if args.artifact_dir:
             kwargs.artifact_dir = args.artifact_dir
 
@@ -517,6 +518,7 @@ def main(sys_args=None):
                                    inventory=args.inventory,
                                    forks=args.forks,
                                    project_dir=args.project_dir,
+                                   artifact_dir=args.artifact_dir,
                                    roles_path=[args.roles_path] if args.roles_path else None,
                                    process_isolation=args.process_isolation,
                                    process_isolation_executable=args.process_isolation_executable,

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -81,7 +81,7 @@ class RunnerConfig(object):
                  tags=None, skip_tags=None, fact_cache_type='jsonfile', fact_cache=None, project_dir=None,
                  directory_isolation_base_path=None, envvars=None, forks=None, cmdline=None):
         self.private_data_dir = os.path.abspath(private_data_dir)
-        self.ident = ident
+        self.ident = str(ident)
         self.json_mode = json_mode
         self.playbook = playbook
         self.inventory = inventory
@@ -93,10 +93,14 @@ class RunnerConfig(object):
         self.binary = binary
         self.rotate_artifacts = rotate_artifacts
         self.artifact_dir = os.path.abspath(artifact_dir or self.private_data_dir)
-        if self.ident is None:
-            self.artifact_dir = os.path.join(self.artifact_dir, "artifacts")
+
+        if artifact_dir is None:
+            self.artifact_dir = os.path.join(self.private_data_dir, 'artifacts')
         else:
-            self.artifact_dir = os.path.join(self.artifact_dir, "artifacts", "{}".format(self.ident))
+            self.artifact_dir = os.path.abspath(artifact_dir)
+
+        if self.ident is not None:
+            self.artifact_dir = os.path.join(self.artifact_dir, "{}".format(self.ident))
 
         self.extra_vars = extravars
         self.process_isolation = process_isolation

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -186,24 +186,33 @@ def test_role_run_cmd_line_abs():
 
 def test_role_run_artifacts_dir():
 
-    rc = main(['-r', 'benthomasson.hello_role',
-               '--hosts', 'localhost',
-               '--roles-path', 'test/integration/roles',
-               '--artifact-dir', 'otherartifacts',
-               'run',
-               "test/integration"])
-    assert rc == 0
+    try:
+        tmpdir = tempfile.mkdtemp()
+        rc = main(['-r', 'benthomasson.hello_role',
+                   '--hosts', 'localhost',
+                   '--roles-path', 'test/integration/roles',
+                   '--artifact-dir', os.path.join(tmpdir, 'otherartifacts'),
+                   'run',
+                   "test/integration"])
+        assert os.path.exists(os.path.join(tmpdir, 'otherartifacts'))
+        assert rc == 0
+    finally:
+        shutil.rmtree(tmpdir)
 
 
 def test_role_run_artifacts_dir_abs():
-    with temp_directory() as temp_dir:
-        rc = main(['-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', os.path.join(HERE, 'project/roles'),
-                   '--artifact-dir', 'otherartifacts',
-                   'run',
-                   temp_dir])
-    assert rc == 0
+    try:
+        with temp_directory() as temp_dir:
+            rc = main(['-r', 'benthomasson.hello_role',
+                       '--hosts', 'localhost',
+                       '--roles-path', os.path.join(HERE, 'project/roles'),
+                       '--artifact-dir', 'otherartifacts',
+                       'run',
+                       temp_dir])
+        assert os.path.exists(os.path.join('.', 'otherartifacts'))
+        assert rc == 0
+    finally:
+        shutil.rmtree(os.path.join('.', 'otherartifacts'))
 
 
 @pytest.mark.parametrize('envvars', [

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -51,7 +51,7 @@ def test_runner_config_init_defaults():
 
 def test_runner_config_with_artifact_dir():
     rc = RunnerConfig('/', artifact_dir='/this-is-some-dir')
-    assert rc.artifact_dir == os.path.join('/this-is-some-dir', 'artifacts/%s' % rc.ident)
+    assert rc.artifact_dir == os.path.join('/this-is-some-dir', rc.ident)
 
 
 def test_runner_config_init_with_ident():


### PR DESCRIPTION
The argument --artifact-dir was only implemented for direct role
execution.  This change implements --artifact-dir for all operations.
When uisng --artifact-dir, the artifacts directly will be located in the
provided path.  If this option is not specified, then the artifiacts are
located in <private_data_dir>/artifacts.

Signed-off-by: Peter Sprygada <psprygad@redhat.com>