### PR TITLE
Do not set callback in entrypoint, so ad hoc commands work

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -17,8 +17,6 @@ if [[ -n "${LAUNCHED_BY_RUNNER}" ]]; then
     # TODO: respect user callback settings via
     # env ANSIBLE_CALLBACK_PLUGINS or ansible.cfg
     export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS)"
-
-    export ANSIBLE_STDOUT_CALLBACK=awx_display
 fi
 
 exec tini -- "${@}"


### PR DESCRIPTION
This is causing a behavior that causes ad hoc commands to look like playbook runs

![Screen Shot 2020-09-04 at 8 45 42 AM](https://user-images.githubusercontent.com/1385596/92240724-177aa580-ee8b-11ea-9cd0-017e04eae800.png)

but it should look like

```
localhost | CHANGED | rc=0 >>
hello world
```