### PR TITLE
always forcibly close the pexpect pty

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -180,10 +180,11 @@ class Runner(object):
             child.logfile_read = stdout_handle
         except pexpect.exceptions.ExceptionPexpect as e:
             child = collections.namedtuple(
-                'MissingProcess', 'exitstatus isalive'
+                'MissingProcess', 'exitstatus isalive close'
             )(
                 exitstatus=127,
-                isalive=lambda: False
+                isalive=lambda: False,
+                close=lambda: None,
             )
 
             def _decode(x):
@@ -226,6 +227,7 @@ class Runner(object):
 
         stdout_handle.flush()
         stdout_handle.close()
+        child.close()
 
         if self.canceled:
             self.status_callback('canceled')


### PR DESCRIPTION
@matburt I think this might be good practice to prevent potential file descriptor leaks in child processes

see: https://github.com/pexpect/pexpect/issues/103
see: https://github.com/pexpect/pexpect/commit/6bfcc542e5c7d6873e11e9cc593949b0996eb787

https://github.com/pexpect/ptyprocess/blob/master/ptyprocess/ptyprocess.py#L401