### PR TITLE
fix test_basic_events

### DIFF
--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -34,9 +34,10 @@ def test_basic_events(containerized, container_runtime_available, is_run_async=F
         thread, r = run_async(**run_args)
         thread.join()  # ensure async run finishes
 
-    event_types = [x['event'] for x in r.events]
+    event_types = [x['event'] for x in r.events if x['event'] != 'verbose']
     okay_events = [x for x in filter(lambda x: 'event' in x and x['event'] == 'runner_on_ok',
                                      r.events)]
+
     assert event_types[0] == 'playbook_on_start'
     assert "playbook_on_play_start" in event_types
     assert "runner_on_ok" in event_types


### PR DESCRIPTION
At the moment, I think we're having a hard time finding a version of ansible that _does not_ include some kind of warning at the head:

* head of devel warns that `You are running the development version of Ansible`
* latest stable release of ansible-base is currently suffering from https://github.com/ansible-collections/community.general/issues/565 which (incorrectly) triggers a deprecation warning

This lets us skip over verbose events so that we can ensure the core events are present.

Confirmed that with this in place test passes. The events that were generated by the test are (in order):

```
"verbose"
"verbose"
"verbose"
"verbose"
"playbook_on_start"
"playbook_on_play_start"
"playbook_on_task_start"
"runner_on_start"
"runner_on_ok"
"playbook_on_stats"
```