### PR TITLE
Bump to 1.4.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@
 Changelog
 ---------
 
+1.4.7 (2020-05-04)
+++++++++++++++++++
+- Fix an issue with extra_vars serialization
+
 1.4.6 (2020-03-26)
 ++++++++++++++++++
 - Fixed a bug that broke Ansible playbook execution prior to version 2.8 of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ author = 'Red Hat Ansible'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '1.4.6'
+release = '1.4.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/packaging/rpm/python-ansible-runner.spec.j2
+++ b/packaging/rpm/python-ansible-runner.spec.j2
@@ -10,7 +10,7 @@
 %bcond_with    python3
 %endif
 
-Name:           %{pypi_name}
+Name:           python-%{pypi_name}
 Version:        {{ version }}
 Release:        {{ release }}%{?dist}
 Summary:        A tool and python library to interface with Ansible
@@ -128,6 +128,9 @@ ln -s %{_bindir}/ansible-runner-%{python2_version} %{buildroot}/%{_bindir}/ansib
 %endif
 
 %changelog
+* Mon May 04 2020 Rabi Mishra <ramishra@redhat.com> - 1.4.7-1
+- Ansible Runner 1.4.7-1
+
 * Thu Mar 19 2020 Ryan Petrello <rpetrell@redhat.com> - 1.4.6-1
 - Ansible Runner 1.4.6-1
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name="ansible-runner",
-    version="1.4.6",
+    version="1.4.7",
     author='Red Hat Ansible',
     url="https://github.com/ansible/ansible-runner",
     license='Apache',


### PR DESCRIPTION
- Includes fix to serialize extra_vars.

Also chages the rpm package name to python-ansible-runner to avoid
NVR mismatches.