### PR TITLE
fix: extra_vars type in RunnerConfig

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -396,12 +396,16 @@ class RunnerConfig(object):
 
         if self.extra_vars:
             if isinstance(self.extra_vars, dict) and self.extra_vars:
+                extra_vars_list = []
+                for k in self.extra_vars:
+                    if isinstance(self.extra_vars[k], str):
+                        extra_vars_list.append("\"{}\":\"{}\"".format(k, self.extra_vars[k]))
+                    else:
+                        extra_vars_list.append("\"{}\":{}".format(k, self.extra_vars[k]))
                 exec_list.extend(
                     [
                         '-e',
-                        '%s' % ' '.join(
-                            ["{}=\"{}\"".format(k, self.extra_vars[k]) for k in self.extra_vars]
-                        )
+                        '{%s}' % ','.join(extra_vars_list)
                     ]
                 )
             elif self.loader.isfile(self.extra_vars):

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -212,11 +212,11 @@ def test_generate_ansible_command():
 
     rc.extra_vars = dict(test="key")
     cmd = rc.generate_ansible_command()
-    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', 'test="key"', 'main.yaml']
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '{"test":"key"}', 'main.yaml']
 
     with patch.object(rc.loader, 'isfile', side_effect=lambda x: True):
         cmd = rc.generate_ansible_command()
-        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', 'test="key"', 'main.yaml']
+        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '{"test":"key"}', 'main.yaml']
         rc.extra_vars = '/tmp/extravars.yml'
         cmd = rc.generate_ansible_command()
         assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '@/tmp/extravars.yml', 'main.yaml']
@@ -279,7 +279,7 @@ def test_generate_ansible_command_with_api_extravars():
         rc.prepare_inventory()
 
     cmd = rc.generate_ansible_command()
-    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', 'foo="bar"', 'main.yaml']
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '{"foo":"bar"}', 'main.yaml']
 
 
 @pytest.mark.parametrize('cmdline,tokens', [


### PR DESCRIPTION
There was issue with extra_vars that they were passing only string values.
This fix will allow return lists and booleans etc.