### PR TITLE
Use relative paths for containerized private_data_dir settings

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -328,10 +328,13 @@ class RunnerConfig(object):
             self.env = {}
             # Special flags to convey info to entrypoint or process in container
             self.env['LAUNCHED_BY_RUNNER'] = '1'
-            artifact_dir = os.path.join("/runner/artifacts", "{}".format(self.ident))
-            self.env['AWX_ISOLATED_DATA_DIR'] = artifact_dir
+            self.env['AWX_ISOLATED_DATA_DIR'] = os.path.join(
+                os.pardir, 'artifacts', str(self.ident)
+            )
             if self.fact_cache_type == 'jsonfile':
-                self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = os.path.join(artifact_dir, 'fact_cache')
+                self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = os.path.join(
+                    os.pardir, 'artifacts', str(self.ident), 'fact_cache'
+                )
         else:
             # seed env with existing shell env
             self.env = os.environ.copy()


### PR DESCRIPTION
Containers are ugly because you have to juggle two sets of paths because the host context has a different filesystem than what the container does. The private_data_dir is mounted to the static location of `/runner`.

This changes the path specification for things inside of the private data directory to a relative specification which relies on the fact that `--workdir` is set to the static location of `/runner/project`