### PR TITLE
simplifies the direct role execution path

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -1,4 +1,21 @@
-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 import json
 import sys
 import re
@@ -21,20 +38,6 @@ except ImportError:
     from collections import Iterable, Mapping
 from io import StringIO
 from six import string_types, PY2, PY3, text_type, binary_type
-
-
-class Bunch(object):
-
-    '''
-    Collect a bunch of variables together in an object.
-    This is a slight modification of Alex Martelli's and Doug Hudgeon's Bunch pattern.
-    '''
-
-    def __init__(self, **kwargs):
-        self.update(**kwargs)
-
-    def update(self, **kwargs):
-        self.__dict__.update(kwargs)
 
 
 def isplaybook(obj):


### PR DESCRIPTION
This commit simplifies the role context manager and helps to stop
overloading variables.  Roles now execute in a temp directory only and
artifacts are not kept by default.  In order to keep artifiacts, the
`--artifacts-dir` command line option must be used.  This change also
enforces the use of `--hosts` instead of attaching to an existing
`private_data_dir`

Signed-off-by: Peter Sprygada <psprygad@redhat.com>