### PR TITLE
Add boto to Docker image so we can run against AWS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD demo/inventory /runner/inventory
 RUN yum-config-manager --add-repo https://releases.ansible.com/ansible-runner/ansible-runner.el7.repo && \
 	yum install -y epel-release && \
 	yum install -y python-pip ansible-runner bubblewrap sudo rsync openssh-clients sshpass && \
-	pip install --no-cache-dir ansible && \
+	pip install --no-cache-dir ansible boto botocore boto3 && \
 	localedef -c -i en_US -f UTF-8 en_US.UTF-8 && \
 	chmod +x /bin/tini /bin/entrypoint && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Hey there, submitting a PR for adding boto library to the docker image which is necessary to run against AWS. There are more details in this issue: https://github.com/ansible/ansible/issues/15019