### PR TITLE
Packaging: Add Requires python3 six

### DIFF
--- a/packaging/rpm/ansible-runner.spec.j2
+++ b/packaging/rpm/ansible-runner.spec.j2
@@ -64,6 +64,7 @@ Summary:        %{summary}
 Requires:       python3-pyyaml
 Requires:       python3-setuptools
 Requires:       python3-daemon
+Requires:       python3-six
 Requires:       python3dist(pexpect) >= 4.6
 Requires:       python3dist(psutil)
 Requires:       python3dist(lockfile)


### PR DESCRIPTION
`six` is a dependency of Ansible Runner. It is properly installed on EL7 systems as a dependency but not on EL8 systems

```
[root@ff94b3170bca yum.repos.d]# ansible-runner --version                                                                                                                                      
Traceback (most recent call last):                                                                                                                                                             
  File "/usr/bin/ansible-runner", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3095, in <module>
    @_call_aside
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3079, in _call_aside
    f(*args, **kwargs)                                                                                                                                                                         
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3108, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 570, in _build_master 
    ws.require(__requires__)
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 888, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.6/site-packages/pkg_resources/__init__.py", line 774, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'six' distribution was not found and is required by ansible-runner
[root@ff94b3170bca yum.repos.d]# yum install python3-six
[...]
[root@ff94b3170bca yum.repos.d]# ansible-runner --version
1.4.5
[root@ff94b3170bca yum.repos.d]# cat /etc/redhat-release 
CentOS Linux release 8.1.1911 (Core) 
```
