### PR TITLE
Add adhoc and playbook subcommands for CLI Exec Env usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,17 @@ RUN chmod +x /bin/entrypoint
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN for dir in \
+      /home/runner \
+      /home/runner/.ansible \
       /runner \
       /home/runner \
       /runner/env \
       /runner/inventory \
       /runner/project \
       /runner/artifacts ; \
-    do mkdir -m 0775 -p $dir ; chmod g+rw $dir ; chgrp runner $dir ; done && \
+    do mkdir -m 0775 -p $dir ; chmod g+rw $dir ; chown -R runner:runner $dir ; done && \
     for file in \
+      /home/runner/.ansible/galaxy_token \
       /etc/passwd ; \
     do touch $file ; chmod g+rw $file ; chgrp runner $file ; done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM docker.io/centos:8
 
 ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /bin/tini
 ADD utils/entrypoint.sh /bin/entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN chmod +x /bin/entrypoint
 # are writeable by the root group.
 RUN for dir in \
       /runner \
+      /home/runner \
       /runner/env \
       /runner/inventory \
       /runner/project \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ADD demo/inventory /runner/inventory
 ADD https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo /etc/yum.repos.d/ansible-runner.repo
 RUN dnf install -y epel-release && \
     dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en git && \
+    alternatives --set python /usr/bin/python3 && \
     pip3 install ansible && \
     chmod +x /bin/tini /bin/entrypoint && \
     rm -rf /var/cache/dnf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM docker.io/centos:8
 
 ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /bin/tini
-ADD utils/entrypoint.sh /bin/entrypoint
 ADD demo/project /runner/project
 ADD demo/env /runner/env
 ADD demo/inventory /runner/inventory
@@ -12,16 +11,26 @@ RUN dnf install -y epel-release && \
     dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en git && \
     alternatives --set python /usr/bin/python3 && \
     pip3 install ansible && \
-    chmod +x /bin/tini /bin/entrypoint && \
+    chmod +x /bin/tini && \
     rm -rf /var/cache/dnf
 
 RUN useradd runner && usermod -aG root runner
 
+ADD utils/entrypoint.sh /bin/entrypoint
+RUN chmod +x /bin/entrypoint
+
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
-RUN mkdir -p /runner/inventory /runner/project /runner/artifacts /runner/.ansible/tmp && \
-	chmod -R g+w /runner && chgrp -R root /runner && \
-	chmod g+w /etc/passwd
+RUN for dir in \
+      /runner \
+      /runner/env \
+      /runner/inventory \
+      /runner/project \
+      /runner/artifacts ; \
+    do mkdir -m 0775 -p $dir ; chmod g+rw $dir ; chgrp runner $dir ; done && \
+    for file in \
+      /etc/passwd ; \
+    do touch $file ; chmod g+rw $file ; chgrp runner $file ; done
 
 VOLUME /runner
 
@@ -29,7 +38,7 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 ENV RUNNER_BASE_COMMAND=ansible-playbook
-ENV HOME=/runner
+ENV HOME=/home/runner
 
 WORKDIR /runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,18 @@ ADD demo/project /runner/project
 ADD demo/env /runner/env
 ADD demo/inventory /runner/inventory
 
+# UNDO Before 2.0 Release:
 # Install Ansible and Runner
-ADD https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo /etc/yum.repos.d/ansible-runner.repo
+#ADD https://releases.ansible.com/ansible-runner/ansible-runner.el8.repo /etc/yum.repos.d/ansible-runner.repo
+#RUN dnf install -y ansible-runner
 RUN dnf install -y epel-release && \
-    dnf install -y ansible-runner python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en git && \
+    dnf install -y python3-pip sudo rsync openssh-clients sshpass glibc-langpack-en git && \
     alternatives --set python /usr/bin/python3 && \
-    pip3 install ansible && \
     chmod +x /bin/tini && \
     rm -rf /var/cache/dnf
+
+RUN dnf install -y gcc python3-devel
+RUN pip3 install https://github.com/ansible/ansible/archive/devel.tar.gz https://github.com/maxamillion/ansible-runner/archive/cli_execenv_rebase.tar.gz
 
 RUN useradd runner && usermod -aG root runner
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ docs:
 	cd docs && make html
 
 image:
-	$(CONTAINER_ENGINE) pull centos:8
+	$(CONTAINER_ENGINE) pull docker.io/centos:8
 	$(CONTAINER_ENGINE) build --rm=true -t $(IMAGE_NAME) .
 
 devimage:

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -626,6 +626,7 @@ def main(sys_args=None):
         dest='command',
         description="COMMAND PRIVATE_DATA_DIR [ARGS]"
     )
+    add_args_to_parser(parser, DEFAULT_CLI_ARGS['generic_args'])
     subparser.required = True
 
 

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -706,7 +706,6 @@ def main(sys_args=None):
     add_args_to_parser(start_runner_group, DEFAULT_CLI_ARGS['receptor_group'])
     add_args_to_parser(stop_runner_group, DEFAULT_CLI_ARGS['receptor_group'])
     add_args_to_parser(isalive_runner_group, DEFAULT_CLI_ARGS['receptor_group'])
-    add_args_to_parser(playbook_runner_group, DEFAULT_CLI_ARGS['receptor_group'])
 
     # mutually exclusive group
     base_mutually_exclusive_group = parser.add_mutually_exclusive_group()

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -431,7 +431,7 @@ DEFAULT_CLI_ARGS = {
             )
         ),
     ),
-    "adhoc_group": (
+    "execenv_cli_group": (
         (
             ('--container-runtime',),
             dict(
@@ -652,7 +652,7 @@ def main(sys_args=None):
              "(project, inventory, env, etc)",
         default='.'
     )
-    add_args_to_parser(adhoc_subparser, DEFAULT_CLI_ARGS['adhoc_group'])
+    add_args_to_parser(adhoc_subparser, DEFAULT_CLI_ARGS['execenv_cli_group'])
 
     # adhoc command exec
     playbook_subparser = subparser.add_parser(
@@ -670,6 +670,7 @@ def main(sys_args=None):
              "(project, inventory, env, etc)",
         default='.'
     )
+    add_args_to_parser(playbook_subparser, DEFAULT_CLI_ARGS['execenv_cli_group'])
 
     # misc args
     add_args_to_parser(run_subparser, DEFAULT_CLI_ARGS['misc_args'])
@@ -796,12 +797,14 @@ def main(sys_args=None):
     stop_container_group = stop_subparser.add_argument_group(*container_group_options)
     isalive_container_group = isalive_subparser.add_argument_group(*container_group_options)
     adhoc_container_group = adhoc_subparser.add_argument_group(*container_group_options)
+    playbook_container_group = playbook_subparser.add_argument_group(*container_group_options)
     add_args_to_parser(base_container_group, DEFAULT_CLI_ARGS['container_group'])
     add_args_to_parser(run_container_group, DEFAULT_CLI_ARGS['container_group'])
     add_args_to_parser(start_container_group, DEFAULT_CLI_ARGS['container_group'])
     add_args_to_parser(stop_container_group, DEFAULT_CLI_ARGS['container_group'])
     add_args_to_parser(isalive_container_group, DEFAULT_CLI_ARGS['container_group'])
     add_args_to_parser(adhoc_container_group, DEFAULT_CLI_ARGS['container_group'])
+    add_args_to_parser(playbook_container_group, DEFAULT_CLI_ARGS['container_group'])
 
     if len(sys.argv) == 1:
         parser.print_usage()

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -319,7 +319,7 @@ DEFAULT_CLI_ARGS = {
                 dest="process_isolation_hide_paths",
                 nargs='*',
                 help="list of paths on the system that should be hidden from the "
-                      "playbook run (default=None)"
+                     "playbook run (default=None)"
             )
         ),
         (
@@ -393,7 +393,8 @@ DEFAULT_CLI_ARGS = {
             ("--resource-profiling-results-dir",),
             dict(
                 dest='resource_profiling_results_dir',
-                help="Directory where profiling data files should be saved. Defaults to None (profiling_data folder under private data dir is used in this case)."
+                help="Directory where profiling data files should be saved. "
+                     "Defaults to None (profiling_data folder under private data dir is used in this case)."
             )
         )
     ),
@@ -421,7 +422,8 @@ DEFAULT_CLI_ARGS = {
             dict(
                 dest="container_volume_mounts",
                 action='append',
-                help="Bind mounts (in the form 'host_dir:/container_dir)'. Can be used more than once to create multiple bind mounts."
+                help="Bind mounts (in the form 'host_dir:/container_dir)'. "
+                     "Can be used more than once to create multiple bind mounts."
             )
         ),
         (
@@ -429,7 +431,8 @@ DEFAULT_CLI_ARGS = {
             dict(
                 dest="container_options",
                 action='append',
-                help="Container options to pass to execution engine. Can be used more than once to send multiple options."
+                help="Container options to pass to execution engine. "
+                     "Can be used more than once to send multiple options."
             )
         ),
     ),
@@ -448,7 +451,8 @@ DEFAULT_CLI_ARGS = {
                 dest='keep_files',
                 action='store_true',
                 default=False,
-                help="Keep temporary files persistent on disk instead of cleaning them automatically. (Useful for debugging)"
+                help="Keep temporary files persistent on disk instead of cleaning them automatically. "
+                     "(Useful for debugging)"
             ),
         ),
     ),
@@ -671,7 +675,7 @@ def main(sys_args=None):
     )
     add_args_to_parser(playbook_subparser, DEFAULT_CLI_ARGS['execenv_cli_group'])
 
-    # generic args for all subparsers 
+    # generic args for all subparsers
     add_args_to_parser(run_subparser, DEFAULT_CLI_ARGS['generic_args'])
     add_args_to_parser(start_subparser, DEFAULT_CLI_ARGS['generic_args'])
     add_args_to_parser(stop_subparser, DEFAULT_CLI_ARGS['generic_args'])
@@ -751,8 +755,8 @@ def main(sys_args=None):
     # modules groups
 
     modules_group_options = (
-            "Ansible Module Options",
-            "configuration options for directly executing Ansible modules",
+        "Ansible Module Options",
+        "configuration options for directly executing Ansible modules",
     )
     base_modules_group = parser.add_argument_group(*modules_group_options)
     run_modules_group = run_subparser.add_argument_group(*modules_group_options)
@@ -814,7 +818,7 @@ def main(sys_args=None):
     vargs = vars(args)
 
     # FIXME - Probably a more elegant way to handle this.
-    # set some state about CLI Exec Env 
+    # set some state about CLI Exec Env
     cli_execenv_cmd = ""
 
     if vargs.get('command') in ('adhoc', 'playbook'):

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -446,7 +446,7 @@ DEFAULT_CLI_ARGS = {
             ('--keep-files',),
             dict(
                 dest='keep_files',
-                type=bool,
+                action='store_true',
                 default=False,
                 help="Keep temporary files persistent on disk instead of cleaning them automatically. (Useful for debugging)"
             ),
@@ -829,15 +829,15 @@ def main(sys_args=None):
     if vargs.get('command') in ('adhoc', 'playbook'):
         cli_execenv_cmd = vargs.get('command')
         if not vargs.get('private_data_dir'):
-            temp_private_dir = tempfile.TemporaryDirectory()
-            vargs['private_data_dir'] = temp_private_dir.name
+            temp_private_dir = tempfile.mkdtemp()
+            vargs['private_data_dir'] = temp_private_dir
             if vargs.get('keep_files', False):
-                print("ANSIBLE-RUNNER: keeping temporary data directory: {}".format(temp_private_dir.name))
+                print("ANSIBLE-RUNNER: keeping temporary data directory: {}".format(temp_private_dir))
 
     @atexit.register
     def conditonally_clean_cli_execenv_tempdir():
         if not vargs.get('keep_files', False):
-            shutil.rmtree(temp_private_dir.name)
+            shutil.rmtree(temp_private_dir)
 
     if vargs.get('command') in ('start', 'run'):
         if vargs.get('hosts') and not (vargs.get('module') or vargs.get('role')):

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -46,7 +46,8 @@ def init_runner(**kwargs):
 
     See parameters given to :py:func:`ansible_runner.interface.run`
     '''
-    dump_artifacts(kwargs)
+    if not kwargs.get('cli_execenv_cmd'):
+        dump_artifacts(kwargs)
 
     debug = kwargs.pop('debug', None)
     logfile = kwargs.pop('logfile', None)
@@ -147,6 +148,7 @@ def run(**kwargs):
     :param via_receptor: If set, specifies a Receptor node-id on which the job will be run remotely
     :param receptor_peer: Specifies the Receptor listener, in URL format, to use to connect to the Receptor network
     :param receptor_node_id: Specifies the node-id to assign to the local Receptor ephemeral node
+    :param cli_execenv_cmd: Tells Ansible Runner to emulate the CLI of Ansible by prepping an Execution Environment and then passing the user provided cmdline
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -192,6 +194,7 @@ def run(**kwargs):
     :type via_receptor: str
     :type receptor_peer: str
     :type receptor_node_id: str
+    :type cli_execenv_cmd: str
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing `rc` if run remotely
     '''

--- a/ansible_runner/loader.py
+++ b/ansible_runner/loader.py
@@ -129,6 +129,7 @@ class ArtifactLoader(object):
         '''
         return os.path.isfile(self.abspath(path))
 
+
     def load_file(self, path, objtype=None, encoding='utf-8'):
         '''
         Load the file specified by path

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -642,9 +642,10 @@ class RunnerConfig(object):
                 # parse everything beyond the first arg because we checked that
                 # in the previous case already
                 for arg in _book_keeping_copy[1:]:
+                    import q; q.q(arg)
                     if arg[0] == '-':
                         continue
-                    elif _book_keeping_copy[_book_keeping_copy.index(arg - 1)][0] != '-':
+                    elif _book_keeping_copy[(_book_keeping_copy.index(arg) - 1)][0] != '-':
                         _playbook = arg
                         break
 

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -624,13 +624,6 @@ class RunnerConfig(object):
                         )
                     ])
 
-            if self.cli_execenv_cmd == 'adhoc':
-                new_args.extend([
-                    "-v", "{}:/runner/project/".format(
-                        os.path.dirname(self.private_data_dir),
-                    )
-                ])
-
             # volume mount inventory into the exec env container if provided at cli
             if '-i' in self.cmdline_args:
                 inventory_file_path = self.cmdline_args[self.cmdline_args.index('-i') + 1]

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -429,6 +429,10 @@ class RunnerConfig(object):
 
         exec_list = [base_command]
 
+        if self.cli_execenv_cmd:
+            # FIXME Add AWX vars
+            pass
+
         try:
             if self.cmdline_args:
                 cmdline_args = self.cmdline_args
@@ -599,6 +603,7 @@ class RunnerConfig(object):
         new_args.extend(["-v", "{}:/runner".format(self.private_data_dir)])
 
         if self.cli_execenv_cmd:
+            # FIXME - need to handle creation of project dir in private_data_dir
             if self.cli_execenv_cmd == 'playbook':
                 # FIXME - this might not be something we can assume
                 # grab the directory relative to the playbook so we capture roles and such
@@ -644,11 +649,8 @@ class RunnerConfig(object):
                             )
                         ])
 
-            # volume mount ~/.ssh/ and ~/.ansible into the exec env container
-            new_args.extend(["-v", "{}/.ssh/:/runner/project/.ssh/".format(os.environ['HOME'])])
-            if not os.path.exists(os.path.join(os.environ['HOME'], '.ansible')):
-                os.mkdir(os.path.join(os.environ['HOME'], '.ansible'))
-            new_args.extend(["-v", "{}/.ansible:/runner/project/.ansible".format(os.environ['HOME'])])
+            # volume mount ~/.ssh/ into the exec env container
+            new_args.extend(["-v", "{}/.ssh/:/runner/.ssh/".format(os.environ['HOME'])])
 
             # volume mount system-wide ssh_known_hosts the exec env container
             if os.path.exists('/etc/ssh/ssh_known_hosts'):

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -698,7 +698,7 @@ class RunnerConfig(object):
                             ])
 
             # volume mount ~/.ssh/ into the exec env container
-            new_args.extend(["-v", "{}/.ssh/:/runner/.ssh/".format(os.environ['HOME'])])
+            new_args.extend(["-v", "{}/.ssh/:/home/runner/.ssh/".format(os.environ['HOME'])])
 
             # volume mount system-wide ssh_known_hosts the exec env container
             if os.path.exists('/etc/ssh/ssh_known_hosts'):

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -642,7 +642,6 @@ class RunnerConfig(object):
                 # parse everything beyond the first arg because we checked that
                 # in the previous case already
                 for arg in _book_keeping_copy[1:]:
-                    import q; q.q(arg)
                     if arg[0] == '-':
                         continue
                     elif _book_keeping_copy[(_book_keeping_copy.index(arg) - 1)][0] != '-':

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -685,15 +685,15 @@ class RunnerConfig(object):
                         if os.path.isabs(inventory_file_path) and (os.path.dirname(inventory_file_path) != '/'):
                             new_args.extend([
                                 "-v", "{}:{}".format(
-                                   os.path.dirname(inventory_file_path),
-                                   os.path.dirname(inventory_file_path),
+                                    os.path.dirname(inventory_file_path),
+                                    os.path.dirname(inventory_file_path),
                                 )
                             ])
                         else:
                             new_args.extend([
                                 "-v", "{}:/runner/project/{}".format(
-                                   os.path.dirname(os.path.abspath(inventory_file_path)),
-                                   os.path.dirname(inventory_file_path),
+                                    os.path.dirname(os.path.abspath(inventory_file_path)),
+                                    os.path.dirname(inventory_file_path),
                                 )
                             ])
 

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -728,7 +728,7 @@ class RunnerConfig(object):
                 _ensure_path_safe_to_mount(host_path)
                 new_args.extend(["-v", "{}:{}".format(host_path, container_path)])
 
-        env_var_whitelist = ['PROJECT_UPDATE_ID', 'ANSIBLE_CALLBACK_PLUGINS', 'ANSIBLE_STDOUT_CALLBACK']
+        env_var_whitelist = ['PROJECT_UPDATE_ID']
 
         for k, v in self.env.items():
             if k in env_var_whitelist:

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -606,6 +606,7 @@ class RunnerConfig(object):
         new_args = [self.process_isolation_executable]
         new_args.extend(['run', '--rm', '--tty', '--interactive'])
         new_args.extend(["--workdir", "/runner/project"])
+        new_args.extend(["-e", "LAUNCHED_BY_RUNNER=1"])
 
         def _ensure_path_safe_to_mount(path):
             if path in ('/home', '/usr'):

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -612,17 +612,24 @@ class RunnerConfig(object):
                 if os.path.isabs(playbook_file_path) and (os.path.dirname(playbook_file_path) != '/'):
                     new_args.extend([
                         "-v", "{}:{}".format(
-                           os.path.dirname(playbook_file_path),
-                           os.path.dirname(playbook_file_path),
+                            os.path.dirname(playbook_file_path),
+                            os.path.dirname(playbook_file_path),
                         )
                     ])
                 else:
                     new_args.extend([
                         "-v", "{}:/runner/project/{}".format(
-                           os.path.dirname(os.path.abspath(playbook_file_path)),
-                           os.path.dirname(playbook_file_path),
+                            os.path.dirname(os.path.abspath(playbook_file_path)),
+                            os.path.dirname(playbook_file_path),
                         )
                     ])
+
+            if self.cli_execenv_cmd == 'adhoc':
+                new_args.extend([
+                    "-v", "{}:/runner/project/".format(
+                        os.path.dirname(self.private_data_dir),
+                    )
+                ])
 
             # volume mount inventory into the exec env container if provided at cli
             if '-i' in self.cmdline_args:
@@ -699,6 +706,7 @@ class RunnerConfig(object):
 
         new_args.extend(args)
         debug(f"container engine invocation: {' '.join(new_args)}")
+
         return new_args
 
     def wrap_args_with_ssh_agent(self, args, ssh_key_path, ssh_auth_sock=None, silence_ssh_add=False):

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -665,7 +665,6 @@ class RunnerConfig(object):
 
             # container namespace stuff 
             new_args.extend(["--userns=keep-id"])
-            new_args.extend(["--pid=host"])
             new_args.extend(["--ipc=host"])
 
         container_volume_mounts = self.container_volume_mounts

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -697,7 +697,7 @@ class RunnerConfig(object):
                             ])
 
             # volume mount ~/.ssh/ into the exec env container
-            new_args.extend(["-v", "{}/.ssh/:/home/runner/.ssh/".format(os.environ['HOME'])])
+            new_args.extend(["-v", "{}/.ssh/:/runner/.ssh/".format(os.environ['HOME'])])
 
             # volume mount system-wide ssh_known_hosts the exec env container
             if os.path.exists('/etc/ssh/ssh_known_hosts'):

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -36,6 +36,9 @@ class Bunch(object):
     def update(self, **kwargs):
         self.__dict__.update(kwargs)
 
+    def get(self, key):
+        return self.__dict__.get(key)
+
 
 def isplaybook(obj):
     '''

--- a/docs/execution_environments.rst
+++ b/docs/execution_environments.rst
@@ -1,0 +1,59 @@
+.. _execution_environments:
+
+Using Runner with Execution Environmnets
+========================================
+
+**Execution Environments** are meant to be a consistent, reproducable, portable,
+and sharable method to run Ansible Automation jobs in the exact same way on
+your laptop as they are executed in `Ansible AWX <https://github.com/ansible/awx/`_. 
+This aids in the development of automation jobs and Ansible Content that is
+meant to be run in **Ansible AWX**, `Ansible Tower <https://www.ansible.com/products/tower>`_,
+or via `Red Hat Ansible Automation Platform <https://www.ansible.com/products/automation-platform>`_
+in a predictable way.
+
+More specifically, the term **Execution Environments** within the context of
+**Ansible Runner** refers to the container runtime execution of **Ansible** via
+**Ansible Runner** within an `OCI Compliant Container Runtime
+<https://github.com/opencontainers/runtime-spec>`_ using an `OCI Compliant
+Container Image <https://github.com/opencontainers/image-spec/>`_ that
+appropriately bundles `Ansible Base <https://github.com/ansible/ansible>`_,
+`Ansible Collection Content <https://github.com/ansible-collections/overview>`_,
+and the runtime dependencies required to support these contents. The base
+image is the `Red Hat Enterprise Linux Universal Base Image
+<https://developers.redhat.com/products/rhel/ubi>`_ and the build tooling
+provided by `Ansible Builder <https://github.com/ansible/ansible-builder>`_
+aids in the creation of these images.
+
+All aspects of running **Ansible Runner** in standalone mode (see: :ref:`standalone`)
+are true here with the exception that the process isolation is inherently a
+container runtime (`podman <https://podman.io/>`_ by default).
+
+Emulating the Ansible CLI
+-------------------------
+
+As previously mentioned, a primary goal of adding the Execution Environment CLI
+interface is to aid in the creation of Ansible Automation jobs and content. The
+approach here is to make it as similar as possible to the way **Ansible** users
+are accustomed to using Ansible today. There are two subcommands, ``adhoc`` and
+``playbook`` that have been added to accomodate this. The ``adhoc`` subcommand 
+to ``ansible-runner`` is synonymous with ``ansible`` and the ``playbook``
+subcommand to ``ansible-runner`` is synonymous with ``ansible-playbook``.
+Examples are below.
+
+Running Ansible adhoc
+^^^^^^^^^^^^^^^^^^^^^
+
+An example invocation using the ``ping`` module and ``localhost`` as target::
+
+  $ ansible-runner adhoc localhost -m ping 
+
+Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using the ``setup`` module. 
+
+Running Ansible ansible-playbook
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An example invocation using the ``demo.yml`` playbook and ``inventory.ini`` inventory file::
+
+  $ ansible-runner playbook demo.yml -i inventory.ini
+
+Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using ``gather_facts: true`` and targeting ``localhost`` in your playbook without explicit host definition in your inventory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ Examples of this could include:
    external_interface
    standalone
    python_interface
+   execution_environments
    container
    receptor
 

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -26,6 +26,8 @@ The different **commands** that runner accepts are:
 * ``start`` starts ``ansible-runner`` as a background daemon process and generates a pid file
 * ``stop`` terminates an ``ansible-runner`` process that was launched in the background with ``start``
 * ``is-alive`` checks the status of an ``ansible-runner`` process that was started in the background with ``start``
+* ``adhoc`` will run ad-hoc ``ansible`` commands inside a containerized Ansible Execution Environment 
+* ``playbook`` will run ``ansible-playbook`` commands inside a containerized Ansible Execution Environment 
 
 While **Runner** is running it creates an ``artifacts`` directory (see :ref:`artifactdir`) regardless of what mode it was started
 in. The resulting output and status from **Ansible** will be located here. You can control the exact location underneath the ``artifacts`` directory
@@ -67,6 +69,24 @@ An example invocation using ``demo`` as private directory and ``localhost`` as t
   $ ansible-runner --role testrole --hosts localhost run demo
 
 Ansible roles directory can be provided with ``--roles-path`` option. Role variables can be passed with ``--role-vars`` at runtime.
+
+Running Ansible adhoc Commands
+------------------------------
+
+An example invocation using the ``ping`` module and ``localhost`` as target::
+
+  $ ansible-runner adhoc localhost -m ping 
+
+Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using the ``setup`` module. 
+
+Running ansible-playbook Commands
+---------------------------------
+
+An example invocation using the ``ping`` module and ``localhost`` as target::
+
+  $ ansible-runner playbook demo.yml
+
+Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using ``gather_facts: true`` and targeting ``localhost`` in your playbook without explicit host definition in your inventory.
 
 .. _outputjson:
 

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -79,6 +79,8 @@ An example invocation using the ``ping`` module and ``localhost`` as target::
 
 Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using the ``setup`` module. 
 
+For more information, see :ref:`execution_environments`
+
 Running Ansible ansible-playbook Commands with Execution Environments
 ---------------------------------------------------------------------
 
@@ -87,6 +89,8 @@ An example invocation using the ``demo.yml`` playbook and ``inventory.ini`` inve
   $ ansible-runner playbook demo.yml -i inventory.ini
 
 Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using ``gather_facts: true`` and targeting ``localhost`` in your playbook without explicit host definition in your inventory.
+
+For more information, see :ref:`execution_environments`
 
 .. _outputjson:
 

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -70,8 +70,8 @@ An example invocation using ``demo`` as private directory and ``localhost`` as t
 
 Ansible roles directory can be provided with ``--roles-path`` option. Role variables can be passed with ``--role-vars`` at runtime.
 
-Running Ansible adhoc Commands
-------------------------------
+Running Ansible adhoc Commands with Execution Environments
+----------------------------------------------------------
 
 An example invocation using the ``ping`` module and ``localhost`` as target::
 
@@ -79,12 +79,12 @@ An example invocation using the ``ping`` module and ``localhost`` as target::
 
 Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using the ``setup`` module. 
 
-Running ansible-playbook Commands
----------------------------------
+Running Ansible ansible-playbook Commands with Execution Environments
+---------------------------------------------------------------------
 
-An example invocation using the ``ping`` module and ``localhost`` as target::
+An example invocation using the ``demo.yml`` playbook and ``inventory.ini`` inventory file::
 
-  $ ansible-runner playbook demo.yml
+  $ ansible-runner playbook demo.yml -i inventory.ini
 
 Something to note here is that implicit ``localhost`` in this context is a containerized instantiation of an Ansible Execution Environment and as such you will not get Ansible Facts about your system if using ``gather_facts: true`` and targeting ``localhost`` in your playbook without explicit host definition in your inventory.
 
@@ -95,7 +95,7 @@ Running with Process Isolation
 
 **Runner** supports process isolation. Process isolation creates a new mount namespace where the root is on a tmpfs that is invisible from the host
 and is automatically cleaned up when the last process exits. You can enable process isolation by providing the ``--process-isolation`` argument on
-the command line. **Runner** defaults to using ``bubblewrap`` as the process isolation executable, but supports
+the command line. **Runner** as of version 2.0 defaults to using ``podman`` as the process isolation executable, but supports
 using any executable that is compatible with the ``bubblewrap`` CLI arguments by passing in the ``--process-isolation-executable`` argument::
 
   $ ansible-runner --process-isolation ...

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -42,7 +42,6 @@ def container_runtime_available():
 @pytest.fixture(scope="session", autouse=True)
 def container_runtime_installed(container_runtime_available):
     import subprocess
-    import warnings
 
     if container_runtime_available:
         for runtime in ('podman', 'docker'):

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -35,3 +35,19 @@ def container_runtime_available():
             warnings.warn(UserWarning(f"{runtime} not available"))
             runtimes_available = False
     return runtimes_available
+
+
+# TODO: determine if we want to add docker / podman
+# to zuul instances in order to run these tests
+@pytest.fixture(scope="session", autouse=True)
+def container_runtime_installed(container_runtime_available):
+    import subprocess
+    import warnings
+
+    if container_runtime_available:
+        for runtime in ('podman', 'docker'):
+            try:
+                subprocess.run([runtime, '-v'])
+                return runtime
+            except FileNotFoundError:
+                pass

--- a/test/integration/containerized/test_cli_containerized.py
+++ b/test/integration/containerized/test_cli_containerized.py
@@ -18,3 +18,31 @@ def test_playbook_run(cli, container_runtime_available):
     if not container_runtime_available:
         pytest.skip('container runtime(s) not available')
     cli(['run', os.path.join(HERE,'priv_data'), '-p', 'test-container.yml'])
+
+
+@pytest.mark.serial
+def test_adhoc_localhost_setup(cli, container_runtime_available, container_runtime_installed):
+    if not container_runtime_available:
+        pytest.skip('container runtime(s) not available')
+    cli(
+        [
+            'adhoc',
+            '--private-data-dir', os.path.join(HERE,'priv_data'),
+            '--container-runtime', container_runtime_installed,
+            'localhost', '-m', 'setup'
+        ]
+    )
+
+
+@pytest.mark.serial
+def test_playbook_with_private_data_dir(cli, container_runtime_available, container_runtime_installed):
+    if not container_runtime_available:
+        pytest.skip('container runtime(s) not available')
+    cli(
+        [
+            'playbook',
+            '--private-data-dir', os.path.join(HERE,'priv_data'),
+            '--container-runtime', container_runtime_installed,
+            'test-container.yml'
+        ]
+    )

--- a/test/integration/exec_env/Containerfile
+++ b/test/integration/exec_env/Containerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+RUN yum -y install python3-pip gcc python3-devel openssh-clients
+RUN pip3 install https://github.com/ansible/ansible/archive/devel.tar.gz
+RUN pip3 install https://github.com/ansible/ansible-runner/archive/devel.tar.gz
+
+

--- a/test/integration/exec_env/demo.yml
+++ b/test/integration/exec_env/demo.yml
@@ -39,5 +39,3 @@
       service:
         name: sshd
         state: restarted
-
-

--- a/test/integration/exec_env/demo.yml
+++ b/test/integration/exec_env/demo.yml
@@ -1,0 +1,43 @@
+---
+- name: Run some basic system automation stuff
+  hosts: rhel8
+  tasks:
+    - name: install some basic packages
+      yum:
+        name:
+          - tmux
+          - git
+          - vim-enhanced
+          - python3
+
+    - name: enable journald persistent storage
+      file:
+        path: /var/log/journal
+        state: directory
+
+    - name: Get tuned profile
+      slurp:
+        src: /etc/tuned/active_profile
+      register: tuned_active_profile
+
+    - debug:
+        msg: "{{ tuned_active_profile['content'] | b64decode | trim }}"
+
+    - name: tuned-adm set throughput-performance
+      shell: /usr/sbin/tuned-adm profile throughput-performance
+      when: "tuned_active_profile['content'] | b64decode | trim != 'throughput-performance'"
+
+    - name: don't allow password based ssh
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^PasswordAuthentication'
+        line: "PasswordAuthentication no"
+      notify: restart sshd
+
+  handlers:
+    - name: restart sshd
+      service:
+        name: sshd
+        state: restarted
+
+

--- a/test/integration/exec_env/inventory.ini
+++ b/test/integration/exec_env/inventory.ini
@@ -1,0 +1,2 @@
+[rhel8]
+azure-rhel8 ansible_host=168.62.187.3 ansible_user=admiller ansible_become=yes

--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -28,7 +28,7 @@ def test_basic_events(containerized, container_runtime_available, is_pre_ansible
     if containerized:
         run_args.update({'process_isolation': True,
                          'process_isolation_executable': 'podman',
-                         'container_image': 'ansible/ansible-runner',
+                         'container_image': 'localhost/ansible/ansible-runner',
                          'container_volume_mounts': [f'{tdir}:{tdir}']})
 
     if not is_run_async:

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -79,9 +79,8 @@ def test_help():
 
 def test_module_run():
     try:
-        rc = main(['-m', 'ping',
+        rc = main(['run', '-m', 'ping',
                    '--hosts', 'localhost',
-                   'run',
                    'ping'])
         assert os.path.exists('./ping')
         assert os.path.exists('./ping/artifacts')
@@ -93,10 +92,9 @@ def test_module_run():
 
 def test_module_run_debug():
     try:
-        rc = main(['-m', 'ping',
+        rc = main(['run', '-m', 'ping',
                    '--hosts', 'localhost',
                    '--debug',
-                   'run',
                    'ping'])
         assert os.path.exists('./ping')
         assert os.path.exists('./ping/artifacts')
@@ -109,18 +107,16 @@ def test_module_run_debug():
 @pytest.mark.serial
 def test_module_run_clean():
     with temp_directory() as temp_dir:
-        rc = main(['-m', 'ping',
+        rc = main(['run', '-m', 'ping',
                    '--hosts', 'localhost',
-                   'run',
                    temp_dir])
     assert rc == 0
 
 
 def test_role_run(skipif_pre_ansible28):
-    rc = main(['-r', 'benthomasson.hello_role',
+    rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/roles',
-               'run',
                "test/integration"])
     assert rc == 0
     ensure_removed("test/integration/artifacts")
@@ -128,21 +124,19 @@ def test_role_run(skipif_pre_ansible28):
 
 def test_role_run_abs():
     with temp_directory() as temp_dir:
-        rc = main(['-r', 'benthomasson.hello_role',
+        rc = main(['run', '-r', 'benthomasson.hello_role',
                    '--hosts', 'localhost',
                    '--roles-path', os.path.join(HERE, 'project/roles'),
-                   'run',
                    temp_dir])
     assert rc == 0
 
 
 def test_role_logfile(skipif_pre_ansible28):
     try:
-        rc = main(['-r', 'benthomasson.hello_role',
+        rc = main(['run', '-r', 'benthomasson.hello_role',
                    '--hosts', 'localhost',
                    '--roles-path', 'test/integration/project/roles',
                    '--logfile', 'new_logfile',
-                   'run',
                    'test/integration'])
         assert os.path.exists('new_logfile')
         assert rc == 0
@@ -153,11 +147,10 @@ def test_role_logfile(skipif_pre_ansible28):
 def test_role_logfile_abs():
     try:
         with temp_directory() as temp_dir:
-            rc = main(['-r', 'benthomasson.hello_role',
+            rc = main(['run', '-r', 'benthomasson.hello_role',
                        '--hosts', 'localhost',
                        '--roles-path', os.path.join(HERE, 'project/roles'),
                        '--logfile', 'new_logfile',
-                       'run',
                        temp_dir])
         assert os.path.exists('new_logfile')
         assert rc == 0
@@ -172,11 +165,10 @@ def test_role_bad_project_dir():
 
     try:
         with pytest.raises(OSError):
-            main(['-r', 'benthomasson.hello_role',
+            main(['run', '-r', 'benthomasson.hello_role',
                   '--hosts', 'localhost',
                   '--roles-path', os.path.join(HERE, 'project/roles'),
                   '--logfile', 'new_logfile',
-                  'run',
                   'bad_project_dir'])
     finally:
         os.unlink('bad_project_dir')
@@ -186,10 +178,9 @@ def test_role_bad_project_dir():
 @pytest.mark.serial
 def test_role_run_clean(skipif_pre_ansible28):
 
-    rc = main(['-r', 'benthomasson.hello_role',
+    rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/roles',
-               'run',
                "test/integration"])
     assert rc == 0
     ensure_removed("test/integration/artifacts")
@@ -197,20 +188,18 @@ def test_role_run_clean(skipif_pre_ansible28):
 
 def test_role_run_cmd_line_abs():
     with temp_directory() as temp_dir:
-        rc = main(['-r', 'benthomasson.hello_role',
+        rc = main(['run', '-r', 'benthomasson.hello_role',
                    '--hosts', 'localhost',
                    '--roles-path', os.path.join(HERE, 'project/roles'),
-                   'run',
                    temp_dir])
     assert rc == 0
 
 
 def test_role_run_artifacts_dir(skipif_pre_ansible28):
-    rc = main(['-r', 'benthomasson.hello_role',
+    rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/roles',
                '--artifact-dir', 'otherartifacts',
-               'run',
                "test/integration"])
     assert rc == 0
     ensure_removed("test/integration/artifacts")
@@ -219,11 +208,10 @@ def test_role_run_artifacts_dir(skipif_pre_ansible28):
 def test_role_run_artifacts_dir_abs(skipif_pre_ansible28):
     try:
         with temp_directory() as temp_dir:
-            rc = main(['-r', 'benthomasson.hello_role',
+            rc = main(['run', '-r', 'benthomasson.hello_role',
                        '--hosts', 'localhost',
                        '--roles-path', os.path.join(HERE, 'project/roles'),
                        '--artifact-dir', 'otherartifacts',
-                       'run',
                        temp_dir])
         assert os.path.exists(os.path.join('.', 'otherartifacts'))
         assert rc == 0
@@ -246,10 +234,9 @@ def test_role_run_env_vars(envvars):
         with codecs.open(os.path.join(temp_dir, 'env/envvars'), 'w', encoding='utf-8') as f:
             f.write(yaml.dump(envvars))
 
-        rc = main(['-r', 'benthomasson.hello_role',
+        rc = main(['run', '-r', 'benthomasson.hello_role',
                    '--hosts', 'localhost',
                    '--roles-path', os.path.join(HERE, 'project/roles'),
-                   'run',
                    temp_dir])
     assert rc == 0
 
@@ -257,11 +244,10 @@ def test_role_run_env_vars(envvars):
 def test_role_run_args():
 
     with temp_directory() as temp_dir:
-        rc = main(['-r', 'benthomasson.hello_role',
+        rc = main(['run', '-r', 'benthomasson.hello_role',
                    '--hosts', 'localhost',
                    '--roles-path', os.path.join(HERE, 'project/roles'),
                    '--role-vars', 'msg=hi',
-                   'run',
                    temp_dir])
     assert rc == 0
 
@@ -273,11 +259,10 @@ def test_role_run_inventory(is_pre_ansible28):
         ensure_directory(os.path.join(temp_dir, 'inventory'))
         shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir, 'inventory/localhost'))
 
-        rc = main(['-r', 'benthomasson.hello_role',
+        rc = main(['run', '-r', 'benthomasson.hello_role',
                    '--hosts', 'localhost',
                    '--roles-path', os.path.join(HERE, 'project/roles'),
                    '--inventory', os.path.join(temp_dir, 'inventory/localhost'),
-                   'run',
                    temp_dir])
     assert rc == 0
 
@@ -290,11 +275,10 @@ def test_role_run_inventory_missing(is_pre_ansible28):
         shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir, 'inventory/localhost'))
 
         with pytest.raises(AnsibleRunnerException):
-            main(['-r', 'benthomasson.hello_role',
+            main(['run', '-r', 'benthomasson.hello_role',
                   '--hosts', 'localhost',
                   '--roles-path', os.path.join(HERE, 'project/roles'),
                   '--inventory', 'does_not_exist',
-                  'run',
                   temp_dir])
 
 
@@ -303,10 +287,9 @@ def test_role_start():
 
     with temp_directory() as temp_dir:
         p = multiprocessing.Process(target=main,
-                                    args=[['-r', 'benthomasson.hello_role',
+                                    args=[['start', '-r', 'benthomasson.hello_role',
                                            '--hosts', 'localhost',
                                            '--roles-path', os.path.join(HERE, 'project/roles'),
-                                           'start',
                                            temp_dir]])
         p.start()
         p.join()
@@ -326,10 +309,9 @@ def test_playbook_start(skipif_pre_ansible28):
         # privateip: removed --hosts command line option from test beause it is
         # not a supported combination of cli options
         p = multiprocessing.Process(target=main,
-                                    args=[['-p', 'hello.yml',
+                                    args=[['start', '-p', 'hello.yml',
                                            '--inventory', os.path.join(HERE, 'inventory/localhost'),
                                            #'--hosts', 'localhost',
-                                           'start',
                                            temp_dir]])
         p.start()
 

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -87,7 +87,8 @@ def test_module_run():
         assert os.path.exists('./ping/artifacts')
         assert rc == 0
     finally:
-        shutil.rmtree('./ping')
+        if os.path.exists('./ping'):
+            shutil.rmtree('./ping')
 
 
 def test_module_run_debug():
@@ -101,7 +102,8 @@ def test_module_run_debug():
         assert os.path.exists('./ping/artifacts')
         assert rc == 0
     finally:
-        shutil.rmtree('./ping')
+        if os.path.exists('./ping'):
+            shutil.rmtree('./ping')
 
 
 @pytest.mark.serial

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -613,13 +613,16 @@ def test_containerization_settings(mock_mkdir, container_runtime):
         extra_container_args = ['--user={os.getuid()}']
 
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
-        ['-v', '{}:/runner:Z'.format(rc.private_data_dir)] + \
-        ['-v', '/host1:/container1:Z', '-v', 'host2:/container2:Z'] + \
-        ['-e', 'ANSIBLE_CALLBACK_PLUGINS=/usr/lib/python3.6/site-packages/ansible_runner/callbacks'] + \
-        ['-e', 'ANSIBLE_STDOUT_CALLBACK=awx_display'] + \
+        ['-e', 'LAUNCHED_BY_RUNNER=1'] + \
+        ['-v', '{}:/runner/project:Z'.format(os.path.join(rc.private_data_dir, 'project'))] + \
+        ['-v', '{}:/runner/artifacts:Z'.format(os.path.join(rc.private_data_dir, 'artifacts'))] + \
+        ['-v', '{}:/runner/inventory:Z'.format(os.path.join(rc.private_data_dir, 'inventory'))] + \
+        ['-v', '{}:/runner/env:Z'.format(os.path.join(rc.private_data_dir, 'env'))] + \
+        ['-v', '/host1:/container1', '-v', 'host2:/container2'] + \
         ['-e', 'AWX_ISOLATED_DATA_DIR=/runner/artifacts/{}'.format(rc.ident)] + \
         extra_container_args + \
         ['my_container', 'ansible-playbook', '-i', '/runner/inventory/hosts', 'main.yaml']
+
     for index, element in enumerate(expected_command_start):
         if '--user' in element:
             assert '--user=' in rc.command[index]

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -7,13 +7,8 @@
 if [ `id -u` -ge 500 ] || [ -z "${CURRENT_UID}" ]; then
 cat << EOF > /etc/passwd
 root:x:0:0:root:/root:/bin/bash
-runner:x:`id -u`:`id -g`:,,,:/runner:/bin/bash
+runner:x:`id -u`:`id -g`:,,,:/home/runner:/bin/bash
 EOF
-
-# Rootless podman volume mounts creates new directories
-# with incorrect permissions, but we have permission
-# to chown them.
-chown -R runner:runner /runner &>/dev/null
 fi
 
 exec tini -- "${@}"

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -5,14 +5,10 @@
 # require a named user. So if we're in OpenShift, we need to make
 # one before Ansible runs.
 if [ `id -u` -ge 500 ] || [ -z "${CURRENT_UID}" ]; then
-
-  cat << EOF > /tmp/passwd
+cat << EOF > /etc/passwd
 root:x:0:0:root:/root:/bin/bash
 runner:x:`id -u`:`id -g`:,,,:/runner:/bin/bash
 EOF
-
-  cat /tmp/passwd > /etc/passwd
-  rm /tmp/passwd
 fi
 
 exec tini -- "${@}"

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -11,4 +11,10 @@ runner:x:`id -u`:`id -g`:,,,:/home/runner:/bin/bash
 EOF
 fi
 
+RUNNER_CALLBACKS=$(python3 -c "import ansible_runner.callbacks; print(ansible_runner.callbacks.__file__)")
+
+export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS):${ANSIBLE_CALLBACK_PLUGINS}"
+
+export ANSIBLE_STDOUT_CALLBACK=awx_display
+
 exec tini -- "${@}"

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -9,6 +9,11 @@ cat << EOF > /etc/passwd
 root:x:0:0:root:/root:/bin/bash
 runner:x:`id -u`:`id -g`:,,,:/runner:/bin/bash
 EOF
+
+# Rootless podman volume mounts creates new directories
+# with incorrect permissions, but we have permission
+# to chown them.
+chown -R runner:runner /runner
 fi
 
 exec tini -- "${@}"

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -11,10 +11,12 @@ runner:x:`id -u`:`id -g`:,,,:/home/runner:/bin/bash
 EOF
 fi
 
-RUNNER_CALLBACKS=$(python3 -c "import ansible_runner.callbacks; print(ansible_runner.callbacks.__file__)")
+if [[ -n "${LAUNCHED_BY_RUNNER}" ]]; then
+    RUNNER_CALLBACKS=$(python3 -c "import ansible_runner.callbacks; print(ansible_runner.callbacks.__file__)")
 
-export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS):${ANSIBLE_CALLBACK_PLUGINS}"
+    export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS):${ANSIBLE_CALLBACK_PLUGINS}"
 
-export ANSIBLE_STDOUT_CALLBACK=awx_display
+    export ANSIBLE_STDOUT_CALLBACK=awx_display
+fi
 
 exec tini -- "${@}"

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -13,7 +13,7 @@ EOF
 # Rootless podman volume mounts creates new directories
 # with incorrect permissions, but we have permission
 # to chown them.
-chown -R runner:runner /runner
+chown -R runner:runner /runner &>/dev/null
 fi
 
 exec tini -- "${@}"


### PR DESCRIPTION
Currently with Execution Environments via process isolation option, the interface to that containerized functionality is either via the native Ansible Runner CLI or the corresponding python API. In an attempt to open this functionality up in a more "familiar feel" to the users of the `ansible` and `ansible-playbook` command line tools, in service of aiding in the dev/test of automation targeted for Tower/AWS, I wanted to introduce the `adhoc` and `playbook` subcommands to the `ansible-runner` CLI (while maintaining backward compatibility with the Runner CLI that exists today). The main goal here is to allow an user to have a familiar feel and even potentially use a shell alias that would allow them to use these subcommands the same way they use `ansible` and `ansible-runner` today.

I've provided the new CLI functionality that targets both `podman` and `docker` (along with the help of @shanemcd, @kdelee, and @jladdjr) as compatible OCI compliant runtimes, I've also included some documentation, and a couple baseline test cases. There's is likely room for improvement on all of these areas but I wanted to go ahead and get the PR open so we can start the review/feedback/iterate process.

Examples using my topic branch and `poetry` to venv management:
`ansible`
```
$ poetry run ansible-runner adhoc localhost -m ping
[WARNING]: No inventory was parsed, only implicit localhost is available
localhost | SUCCESS => {
    "changed": false,
    "ping": "pong"
}

$ alias ansible="poetry run ansible-runner adhoc"

$ which ansible
alias ansible='poetry run ansible-runner adhoc'
        ~/.local/bin/poetry

$ ansible localhost -m ping
[WARNING]: No inventory was parsed, only implicit localhost is available
localhost | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```
`ansible-playbook`
```
$ poetry run ansible-runner playbook test/integration/exec_env/demo.yml -i test/integration/exec_env/inventory.ini

PLAY [Run some basic system automation stuff] **********************************

TASK [Gathering Facts] *********************************************************
ok: [azure-rhel8]

TASK [install some basic packages] *********************************************
ok: [azure-rhel8]

TASK [enable journald persistent storage] **************************************
ok: [azure-rhel8]

TASK [Get tuned profile] *******************************************************
ok: [azure-rhel8]

TASK [debug] *******************************************************************
ok: [azure-rhel8] => {
    "msg": "throughput-performance"
}

TASK [tuned-adm set throughput-performance] ************************************
skipping: [azure-rhel8]

TASK [don't allow password based ssh] ******************************************
ok: [azure-rhel8]

PLAY RECAP *********************************************************************
azure-rhel8                : ok=6    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0

$ alias ansible-playbook="poetry run ansible-runner playbook"

$ which ansible-playbook
alias ansible-playbook='poetry run ansible-runner playbook'
        ~/.local/bin/poetry

$ ansible-playbook test/integration/exec_env/demo.yml -i test/integration/exec_env/inventory.ini

PLAY [Run some basic system automation stuff] **********************************

TASK [Gathering Facts] *********************************************************
ok: [azure-rhel8]

TASK [install some basic packages] *********************************************
ok: [azure-rhel8]

TASK [enable journald persistent storage] **************************************
ok: [azure-rhel8]

TASK [Get tuned profile] *******************************************************
ok: [azure-rhel8]

TASK [debug] *******************************************************************
ok: [azure-rhel8] => {
    "msg": "throughput-performance"
}

TASK [tuned-adm set throughput-performance] ************************************
skipping: [azure-rhel8]

TASK [don't allow password based ssh] ******************************************
ok: [azure-rhel8]

PLAY RECAP *********************************************************************
azure-rhel8                : ok=6    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```

Thank you,
-AdamM