### PR TITLE
test_basic_events should run serially

### DIFF
--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -45,6 +45,7 @@ def test_basic_events(is_run_async=False,g_facts=False):
     assert "event_data" in okay_event and len(okay_event['event_data']) > 0
 
 
+@pytest.mark.serial
 def test_async_events():
     test_basic_events(is_run_async=True,g_facts=True)
 


### PR DESCRIPTION
Looks like this might be another test w/ flake because of the move to parallelize test runs with xdist.