### PR TITLE
Cap zipp<0.6.0 for tox dependency

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -2,4 +2,6 @@
 
 # NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
 # to the latest version
-sudo pip install -U tox
+# NOTE(pabelanger): Cap zipp<0.6.0 due to python2.7 issue with more-iterrtools
+# https://github.com/jaraco/zipp/issues/14
+sudo pip install -U tox "zipp<0.6.0"


### PR DESCRIPTION
A new dependency on more-itertools is only python3 only.

Related-to: https://github.com/jaraco/zipp/issues/14
Signed-off-by: Paul Belanger <pabelanger@redhat.com>