### PR TITLE
updates test cases to clean up left behind files

### DIFF
--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -4,6 +4,7 @@ from distutils.version import LooseVersion
 import pkg_resources
 import json
 import os
+import shutil
 
 from ansible_runner import run, run_async
 
@@ -80,14 +81,17 @@ def test_playbook_on_stats_summary_fields(rc):
 
 
 def test_include_role_events():
-    r = run(
-        private_data_dir=os.path.abspath('test/integration'),
-        playbook='use_role.yml'
-    )
-    role_events = [event for event in r.events if event.get('event_data', {}).get('role', '') == "benthomasson.hello_role"]
-    assert 'runner_on_ok' in [event['event'] for event in role_events]
-    for event in role_events:
-        event_data = event['event_data']
-        assert not event_data.get('warning', False)  # role use should not contain warnings
-        if event['event'] == 'runner_on_ok':
-            assert event_data['res']['msg'] == 'Hello world!'
+    try:
+        r = run(
+            private_data_dir=os.path.abspath('test/integration'),
+            playbook='use_role.yml'
+        )
+        role_events = [event for event in r.events if event.get('event_data', {}).get('role', '') == "benthomasson.hello_role"]
+        assert 'runner_on_ok' in [event['event'] for event in role_events]
+        for event in role_events:
+            event_data = event['event_data']
+            assert not event_data.get('warning', False)  # role use should not contain warnings
+            if event['event'] == 'runner_on_ok':
+                assert event_data['res']['msg'] == 'Hello world!'
+    finally:
+        shutil.rmtree('test/integration/artifacts')

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -33,7 +33,6 @@ def ensure_removed(path):
 
 @contextmanager
 def temp_directory(files=None):
-
     temp_dir = tempfile.mkdtemp()
     print(temp_dir)
     try:
@@ -135,26 +134,32 @@ def test_role_run_abs():
 
 
 def test_role_logfile():
-
-    rc = main(['-r', 'benthomasson.hello_role',
-               '--hosts', 'localhost',
-               '--roles-path', 'test/integration/project/roles',
-               '--logfile', 'new_logfile',
-               'run',
-               'test/integration'])
-    assert rc == 0
-    ensure_removed("test/integration/artifacts")
+    try:
+        rc = main(['-r', 'benthomasson.hello_role',
+                   '--hosts', 'localhost',
+                   '--roles-path', 'test/integration/project/roles',
+                   '--logfile', 'new_logfile',
+                   'run',
+                   'test/integration'])
+        assert os.path.exists('new_logfile')
+        assert rc == 0
+    finally:
+        ensure_removed("test/integration/artifacts")
 
 
 def test_role_logfile_abs():
-    with temp_directory() as temp_dir:
-        rc = main(['-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', os.path.join(HERE, 'project/roles'),
-                   '--logfile', 'new_logfile',
-                   'run',
-                   temp_dir])
-    assert rc == 0
+    try:
+        with temp_directory() as temp_dir:
+            rc = main(['-r', 'benthomasson.hello_role',
+                       '--hosts', 'localhost',
+                       '--roles-path', os.path.join(HERE, 'project/roles'),
+                       '--logfile', 'new_logfile',
+                       'run',
+                       temp_dir])
+        assert os.path.exists('new_logfile')
+        assert rc == 0
+    finally:
+        ensure_removed("new_logfile")
 
 
 def test_role_bad_project_dir():
@@ -172,6 +177,7 @@ def test_role_bad_project_dir():
                   'bad_project_dir'])
     finally:
         os.unlink('bad_project_dir')
+        ensure_removed("new_logfile")
 
 
 def test_role_run_clean():
@@ -204,20 +210,6 @@ def test_role_run_artifacts_dir():
                "test/integration"])
     assert rc == 0
     ensure_removed("test/integration/artifacts")
-
-
-def test_role_run_artifacts_dir_abs():
-    with temp_directory() as temp_dir:
-        rc = main(['-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', 'test/integration/roles',
-                   '--artifact-dir', os.path.join(tmpdir, 'otherartifacts'),
-                   'run',
-                   "test/integration"])
-        assert os.path.exists(os.path.join(tmpdir, 'otherartifacts'))
-        assert rc == 0
-    finally:
-        shutil.rmtree(tmpdir)
 
 
 def test_role_run_artifacts_dir_abs():


### PR DESCRIPTION
This commit updates some test cases to remove left behind artifact
directories such that all tests now leave a clean file system at the
conclusion of the test run.

Signed-off-by: Peter Sprygada <psprygad@redhat.com>