### PR TITLE
fix: move creating logic of job_events folder to run

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -46,9 +46,6 @@ class Runner(object):
         later use
         '''
         self.last_stdout_update = time.time()
-        job_events_path = os.path.join(self.config.artifact_dir, 'job_events')
-        if not os.path.exists(job_events_path):
-            os.mkdir(job_events_path, 0o700)
         if 'uuid' in event_data:
             filename = '{}-partial.json'.format(event_data['uuid'])
             partial_filename = os.path.join(self.config.artifact_dir,
@@ -106,6 +103,10 @@ class Runner(object):
             else:
                 raise
         os.close(os.open(stdout_filename, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
+
+        job_events_path = os.path.join(self.config.artifact_dir, 'job_events')
+        if not os.path.exists(job_events_path):
+            os.mkdir(job_events_path, 0o700)
 
         if six.PY2:
             command = [a.decode('utf-8') for a in self.config.command]


### PR DESCRIPTION
Hi,
we found an issue when trying to read events right after the playbook is executed it failed because could not find the job_events folder.

It failed on this line https://github.com/ansible/ansible-runner-service/blob/master/runner_service/services/jobs.py#L181
Error:
```
Mar 10 12:15:39 user gunicorn-3[30567]:     _events = os.listdir(event_dir)
Mar 10 12:15:39 user gunicorn-3[30567]: FileNotFoundError: [Errno 2] No such file or directory: '/home/user/ovirt-engine-master/share/ovirt-engine/ansible-runner-service-project/artifacts/175b5662-62b8-11ea-af39-144f8a9f8bed/job_events'
```
