### PR TITLE
Change sample directory tree to agree with docs and current codebase

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -37,7 +37,7 @@ Note that not everything is required. Defaults will be used or values will be om
     │   └── ssh_key
     ├── inventory
     │   └── hosts
-    ├── project
+    └── project
         ├── test.yml
         └── roles
             └── testrole

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -38,16 +38,16 @@ Note that not everything is required. Defaults will be used or values will be om
     ├── inventory
     │   └── hosts
     ├── project
-    │   └── test.yml
-    └── roles
-        └── testrole
-            ├── defaults
-            ├── handlers
-            ├── meta
-            ├── README.md
-            ├── tasks
-            ├── tests
-            └── vars
+        ├── test.yml
+        └── roles
+            └── testrole
+                ├── defaults
+                ├── handlers
+                ├── meta
+                ├── README.md
+                ├── tasks
+                ├── tests
+                └── vars
 
 The ``env`` directory
 ---------------------


### PR DESCRIPTION
As described in the section "Project", the "roles" directory needs to be a subdirectory of "project". Creating the tree originally described in "Runner Artifacts Directory Hierarchy" causes the roles directory to be ignored without an explicit use of `--roles`.