### PR TITLE
Do not install Ansible content distribution in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ADD https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo /etc/yum
 RUN dnf install -y epel-release && \
     dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en && \
     alternatives --set python /usr/bin/python3 && \
-    pip3 install ansible && \
+    pip3 install ansible-base && \
     chmod +x /bin/tini /bin/entrypoint && \
     rm -rf /var/cache/dnf
 


### PR DESCRIPTION
I was trying to install collections, and then was like "wait, what are all _these_ collections doing lying around here?"