### PR TITLE
Switch python36 testing to centos-8

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -5,3 +5,4 @@ gcc-c++ [test platform:rpm]
 python3-devel [test !platform:centos-7 platform:rpm]
 python3 [test !platform:centos-7 platform:rpm]
 python36 [test !platform:centos-7 !platform:fedora-28]
+


### PR DESCRIPTION
This moves away from using fedora-30 for testing of python36. This means
less chrun on nodes, and centos-8 is supported much longer then
fedora-30.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/231
Signed-off-by: Paul Belanger <pabelanger@redhat.com>