### PR TITLE
Increase job_timeout in tests

### DIFF
--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -27,7 +27,7 @@ def rc(request, tmpdir):
     }
     rc.cwd = str(tmpdir)
     rc.env = {}
-    rc.job_timeout = .1
+    rc.job_timeout = .5
     rc.idle_timeout = 0
     rc.pexpect_timeout = .1
     rc.pexpect_use_poll = True


### PR DESCRIPTION
Not sure why, but a single python27 test started failing because of this.