### PR TITLE
Refactor Dockerfile and entryoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,35 @@
 FROM centos:7
 
-ADD https://github.com/krallin/tini/releases/download/v0.14.0/tini /tini
+ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /bin/tini
+ADD utils/entrypoint.sh /bin/entrypoint
+ADD demo/project /runner/project
+ADD demo/env /runner/env
+ADD demo/inventory /runner/inventory
 
 # Install Ansible Runner
-RUN yum -y install epel-release  && \
-    yum -y install ansible python-psutil python-pip python-docutils bubblewrap bzip2 python-crypto openssh openssh-clients git && \
-    localedef -c -i en_US -f UTF-8 en_US.UTF-8 && \
-    chmod +x /tini && \
-    pip install --no-cache-dir wheel pexpect psutil python-daemon && \
-    rm -rf /var/cache/yum
+RUN yum-config-manager --add-repo https://releases.ansible.com/ansible-runner/ansible-runner.el7.repo && \
+	yum install -y epel-release && yum install -y python-pip ansible-runner bubblewrap sudo rsync && \
+	pip install --no-cache-dir ansible && \
+	localedef -c -i en_US -f UTF-8 en_US.UTF-8 && \
+	chmod +x /bin/tini /bin/entrypoint && rm -rf /var/cache/yum
 
-ENV LANG=en_US.UTF-8 \
-    LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
+# In OpenShift, container will run as a random uid number and gid 0. Make sure things
+# are writeable by the root group.
+RUN mkdir -p /runner/inventory /runner/project /runner/artifacts /runner/.ansible/tmp && \
+	chmod -R g+w /runner && chgrp -R root /runner && \
+	chmod g+w /etc/passwd
 
 VOLUME /runner/inventory
 VOLUME /runner/project
 VOLUME /runner/artifacts
-ENTRYPOINT ["/tini", "--"]
-WORKDIR /
-ENV RUNNER_BASE_COMMAND=ansible-playbook
-CMD /entrypoint.sh
 
-ADD utils/entrypoint.sh /entrypoint.sh
-ADD demo/project /runner/project
-ADD demo/env /runner/env
-ADD demo/inventory /runner/inventory
-ADD dist/ansible_runner-1.3.4-py2.py3-none-any.whl /ansible_runner-1.3.4-py2.py3-none-any.whl
-# In OpenShift, container will run as a random uid number and gid 0. Make sure things
-# are writeable by the root group.
-RUN chmod 755 /entrypoint.sh && chmod -R g+w /runner && chgrp -R root /runner && \
-    chmod g+w /etc/passwd && \
-    pip install --no-cache-dir /ansible_runner-1.3.4-py2.py3-none-any.whl
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV RUNNER_BASE_COMMAND=ansible-playbook
+ENV HOME=/runner
+
+WORKDIR /runner
+
+ENTRYPOINT ["entrypoint"]
+CMD ["ansible-runner", "run", "/runner"]


### PR DESCRIPTION
Things I found when building out the AWX jobs-in-k8s feature. Notable changes: 

- I switched to installing our upstream RPM. This removed the hardcoded `.whl` stuff.
- Updated `entrypoint.sh` to make it possible to start the container with another command such as `bash` without needing to monkey around with `--entrypoint`.