### PR TITLE
doc: event_handler callback should return a value

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -115,7 +115,7 @@ def run(**kwargs):
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
-    :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself
+    :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
     :param cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
     :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
     :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -75,7 +75,7 @@ handle containing the ``stdout`` of the **Ansible** process.
 ------------------------
 
 A function passed to `__init__` of :class:`Runner <ansible_runner.runner.Runner>`, this is invoked every time an Ansible event is received. You can use this to
-inspect/process/handle events as they come out of Ansible.
+inspect/process/handle events as they come out of Ansible. This function should return `True` to keep the event, otherwise it will be discarded.
 
 ``Runner.cancel_callback``
 --------------------------


### PR DESCRIPTION
I set an `event_handler`, and found that `Runner.stats` and `Runner.events` were empty. I thought it was a bug until I checked the code I discovered the handler needs to return `True`:
https://github.com/ansible/ansible-runner/blob/26a06567df037889f15e4b2eaa29919c6637986f/ansible_runner/runner.py#L68-L71

This updates the doc to mention that.