### PR TITLE
Include common python requirements in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ADD https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo /etc/yum
 RUN dnf install -y epel-release && \
     dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en && \
     alternatives --set python /usr/bin/python3 && \
-    pip3 install ansible && \
+    pip3 install --no-cache-dir ansible netaddr pywinrm requests && \
     chmod +x /bin/tini /bin/entrypoint && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
It's a really common thing to require additional python packages to
perform filters and some simple tests that normally run on the host.

Closes: #427