### PR TITLE
Set version to be the short commit hash when building from repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ifeq ($(OFFICIAL),yes)
     RELEASE ?= 1
 else
     ifeq ($(origin RELEASE), undefined)
+        VERSION = $(shell git describe --tags)
         RELEASE := 0.git$(shell date -u +%Y%m%d%H).$(shell git rev-parse --short HEAD)
     endif
 endif

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.md', 'r') as f:
 
 def version(default):
     try:
-        process = subprocess.check_output(['git', 'describe', '--tags'], text=True)
+        process = subprocess.check_output(['git', 'describe', '--tags'], universal_newlines=True)
         commit = re.match(r'([\d\.]+)[\d-]*([a-g0-9-]*)', process)
         if commit:
             if len(commit.group(2)) > 0:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def version(default):
                 return commit.group(1)
         else:
             return default
-    except (SystemError, OSError):
+    except (Exception):
         return default
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,26 @@
 
 # Copyright (c) 2018 Red Hat, Inc.
 # All Rights Reserved.
+import re, subprocess
 
 from setuptools import setup, find_packages
 
 with open('README.md', 'r') as f:
     long_description = f.read()
+
+
+def version(default):
+    try:
+        process = subprocess.check_output(['git', 'describe', '--tags'], text=True)
+        commit = re.match(r'([\d\.]+)[\d-]*([a-g0-9-]*)', process)
+        if commit:
+            if len(commit.group(2)) > 0:
+                return commit.group(2)[1:]
+            else:
+                return commit.group(1)
+        else: return default
+    except:
+        return default
 
 setup(
     name="ansible-runner",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 
 # Copyright (c) 2018 Red Hat, Inc.
 # All Rights Reserved.
-import re, subprocess
+import re
+import subprocess
 
 from setuptools import setup, find_packages
 
@@ -19,9 +20,11 @@ def version(default):
                 return commit.group(2)[1:]
             else:
                 return commit.group(1)
-        else: return default
-    except:
+        else:
+            return default
+    except (SystemError, OSError):
         return default
+
 
 setup(
     name="ansible-runner",


### PR DESCRIPTION
Default version is still hardcoded. Creates a warning as the hashes aren't valid versions. Returns default when building from outside the repo folder, but the setup.py script doesn't work from outside the folder either.

Should resolve #253 if the setuptools.dist warning doesn't cause problems.