### PR TITLE
Serialize python objects before adding them to extra_vars_list

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import json
 import logging
 import os
 import pexpect
@@ -398,10 +399,8 @@ class RunnerConfig(object):
             if isinstance(self.extra_vars, dict) and self.extra_vars:
                 extra_vars_list = []
                 for k in self.extra_vars:
-                    if isinstance(self.extra_vars[k], str):
-                        extra_vars_list.append("\"{}\":\"{}\"".format(k, self.extra_vars[k]))
-                    else:
-                        extra_vars_list.append("\"{}\":{}".format(k, self.extra_vars[k]))
+                    extra_vars_list.append("\"{}\":{}".format(k, json.dumps(self.extra_vars[k])))
+
                 exec_list.extend(
                     [
                         '-e',

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -282,6 +282,16 @@ def test_generate_ansible_command_with_api_extravars():
     assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '{"foo":"bar"}', 'main.yaml']
 
 
+def test_generate_ansible_command_with_dict_extravars():
+    rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo":"test \n hello"})
+    with patch('os.path.exists') as path_exists:
+        path_exists.return_value=True
+        rc.prepare_inventory()
+
+    cmd = rc.generate_ansible_command()
+    assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '{"foo":"test \\n hello"}', 'main.yaml']
+
+
 @pytest.mark.parametrize('cmdline,tokens', [
     (u'--tags foo --skip-tags', ['--tags', 'foo', '--skip-tags']),
     (u'--limit "䉪ቒ칸ⱷ?噂폄蔆㪗輥"', ['--limit', '䉪ቒ칸ⱷ?噂폄蔆㪗輥']),


### PR DESCRIPTION
This would ensure that any python type is handled properly.
Without that dictionaries with multiline strings end up in
incorrect format.