### PR TITLE
Clear test flake (test_password_prompt)

### DIFF
--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -15,6 +15,7 @@ from ansible_runner import Runner
 from ansible_runner.exceptions import AnsibleRunnerException
 
 
+@pytest.mark.serial
 def test_password_prompt(rc):
     rc.command = [sys.executable, '-c' 'import time; print(input("Password: "))']
     rc.expect_passwords[re.compile(r'Password:\s*?$', re.M)] = '1234'


### PR DESCRIPTION
Tests are currently failing with:

```
=================================== FAILURES ===================================
_____________________________ test_password_prompt _____________________________
[gw0] linux -- Python 3.7.7 /home/zuul/src/github.com/ansible/ansible-runner/.tox/py37/bin/python3

rc = <ansible_runner.runner_config.RunnerConfig object at 0x7fbb078bf5d0>

    def test_password_prompt(rc):
        rc.command = [sys.executable, '-c' 'import time; print(input("Password: "))']
        rc.expect_passwords[re.compile(r'Password:\s*?$', re.M)] = '1234'
        status, exitcode = Runner(config=rc).run()
        assert status == 'successful'
        assert exitcode == 0
        with open(os.path.join(rc.artifact_dir, 'stdout')) as f:
>           assert '1234' in f.read()
E           AssertionError: assert '1234' in 'Password: '
E            +  where 'Password: ' = <built-in method read of _io.TextIOWrapper object at 0x7fbb076bb4b0>()
E            +    where <built-in method read of _io.TextIOWrapper object at 0x7fbb076bb4b0> = <_io.TextIOWrapper name='/tmp/pytest-of-zuul/pytest-0/popen-gw0/test_password_prompt0/artifacts/8ca9f3a1-b953-4da3-8394-7d349018037a/stdout' mode='r' encoding='UTF-8'>.read

test/integration/test_runner.py:25: AssertionError
============== 1 failed, 166 passed, 1 skipped in 149.69 seconds ===============
ERROR: InvocationError for command /home/zuul/src/github.com/ansible/ansible-runner/.tox/py37/bin/poetry run py.test -v -n 4 -m 'not serial' test (exited with code 1)
py37 finish: run-test  after 172.62 seconds
py37 start: run-test-post 
py37 finish: run-test-post  after 0.00 seconds
___________________________________ summary ____________________________________
ERROR:   py37: commands failed
cleanup /home/zuul/src/github.com/ansible/ansible-runner/.tox/.tmp/package/1/ansible-runner-1.4.6.tar.gz
```

This changes `test_password_prompt` to run serially. Seems like `$artifact_dir/stdout` must be getting stomped on by other tests / noisey neighbors.