### PR TITLE
fix a bug that breaks the callback plugin in older versions of ansible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+1.4.6 (2020-03-26)
+++++++++++++++++++
+- Fixed a bug that broke Ansible playbook execution prior to version 2.8 of
+  Ansible.
+
 1.4.5 (2020-03-19)
 ++++++++++++++++++
 - Fix an issue with --process_isoloation_*_ paths parsing cli args

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ author = 'Red Hat Ansible'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '1.4.5'
+release = '1.4.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/packaging/rpm/ansible-runner.spec.j2
+++ b/packaging/rpm/ansible-runner.spec.j2
@@ -128,6 +128,9 @@ ln -s %{_bindir}/ansible-runner-%{python2_version} %{buildroot}/%{_bindir}/ansib
 %endif
 
 %changelog
+* Thu Mar 19 2020 Ryan Petrello <rpetrell@redhat.com> - 1.4.6-1
+- Ansible Runner 1.4.6-1
+
 * Thu Mar 19 2020 Matthew Jones <matburt@redhat.com> - 1.4.5-1
 - Ansible Runner 1.4.5-1
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name="ansible-runner",
-    version="1.4.5",
+    version="1.4.6",
     author='Red Hat Ansible',
     url="https://github.com/ansible/ansible-runner",
     license='Apache',

--- a/tools/test-setup.sh
+++ b/tools/test-setup.sh
@@ -8,4 +8,4 @@ PIP=$(command -v pip3) || PIP=$(command -v pip2)
 # to the latest version
 # NOTE(pabelanger): Cap zipp<0.6.0 due to python2.7 issue with more-iterrtools
 # https://github.com/jaraco/zipp/issues/14
-sudo $PIP install -U tox "zipp<0.6.0;python_version=='2.7'"
+sudo $PIP install -U tox "configparser<5" "zipp<0.6.0;python_version=='2.7'"


### PR DESCRIPTION
tracking start/end times accurately relies on v2_runner_on_start, which
was introduced in Ansible 2.8 (and doesn't exist in older versions of
Ansible)

see: https://github.com/ansible/ansible-runner/issues/435