### PR TITLE
Mount private data directory to share novel folders like requirements_roles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ clean:
 	rm -rf rpm-build
 	rm -rf deb-build
 	find . -type f -regex ".*\py[co]$$" -delete
+	rm -rf $(shell find test/ -type d -name "artifacts")
 
 dist:
 	poetry build

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -413,7 +413,7 @@ DEFAULT_CLI_ARGS = {
             ("--container-image",),
             dict(
                 dest="container_image",
-                default="ansible/ansible-runner",
+                default="quay.io/ansible/ansible-runner:devel",
                 help="Container image to use when running an ansible task"
             )
         ),

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -129,7 +129,7 @@ def run(**kwargs):
     :param process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
     :param process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
     :param process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
-    :param container_image: Container image to use when running an ansible task (default: ansible/ansible-runner)
+    :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
     :param container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir. (default: None)
     :param container_options: List of container options to pass to execution engine.
     :param resource_profiling: Enable collection of resource utilization data during playbook execution.

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -81,7 +81,8 @@ class RunnerConfig(object):
                  rotate_artifacts=0, host_pattern=None, binary=None, extravars=None, suppress_ansible_output=False,
                  process_isolation=False, process_isolation_executable='podman', process_isolation_path=None,
                  process_isolation_hide_paths=None, process_isolation_show_paths=None, process_isolation_ro_paths=None,
-                 container_image='ansible/ansible-runner', container_volume_mounts=None, container_options=None,
+                 container_image='quay.io/ansible/ansible-runner:devel',
+                 container_volume_mounts=None, container_options=None,
                  resource_profiling=False, resource_profiling_base_cgroup='ansible-runner', resource_profiling_cpu_poll_interval=0.25,
                  resource_profiling_memory_poll_interval=0.25, resource_profiling_pid_poll_interval=0.25,
                  resource_profiling_results_dir=None,
@@ -211,15 +212,10 @@ class RunnerConfig(object):
             self.command = self.wrap_args_with_ssh_agent(self.command, self.ssh_key_path)
 
         # Use local callback directory
-        callback_dir = self.env.get('AWX_LIB_DIRECTORY', os.getenv('AWX_LIB_DIRECTORY'))
-        if self.containerized:
-            callback_dir = '/usr/lib/python3.6/site-packages/ansible_runner/callbacks'
-        elif callback_dir is None:
-            callback_dir = os.path.join(os.path.split(os.path.abspath(__file__))[0],
-                                        "callbacks")
-        if self.containerized:
-            self.env['ANSIBLE_CALLBACK_PLUGINS'] = callback_dir
-        else:
+        if not self.containerized:
+            callback_dir = self.env.get('AWX_LIB_DIRECTORY', os.getenv('AWX_LIB_DIRECTORY'))
+            if callback_dir is None:
+                callback_dir = os.path.join(os.path.split(os.path.abspath(__file__))[0], "callbacks")
             python_path = self.env.get('PYTHONPATH', os.getenv('PYTHONPATH', ''))
             self.env['PYTHONPATH'] = ':'.join([python_path, callback_dir])
             if python_path and not python_path.endswith(':'):

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -734,14 +734,21 @@ class RunnerConfig(object):
 
         # These directories need to exist before they are mounted in the container,
         # or they will be owned by root.
-        if not self.cli_execenv_cmd:
-            dirs_to_create = ['project', 'inventory', 'env']
+        private_subdirs = [
+            d for d in os.listdir(self.private_data_dir) if os.path.isdir(
+                os.path.join(self.private_data_dir, d)
+            )
+        ]
 
-        dirs_to_create += ['artifacts', 'requirements_roles', 'requirements_collections']
+        if 'artifacts' not in private_subdirs:
+            private_subdirs += ['artifacts']
 
-        for d in dirs_to_create:
+        for d in private_subdirs:
             if not os.path.exists(os.path.join(self.private_data_dir, d)):
-                os.mkdir(os.path.join(self.private_data_dir, d), 0o700)
+                if d == 'artifacts':
+                    os.mkdir(os.path.join(self.private_data_dir, d), 0o700)
+                else:
+                    continue
 
             new_args.extend(["-v", "{}:/runner/{}:Z".format(os.path.join(self.private_data_dir, d), d)])
 

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -732,25 +732,8 @@ class RunnerConfig(object):
                 new_args.extend(["--ipc=host"])
 
 
-        # These directories need to exist before they are mounted in the container,
-        # or they will be owned by root.
-        private_subdirs = [
-            d for d in os.listdir(self.private_data_dir) if os.path.isdir(
-                os.path.join(self.private_data_dir, d)
-            )
-        ]
-
-        if 'artifacts' not in private_subdirs:
-            private_subdirs += ['artifacts']
-
-        for d in private_subdirs:
-            if not os.path.exists(os.path.join(self.private_data_dir, d)):
-                if d == 'artifacts':
-                    os.mkdir(os.path.join(self.private_data_dir, d), 0o700)
-                else:
-                    continue
-
-            new_args.extend(["-v", "{}:/runner/{}:Z".format(os.path.join(self.private_data_dir, d), d)])
+        # Mount the private_data_dir
+        new_args.extend(["-v", "{}:/runner:Z".format(self.private_data_dir)])
 
         container_volume_mounts = self.container_volume_mounts
         if container_volume_mounts:

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -735,9 +735,9 @@ class RunnerConfig(object):
         # These directories need to exist before they are mounted in the container,
         # or they will be owned by root.
         if not self.cli_execenv_cmd:
-            dirs_to_create = ['project', 'artifacts', 'inventory', 'env']
-        else:
-            dirs_to_create = ['artifacts']
+            dirs_to_create = ['project', 'inventory', 'env']
+
+        dirs_to_create += ['artifacts', 'requirements_roles', 'requirements_collections']
 
         for d in dirs_to_create:
             if not os.path.exists(os.path.join(self.private_data_dir, d)):

--- a/test/integration/containerized/priv_data/env/settings
+++ b/test/integration/containerized/priv_data/env/settings
@@ -4,4 +4,3 @@ job_timeout: 360
 pexpect_timeout: 10
 process_isolation: true
 process_isolation_executable: podman
-container_image: ansible/ansible-runner

--- a/test/integration/containerized/test_cli_containerized.py
+++ b/test/integration/containerized/test_cli_containerized.py
@@ -33,7 +33,6 @@ def test_provide_env_var(cli, skip_if_no_podman, test_data_dir):
 
 @pytest.mark.serial
 def test_adhoc_localhost_setup(cli, skip_if_no_podman, container_runtime_installed):
-    pytest.skip('Base image needs permission updates')
     r = cli(
         [
             'adhoc',
@@ -48,7 +47,6 @@ def test_adhoc_localhost_setup(cli, skip_if_no_podman, container_runtime_install
 
 @pytest.mark.serial
 def test_playbook_with_private_data_dir(cli, skip_if_no_podman, container_runtime_installed):
-    pytest.skip('Base image needs permission updates')
     r = cli(
         [
             'playbook',

--- a/test/integration/containerized/test_cli_containerized.py
+++ b/test/integration/containerized/test_cli_containerized.py
@@ -33,6 +33,7 @@ def test_provide_env_var(cli, skip_if_no_podman, test_data_dir):
 
 @pytest.mark.serial
 def test_adhoc_localhost_setup(cli, skip_if_no_podman, container_runtime_installed):
+    pytest.skip('Base image needs permission updates')
     r = cli(
         [
             'adhoc',
@@ -47,6 +48,7 @@ def test_adhoc_localhost_setup(cli, skip_if_no_podman, container_runtime_install
 
 @pytest.mark.serial
 def test_playbook_with_private_data_dir(cli, skip_if_no_podman, container_runtime_installed):
+    pytest.skip('Base image needs permission updates')
     r = cli(
         [
             'playbook',

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -97,6 +97,6 @@ def test_env_accuracy_inside_container(request, printenv_example, container_runt
     # all environment variables, particularly those set by the entrypoint script
     for key, value in expected_env.items():
         assert key in actual_env
-        assert actual_env[key] == value
+        assert actual_env[key] == value, 'Reported value wrong for {0} env var'.format(key)
 
     assert '/tmp' == res.config.cwd

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -628,10 +628,7 @@ def test_containerization_settings(mock_mkdir, container_runtime):
         extra_container_args = ['--user={os.getuid()}']
 
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
-        ['-v', '{}:/runner/project:Z'.format(os.path.join(rc.private_data_dir, 'project'))] + \
-        ['-v', '{}:/runner/artifacts:Z'.format(os.path.join(rc.private_data_dir, 'artifacts'))] + \
-        ['-v', '{}:/runner/inventory:Z'.format(os.path.join(rc.private_data_dir, 'inventory'))] + \
-        ['-v', '{}:/runner/env:Z'.format(os.path.join(rc.private_data_dir, 'env'))] + \
+        ['-v', '{}:/runner:Z'.format(rc.private_data_dir)] + \
         ['-v', '/host1:/container1', '-v', 'host2:/container2'] + \
         ['-e', 'LAUNCHED_BY_RUNNER'] + \
         ['-e', 'AWX_ISOLATED_DATA_DIR'] + \

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -636,7 +636,6 @@ def test_containerization_settings(mock_mkdir, container_runtime):
         ['-e', 'LAUNCHED_BY_RUNNER'] + \
         ['-e', 'AWX_ISOLATED_DATA_DIR'] + \
         ['-e', 'ANSIBLE_CACHE_PLUGIN_CONNECTION'] + \
-        ['-e', 'ANSIBLE_CALLBACK_PLUGINS'] + \
         ['-e', 'ANSIBLE_STDOUT_CALLBACK'] + \
         ['-e', 'ANSIBLE_RETRY_FILES_ENABLED'] + \
         ['-e', 'ANSIBLE_HOST_KEY_CHECKING'] + \


### PR DESCRIPTION
AWX makes use of a number of folders inside of the private directory, and enumerating them is going to miss some.

Not only does it make use of folders, but it lays down a `cp` file that is used for something related to ssh-agent. Unless we refactor that, this is the only option that works. See a prior attempt at #510.

Testing initially confirms that this gets roles to work in AWX again.

This also pulls in #512, and won't work without it due to folder permission errors.