### PR TITLE
Remove PID file after killing daemon

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -538,6 +538,7 @@ def main(sys_args=None):
             raise
 
     stderr_path = None
+    context = None
     if args.command != 'run':
         stderr_path = os.path.join(args.private_data_dir, 'daemon.log')
         if not os.path.exists(stderr_path):
@@ -608,7 +609,7 @@ def main(sys_args=None):
         return(1)
 
     if args.command == 'stop':
-        Runner.handle_termination(pid)
+        Runner.handle_termination(pid, pidfile)
         return (0)
 
     elif args.command == 'is-alive':

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -609,7 +609,7 @@ def main(sys_args=None):
         return(1)
 
     if args.command == 'stop':
-        Runner.handle_termination(pid, pidfile)
+        Runner.handle_termination(pid, pidfile=pidfile)
         return (0)
 
     elif args.command == 'is-alive':

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -379,7 +379,7 @@ class Runner(object):
         return all_host_events
 
     @classmethod
-    def handle_termination(self, pid, pidfile=None, is_cancel=True):
+    def handle_termination(cls, pid, pidfile=None, is_cancel=True):
         '''
         Internal method to terminate a subprocess spawned by `pexpect` representing an invocation of runner.
 

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -379,14 +379,16 @@ class Runner(object):
         return all_host_events
 
     @classmethod
-    def handle_termination(cls, pid, is_cancel=True):
+    def handle_termination(self, pid, pidfile, is_cancel=True):
         '''
         Internal method to terminate a subprocess spawned by `pexpect` representing an invocation of runner.
 
         :param pid:       the process id of the running the job.
+        :param pidfile:   the daemon's PID file
         :param is_cancel: flag showing whether this termination is caused by
                           instance's cancel_flag.
         '''
+
         try:
             main_proc = psutil.Process(pid=pid)
             child_procs = main_proc.children(recursive=True)
@@ -396,6 +398,7 @@ class Runner(object):
                 except (TypeError, OSError):
                     pass
             os.kill(main_proc.pid, signal.SIGKILL)
+            os.remove(pidfile)
         except (TypeError, psutil.Error, OSError):
             try:
                 os.kill(pid, signal.SIGKILL)

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -379,7 +379,7 @@ class Runner(object):
         return all_host_events
 
     @classmethod
-    def handle_termination(self, pid, pidfile, is_cancel=True):
+    def handle_termination(self, pid, pidfile=None, is_cancel=True):
         '''
         Internal method to terminate a subprocess spawned by `pexpect` representing an invocation of runner.
 
@@ -398,7 +398,10 @@ class Runner(object):
                 except (TypeError, OSError):
                     pass
             os.kill(main_proc.pid, signal.SIGKILL)
-            os.remove(pidfile)
+            try:
+                os.remove(pidfile)
+            except (OSError):
+                pass
         except (TypeError, psutil.Error, OSError):
             try:
                 os.kill(pid, signal.SIGKILL)


### PR DESCRIPTION
Leaving the PID file in the directory prevents the creation of a new daemon context. This removes the file, allowing a new context to be created.