### PR TITLE
Add git to Docker image (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD demo/inventory /runner/inventory
 # Install Ansible and Runner
 ADD https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo /etc/yum.repos.d/ansible-runner.repo
 RUN dnf install -y epel-release && \
-    dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en && \
+    dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en git && \
     alternatives --set python /usr/bin/python3 && \
     pip3 install ansible-base && \
     chmod +x /bin/tini /bin/entrypoint && \


### PR DESCRIPTION
This was originally reported in https://github.com/ansible/ansible-runner/issues/232, fixed in https://github.com/ansible/ansible-runner/pull/233, then lost in refactoring (https://github.com/ansible/ansible-runner/commit/56f14a3ee15826147809d219b1090d1017776d06#diff-3254677a7917c6c01f55212f86c57fbf).

As stated in the original issue, ansible-galaxy installs from git sources fail without git.