### PR TITLE
Prepare for centos-8 testing

### DIFF
--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+# NOTE(pabelanger): Default to pip3, when possible this is becaue python2
+# support is EOL.
+PIP=$(command -v pip3) || PIP=$(command -v pip2)
+
 # NOTE(pabelanger): Tox on centos-7 is old, so upgrade it across all distros
 # to the latest version
 # NOTE(pabelanger): Cap zipp<0.6.0 due to python2.7 issue with more-iterrtools
 # https://github.com/jaraco/zipp/issues/14
-sudo pip install -U tox "zipp<0.6.0"
+sudo $PIP install -U tox "zipp<0.6.0"


### PR DESCRIPTION
Because centos-8 images don't have python2 by default, and since python2
is EOL in less then a month, use pip3 when possible.  This should mean,
only centos-7 will continue to use pip2, and fedora / centos-8 python3.

Depends-On: https://github.com/ansible/ansible-runner/pull/388
Signed-off-by: Paul Belanger <pabelanger@redhat.com>