### PR TITLE
devel is future 2.x

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ author = 'Red Hat Ansible'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '1.4.6'
+release = '2.0.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name="ansible-runner",
-    version="1.4.6",
+    version="2.0.0",
     author='Red Hat Ansible',
     url="https://github.com/ansible/ansible-runner",
     license='Apache',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linters, py27, py3
+envlist = linters, py3
 isolated_build = true
 
 [tox:.package]
@@ -28,9 +28,6 @@ commands=
     poetry run yamllint --version
     poetry run yamllint -s .
 
-[testenv:py27]
-commands =
-    {[testenv]commands}
 [testenv:py3]
 commands =
     {[testenv]commands}


### PR DESCRIPTION
1.x is now living on a stable branch

There are some other places like release notes that we will have to update at release time, but for now this will at least make devel report as a different version than 1.4.6