### PR TITLE
Correctly silence warnings, make tests more robust

### DIFF
--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -21,7 +21,12 @@ def executor(tmpdir, request):
     playbooks = request.node.callspec.params.get('playbook')
     playbook = list(playbooks.values())[0]
     envvars = request.node.callspec.params.get('envvars')
-    envvars = envvars.update({"ANSIBLE_DEPRECATION_WARNINGS": "False"}) if envvars is not None else {"ANSIBLE_DEPRECATION_WARNINGS": "False"}
+    if envvars is None:
+        envvars = {}
+    # warning messages create verbose events and interfere with assertions
+    envvars["ANSIBLE_DEPRECATION_WARNINGS"] = "False"
+    # python interpreter used is not of much interest, we really want to silence warnings
+    envvars['ANSIBLE_PYTHON_INTERPRETER'] = 'auto_silent'
 
     r = init_runner(
         private_data_dir=private_data_dir,


### PR DESCRIPTION
I've had a problem running tests locally on my Mac, in that I get this:

```
================================================================================ test session starts ================================================================================
platform darwin -- Python 3.6.5, pytest-5.3.2, py-1.8.0, pluggy-0.12.0
rootdir: /Users/alancoding/Documents/repos/ansible-runner
collected 171 items                                                                                                                                                                 

test/integration/test___main__.py ...........                                                                                                                                 [  6%]
test/integration/test_display_callback.py ...........................F..^C

===================================================================================== FAILURES ======================================================================================
__________________________________________________________________ test_callback_plugin_task_args_leak[playbook0] ___________________________________________________________________

executor = <ansible_runner.runner.Runner object at 0x102b0da58>
playbook = {'no_log_on_ok.yml': '\n- name: args should not be logged when no_log is set at the task or module level\n  connection...echo "PRIVATE"\n      no_log: true\n    - uri: url=https://example.org url_username="PUBLIC" url_password="PRIVATE"\n'}

    @pytest.mark.parametrize('playbook', [
    {'no_log_on_ok.yml': '''
    - name: args should not be logged when no_log is set at the task or module level
      connection: local
      hosts: all
      gather_facts: no
      tasks:
        - shell: echo "PUBLIC"
        - shell: echo "PRIVATE"
          no_log: true
        - uri: url=https://example.org url_username="PUBLIC" url_password="PRIVATE"
    '''},  # noqa
    ])
    def test_callback_plugin_task_args_leak(executor, playbook):
        executor.run()
        events = list(executor.events)
        assert events[0]['event'] == 'playbook_on_start'
        assert events[1]['event'] == 'playbook_on_play_start'
    
        # task 1
        assert events[2]['event'] == 'playbook_on_task_start'
        assert events[3]['event'] == 'runner_on_start'
>       assert events[4]['event'] == 'runner_on_ok'
E       AssertionError: assert 'verbose' == 'runner_on_ok'
E         - verbose
E         + runner_on_ok

test/integration/test_display_callback.py:182: AssertionError
------------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------------
 ___________________________________________________________ 
/ PLAY [args should not be logged when no_log is set at the \
\ task or module level]                                     /
 ----------------------------------------------------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

 ______________ 
< TASK [shell] >
 -------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

[WARNING]: Platform darwin on host localhost is using the discovered Python
interpreter at /usr/bin/python, but future installation of another Python
interpreter could change this. See https://docs.ansible.com/ansible/devel/refer
ence_appendices/interpreter_discovery.html for more information.

changed: [localhost]
 ______________ 
< TASK [shell] >
 -------------- 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

changed: [localhost]
 ____________ 
< TASK [uri] >
 ------------ 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

ok: [localhost]
localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
 ____________ 
< PLAY RECAP >
 ------------ 
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

================================================================================= warnings summary ==================================================================================
/Users/alancoding/.virtualenvs/runner/lib/python3.6/site-packages/_pytest/mark/structures.py:327
  /Users/alancoding/.virtualenvs/runner/lib/python3.6/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
/Users/alancoding/.virtualenvs/runner/lib/python3.6/site-packages/pexpect/utils.py:173: KeyboardInterrupt
(to show a full traceback on KeyboardInterrupt use --full-trace)
===================================================================== 1 failed, 40 passed, 1 warning in 59.36s ======================================================================
```

More or less, I don't care if the interpreter is wrong or not. I don't ever ever ever want it to issue that warning during these tests. This adds a setting so that, whatever it does, it doesn't warn me.

Secondly, I think there was a non-consequential bug introduced in https://github.com/ansible/ansible-runner/pull/327/files, where `envvars.update({"ANSIBLE_DEPRECATION_WARNINGS": "False"})` is an in-place operation. So yes, it does update the `envvars` dict. But after it updates it, it assigns the return value of the `.update` operation (`None`) to `envvars`.

Clearly, that bug isn't a problem if no warnings are being issued. But I really don't want it to issue warnings, even if they appear in the future.