### PR TITLE
Make sleep duration in temp file clearing stage of run configurable

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -336,6 +336,13 @@ def main(sys_args=None):
              "ansible-playbook output (default=None)"
     )
 
+    runner_group.add_argument(
+        "--delete-sleep",
+        default=1,
+        type=float,
+        help="Seconds to wait between attempts to remove temporary files (default=1)"
+    )
+
     # ansible options
 
     ansible_group = parser.add_argument_group(
@@ -568,6 +575,7 @@ def main(sys_args=None):
                                    json_mode=args.json,
                                    omit_event_data=args.omit_event_data,
                                    only_failed_event_data=args.only_failed_event_data,
+                                   delete_sleep=args.delete_sleep,
                                    inventory=args.inventory,
                                    forks=args.forks,
                                    project_dir=args.project_dir,

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -132,6 +132,7 @@ def run(**kwargs):
     :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
     :param only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
+    :param delete_sleep: Seconds to wait between attempts to remove temporary files
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -171,6 +172,7 @@ def run(**kwargs):
     :type fact_cache_type: str
     :type omit_event_data: bool
     :type only_failed_event_data: bool
+    :type delete_sleep: float
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object
     '''

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -250,18 +250,18 @@ class Runner(object):
         if self.config.directory_isolation_path and self.config.directory_isolation_cleanup:
             shutil.rmtree(self.config.directory_isolation_path)
         if self.config.process_isolation and self.config.process_isolation_path_actual:
-            def _delete(retries=15):
+            def _delete(retries=15, delete_sleep=1):
                 try:
                     shutil.rmtree(self.config.process_isolation_path_actual)
                 except OSError as e:
                     res = False
                     if e.errno == 16 and retries > 0:
-                        time.sleep(1)
-                        res = _delete(retries=retries - 1)
+                        time.sleep(delete_sleep)
+                        res = _delete(retries=retries - 1, delete_sleep=delete_sleep)
                     if not res:
                         raise
                 return True
-            _delete()
+            _delete(delete_sleep=self.config.delete_sleep)
         if self.config.resource_profiling:
             cmd = 'cgdelete -g cpuacct,memory,pids:{}'.format(cgroup_path)
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -83,7 +83,7 @@ class RunnerConfig(object):
                  resource_profiling_results_dir=None,
                  tags=None, skip_tags=None, fact_cache_type='jsonfile', fact_cache=None,
                  project_dir=None, directory_isolation_base_path=None, envvars=None, forks=None, cmdline=None, omit_event_data=False,
-                 only_failed_event_data=False):
+                 only_failed_event_data=False, delete_sleep=1):
         self.private_data_dir = os.path.abspath(private_data_dir)
         self.ident = str(ident)
         self.json_mode = json_mode
@@ -140,6 +140,7 @@ class RunnerConfig(object):
         self.cmdline_args = cmdline
         self.omit_event_data = omit_event_data
         self.only_failed_event_data = only_failed_event_data
+        self.delete_sleep = delete_sleep
 
     def prepare(self):
         """


### PR DESCRIPTION
This makes it possible to adjust for systems where deletion takes more resources. Should resolve #366, though per the linked conversation I'm unsure if this actually solves the commenter's problem.