### PR TITLE
Silence new Ansible devel warning

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_env_user(monkeypatch):
+    monkeypatch.setenv("ANSIBLE_DEVEL_WARNING", "False")


### PR DESCRIPTION
https://github.com/ansible/ansible/blob/devel/lib/ansible/config/base.yml#L1234

This is a new thing, tests fail with Ansible `devel`, and we do not want them to fail.