### PR TITLE
RPM: Ensure python-ansible-runner upgrade along side ansible-runner

### DIFF
--- a/packaging/rpm/ansible-runner.spec.j2
+++ b/packaging/rpm/ansible-runner.spec.j2
@@ -23,13 +23,13 @@ BuildArch:      noarch
 %if %{with python2}
 BuildRequires: python-rpm-macros
 BuildRequires: python2-setuptools
-Requires:      python2-%{pypi_name}
+Requires:      python2-%{pypi_name}={{ version }}-{{ release }}
 %endif
 
 %if %{with python3}
 BuildRequires: python3
 BuildRequires: python3-setuptools
-Requires:      python3-%{pypi_name}
+Requires:      python3-%{pypi_name}={{ version }}-{{ release }}
 %endif
 
 %description
@@ -127,6 +127,9 @@ ln -s %{_bindir}/ansible-runner-%{python2_version} %{buildroot}/%{_bindir}/ansib
 %endif
 
 %changelog
+* Tue Feb 25 2020 Yanis Guenane <yguenane@redhat.com> - 1.4.4-2
+- Ansible Runner 1.4.4-2
+
 * Fri Oct 25 2019 Matthew Jones <matburt@redhat.com> - 1.4.4-1
 - Ansible Runner 1.4.4-1
 


### PR DESCRIPTION
When upgrading the ansible-runner package, the subpackage is not updated
accordingly leading to no change actually happening on the machine.

ansible-runner is a metapackage. The bits live in the
python-ansible-runner package. This package if already installed will
not be picked up during metapackage upgrade. This commit fixes that.