### PR TITLE
Set created time for verbose events

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -65,6 +65,11 @@ class Runner(object):
                         os.remove(partial_filename)
                 except IOError:
                     debug("Failed to open ansible stdout callback plugin partial data file {}".format(partial_filename))
+
+                # prefer 'created' from partial data, but verbose events set time here
+                if 'created' not in event_data:
+                    event_data['created'] = datetime.datetime.utcnow().isoformat()
+
                 if self.event_handler is not None:
                     should_write = self.event_handler(event_data)
                 else:


### PR DESCRIPTION
in AWX, there is a gap between the time when an event is produced by the `ansible` or `ansible-playbook` process and the time this event is saved to the database. I would like to be able to reliably obtain this time delta from historical data in the database. Currently, however, many events have `created` and `modified` fields identically equal. In these cases, no measurement of production time is ever taken or recorded.

This adds the field for the case where the callback receiver does not add it. Obviously this is the case for verbose events, because the code path in the callback receiver is never touched.

I believe that these types of events could have (previously) had a created/modified delta, but only due to updating fields after the initial insert, which are operations that were recently removed.