### PR TITLE
ansible_runner: updated new_args.extend to os.path.realpath()

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -493,7 +493,7 @@ class RunnerConfig(object):
             if self.directory_isolation_path is not None:
                 new_args.extend(['--chdir', os.path.realpath(self.directory_isolation_path)])
             else:
-                new_args.extend(['--chdir', self.project_dir])
+                new_args.extend(['--chdir', os.path.realpath(self.project_dir)])
         elif self.execution_mode == ExecutionMode.ANSIBLE:
             # ad-hoc runs should cwd to the root of the private data dir
             new_args.extend(['--chdir', os.path.realpath(self.private_data_dir)])


### PR DESCRIPTION
Updated `new_args.extend()` to use `os.path.realpath(self.project_dir)`.
This remedies issues in AWX when the playbook is referenced via symlink and job isolation is enabled (i.e. `bubblewrap`).