### PR TITLE
Add config for pre-commit framework (see http://pre-commit.com)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+      - id: flake8


### PR DESCRIPTION
This allows easy setup of flake8 as a local pre-commit check by pip installing pre-commit and then running `pre-commit install` to add the git hook.