### PR TITLE
Avoid trailing colon in callback plugins

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -14,7 +14,9 @@ fi
 if [[ -n "${LAUNCHED_BY_RUNNER}" ]]; then
     RUNNER_CALLBACKS=$(python3 -c "import ansible_runner.callbacks; print(ansible_runner.callbacks.__file__)")
 
-    export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS):${ANSIBLE_CALLBACK_PLUGINS}"
+    # TODO: respect user callback settings via
+    # env ANSIBLE_CALLBACK_PLUGINS or ansible.cfg
+    export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS)"
 
     export ANSIBLE_STDOUT_CALLBACK=awx_display
 fi


### PR DESCRIPTION
I know I was involved in supporting custom user callbacks (not display, aggregate and the like)

but honestly I don't think it would work right now anyway, because we would have to somehow figure out the path in the container, as opposed to the host machine.

The trailing colon will cause it to recognize cwd as a callback plugin path:

```
bash-4.4$ ANSIBLE_CALLBACK_PLUGINS=/awx_devel/ansible-runner/ansible_runner/callbacks/: ansible-config dump --only-changed
DEFAULT_CALLBACK_PLUGIN_PATH(env: ANSIBLE_CALLBACK_PLUGINS) = ['/awx_devel/ansible-runner/ansible_runner/callbacks', '/tmp/awx_5_ujh8xzrh']
```

That's a problem because it looks recursively in subdirectories.. which we really do not want at all.