### PR TITLE
Get integration tests to run content instead of returning help text

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -49,3 +49,4 @@ def container_runtime_installed():
             return runtime
         except FileNotFoundError:
             pass
+    pytest.skip('No container runtime is available.')

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -40,13 +40,12 @@ def container_runtime_available():
 # TODO: determine if we want to add docker / podman
 # to zuul instances in order to run these tests
 @pytest.fixture(scope="session", autouse=True)
-def container_runtime_installed(container_runtime_available):
+def container_runtime_installed():
     import subprocess
 
-    if container_runtime_available:
-        for runtime in ('podman', 'docker'):
-            try:
-                subprocess.run([runtime, '-v'])
-                return runtime
-            except FileNotFoundError:
-                pass
+    for runtime in ('podman', 'docker'):
+        try:
+            subprocess.run([runtime, '-v'])
+            return runtime
+        except FileNotFoundError:
+            pass

--- a/test/integration/containerized/conftest.py
+++ b/test/integration/containerized/conftest.py
@@ -60,7 +60,7 @@ def cli(request):
         })
 
         try:
-            ret = CompletedProcessProxy(subprocess.run(args, shell=True, *a, **kw))
+            ret = CompletedProcessProxy(subprocess.run(' '.join(args), shell=True, *a, **kw))
         except subprocess.CalledProcessError as err:
             pytest.fail(
                 f"Running {err.cmd} resulted in a non-zero return code: {err.returncode} - stdout: {err.stdout}, stderr: {err.stderr}"

--- a/test/integration/containerized/test_cli_containerized.py
+++ b/test/integration/containerized/test_cli_containerized.py
@@ -6,25 +6,29 @@ import pytest
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 
-@pytest.mark.serial
-def test_module_run(cli, container_runtime_available):
-    if not container_runtime_available:
-        pytest.skip('container runtime(s) not available')
-    cli(['-m', 'ping','--hosts', 'localhost', 'run', os.path.join(HERE, 'priv_data')])
+@pytest.fixture
+def skip_if_no_podman(container_runtime_installed):
+    return
+    if container_runtime_installed != 'podman':
+        pytest.skip('podman container runtime(s) not available')
 
 
 @pytest.mark.serial
-def test_playbook_run(cli, container_runtime_available):
-    if not container_runtime_available:
-        pytest.skip('container runtime(s) not available')
-    cli(['run', os.path.join(HERE,'priv_data'), '-p', 'test-container.yml'])
+def test_module_run(cli, skip_if_no_podman):
+    r = cli(['run', '-m', 'ping','--hosts', 'localhost', os.path.join(HERE, 'priv_data')])
+    assert '"ping": "pong"' in r.stdout
 
 
 @pytest.mark.serial
-def test_adhoc_localhost_setup(cli, container_runtime_available, container_runtime_installed):
-    if not container_runtime_available:
-        pytest.skip('container runtime(s) not available')
-    cli(
+def test_playbook_run(cli, skip_if_no_podman):
+    r = cli(['run', os.path.join(HERE,'priv_data'), '-p', 'test-container.yml'])
+    assert 'PLAY RECAP *******' in r.stdout
+    assert 'failed=0' in r.stdout
+
+
+@pytest.mark.serial
+def test_adhoc_localhost_setup(cli, skip_if_no_podman, container_runtime_installed):
+    r = cli(
         [
             'adhoc',
             '--private-data-dir', os.path.join(HERE,'priv_data'),
@@ -32,17 +36,19 @@ def test_adhoc_localhost_setup(cli, container_runtime_available, container_runti
             'localhost', '-m', 'setup'
         ]
     )
+    # TODO: look for some fact that indicates we are in container?
+    assert '"ansible_facts": {' in r.stdout
 
 
 @pytest.mark.serial
-def test_playbook_with_private_data_dir(cli, container_runtime_available, container_runtime_installed):
-    if not container_runtime_available:
-        pytest.skip('container runtime(s) not available')
-    cli(
+def test_playbook_with_private_data_dir(cli, skip_if_no_podman, container_runtime_installed):
+    r = cli(
         [
             'playbook',
             '--private-data-dir', os.path.join(HERE,'priv_data'),
             '--container-runtime', container_runtime_installed,
-            'test-container.yml'
+            'test/integration/containerized/priv_data/project/test-container.yml'  # FIXME: this may be a bug
         ]
     )
+    assert 'PLAY RECAP *******' in r.stdout
+    assert 'failed=0' in r.stdout


### PR DESCRIPTION
Prior behavior was that it ran just `ansible-runner` and gave help text - see comments on `subprocess.run` expected call pattern.

----
@kdelee I think this playbook comes from you. I couldn't really do it justice with my assertions.

```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
[DEPRECATION WARNING]: Distribution centos 8.1.1911 on host localhost should 
use /usr/libexec/platform-python, but is using /usr/bin/python for backward 
compatibility with prior Ansible releases. A future Ansible release will 
default to using the discovered platform python for this host. See https://docs
.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for 
more information. This feature will be removed in version 2.12. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "msg": "Test if we are in a container!"
}

TASK [Look for container env var defined in /proc/1/environ] *******************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "grep 'container=' /proc/1/environ", "delta": "0:00:00.006559", "end": "2020-08-28 01:48:05.721700", "msg": "non-zero return code", "rc": 2, "start": "2020-08-28 01:48:05.715141", "stderr": "grep: /proc/1/environ: Permission denied", "stderr_lines": ["grep: /proc/1/environ: Permission denied"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [Look for container info defined in /proc/1/cgroup] ***********************
changed: [localhost]

TASK [Found evidence that we are in docker container] **************************
ok: [localhost]

TASK [Found evidence that we are in podman container] **************************
skipping: [localhost]

TASK [Found evidence that we are in a container] *******************************
ok: [localhost]

TASK [fail] ********************************************************************
skipping: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=6    changed=2    unreachable=0    failed=0    skipped=2    rescued=0    ignored=1 
```

I think this gives information about whether you are running in podman or docker. In which case, you caught me, I'm running docker. However, that's not a durable assertion and no one wants to really parse Ansible output, so this is the best I've got.