### PR TITLE
Allow limiting the ansible event datastructure

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -308,6 +308,22 @@ def main(sys_args=None):
     )
 
     runner_group.add_argument(
+        "--omit-event-data",
+        action="store_true",
+        help="Omits including extra event data in the callback payloads "
+             "or the Runner payload data files "
+             "(status and stdout still included)"
+    )
+
+    runner_group.add_argument(
+        "--only-failed-event-data",
+        action="store_true",
+        help="Only adds extra event data for failed tasks in the callback "
+             "payloads or the Runner payload data files "
+             "(status and stdout still included for other events)"
+    )
+
+    runner_group.add_argument(
         "-q", "--quiet",
         action="store_true",
         help="disable all messages sent to stdout/stderr (default=False)"
@@ -515,6 +531,8 @@ def main(sys_args=None):
                                    rotate_artifacts=args.rotate_artifacts,
                                    ignore_logging=False,
                                    json_mode=args.json,
+                                   omit_event_data=args.omit_event_data,
+                                   only_failed_event_data=args.only_failed_event_data,
                                    inventory=args.inventory,
                                    forks=args.forks,
                                    project_dir=args.project_dir,

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -124,6 +124,8 @@ def run(**kwargs):
     :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
                        This is only used for 'jsonfile' type fact caches.
     :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
+    :param omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
+    :param only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -155,6 +157,8 @@ def run(**kwargs):
     :type directory_isolation_base_path: str
     :type fact_cache: str
     :type fact_cache_type: str
+    :type omit_event_data: bool
+    :type only_failed_event_data: bool
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -79,7 +79,8 @@ class RunnerConfig(object):
                  process_isolation=False, process_isolation_executable=None, process_isolation_path=None,
                  process_isolation_hide_paths=None, process_isolation_show_paths=None, process_isolation_ro_paths=None,
                  tags=None, skip_tags=None, fact_cache_type='jsonfile', fact_cache=None, project_dir=None,
-                 directory_isolation_base_path=None, envvars=None, forks=None, cmdline=None):
+                 directory_isolation_base_path=None, envvars=None, forks=None, cmdline=None, omit_event_data=False,
+                 only_failed_event_data=False):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = str(ident)
         self.json_mode = json_mode
@@ -127,6 +128,8 @@ class RunnerConfig(object):
         self.envvars = envvars
         self.forks = forks
         self.cmdline_args = cmdline
+        self.omit_event_data = omit_event_data
+        self.only_failed_event_data = only_failed_event_data
 
     def prepare(self):
         """
@@ -199,6 +202,9 @@ class RunnerConfig(object):
         if self.fact_cache_type == 'jsonfile':
             self.env['ANSIBLE_CACHE_PLUGIN'] = 'jsonfile'
             self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = self.fact_cache
+
+        self.env["RUNNER_OMIT_EVENTS"] = str(self.omit_event_data)
+        self.env["RUNNER_ONLY_FAILED_EVENTS"] = str(self.only_failed_event_data)
 
     def prepare_inventory(self):
         """


### PR DESCRIPTION
This adds two tunables:

* omit_event_data: excludes everything under the event['event_data']
                   property
* only_failed_event_data: As above, but will include event data for
                          failed events

The idea here is to allow the caller to further constrain the size of
the data payload returned to the interested system.