### PR TITLE
updates to Makefile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .coverage
 *,cover
 /test/integration/artifacts
+.venv
 
 # ansible-runner
 artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,4 @@
 .pytest_cache
 .coverage
 *,cover
-/test/integration/artifacts
 .venv
-
-# ansible-runner
-artifacts/
-new_logfile

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,11 @@ DEB_DATE := $(shell LC_TIME=C date +"%a, %d %b %Y %T %z")
 
 clean:
 	rm -rf dist
+	rm -rf build
 	rm -rf ansible-runner.egg-info
 	rm -rf rpm-build
 	rm -rf deb-build
+	find . -type f -regex ".*\py[co]$$" -delete
 
 dist:
 	$(DIST_PYTHON) setup.py bdist_wheel --universal


### PR DESCRIPTION
This commit updates Makefile to remove the build/ folder and to remove
all Python byte compiled files when the `make clean` command is entered.

This commit also adds .venv to the .gitignore file to exclude
virtualenvs that are keep in the project src

Signed-off-by: Peter Sprygada <psprygad@redhat.com>