### PR TITLE
Workaround for issue #474

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -93,7 +93,7 @@ class Runner(object):
         '''
         self.status_callback('starting')
         stdout_filename = os.path.join(self.config.artifact_dir, 'stdout')
-        command_filename = os.path.join(self.config.artifact_dir, 'command')
+        command_filename = os.path.join(self.config.artifact_dir, 'ansible-runner-command')
 
         try:
             os.makedirs(self.config.artifact_dir, mode=0o700)


### PR DESCRIPTION
- current "command" file in artifacts/<uuid> covers ansible module command in case of ansible-runner in venv
- here is ansible configuration:
  config file = /Users/janmalanik/build/vps_manager/project/ansible.cfg
  configured module search path = ['/Users/janmalanik/build/vps_manager']
  ansible python module location = /Users/janmalanik/build/vps_manager/venv/lib/python3.7/site-packages/ansible
- default value for 'configured module search path' cause this problem

Signed-off-by: Malanik Jan <malanik.jan@gmail.com>