### PR TITLE
Add test to catch collection install permission denied error

### DIFF
--- a/test/data/collection_install/project/project_update.yml
+++ b/test/data/collection_install/project/project_update.yml
@@ -5,21 +5,19 @@
   gather_facts: false
   connection: local
   name: Update collections
-  vars:
-    content_path: /home/runner/collections
   tasks:
 
     - name: fetch galaxy collections
       command: >
         ansible-galaxy collection install awx.awx
-        --collections-path {{ content_path }}
+        --collections-path /var/lib/awx/projects/collections
         {{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
       args:
-        chdir: "{{ content_path }}"
+        chdir: /var/lib/awx/projects/collections
       register: galaxy_collection_result
       changed_when: "'Installing ' in galaxy_collection_result.stdout"
       environment:
         ANSIBLE_FORCE_COLOR: false
-        ANSIBLE_COLLECTIONS_PATHS: "{{ content_path }}"
+        ANSIBLE_COLLECTIONS_PATHS: "/var/lib/awx/projects/collections"
         GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
 

--- a/test/data/collection_install/project/project_update.yml
+++ b/test/data/collection_install/project/project_update.yml
@@ -5,19 +5,21 @@
   gather_facts: false
   connection: local
   name: Update collections
+  vars:
+    content_path: /home/runner/collections
   tasks:
 
     - name: fetch galaxy collections
       command: >
         ansible-galaxy collection install awx.awx
-        --collections-path /var/lib/awx/projects/collections
+        --collections-path {{ content_path }}
         {{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
       args:
-        chdir: /var/lib/awx/projects/collections
+        chdir: "{{ content_path }}"
       register: galaxy_collection_result
       changed_when: "'Installing ' in galaxy_collection_result.stdout"
       environment:
         ANSIBLE_FORCE_COLOR: false
-        ANSIBLE_COLLECTIONS_PATHS: "/var/lib/awx/projects/collections"
+        ANSIBLE_COLLECTIONS_PATHS: "{{ content_path }}"
         GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
 

--- a/test/data/collection_install/project/project_update.yml
+++ b/test/data/collection_install/project/project_update.yml
@@ -20,4 +20,7 @@
         ANSIBLE_FORCE_COLOR: false
         ANSIBLE_COLLECTIONS_PATHS: "/var/lib/awx/projects/collections"
         GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+        # Put the local tmp directory to same volume as collection destination
+        # otherwise, files cannot be moved accross volumes and will cause error
+        ANSIBLE_LOCAL_TEMP: "/var/lib/awx/projects/collections/tmp"
 

--- a/test/data/collection_install/project/project_update.yml
+++ b/test/data/collection_install/project/project_update.yml
@@ -23,4 +23,3 @@
         # Put the local tmp directory to same volume as collection destination
         # otherwise, files cannot be moved accross volumes and will cause error
         ANSIBLE_LOCAL_TEMP: "/var/lib/awx/projects/collections/tmp"
-

--- a/test/data/collection_install/project/project_update.yml
+++ b/test/data/collection_install/project/project_update.yml
@@ -1,0 +1,23 @@
+---
+# Reduced version of the AWX project_update.yml playbook
+
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  name: Update collections
+  tasks:
+
+    - name: fetch galaxy collections
+      command: >
+        ansible-galaxy collection install awx.awx
+        --collections-path /var/lib/awx/projects/collections
+        {{ ' -' + 'v' * ansible_verbosity if ansible_verbosity else '' }}
+      args:
+        chdir: /var/lib/awx/projects/collections
+      register: galaxy_collection_result
+      changed_when: "'Installing ' in galaxy_collection_result.stdout"
+      environment:
+        ANSIBLE_FORCE_COLOR: false
+        ANSIBLE_COLLECTIONS_PATHS: "/var/lib/awx/projects/collections"
+        GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -127,7 +127,7 @@ def test_collection_install(request, test_data_dir, container_runtime_installed,
             'process_isolation_executable': container_runtime_installed,
             'process_isolation': True,
             'container_volume_mounts': [
-                f'{host_folder}:/var/lib/awx/projects/collections:Z'
+                f'{host_folder}:/home/runner/collections:Z'
             ]
         }
     )

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -123,7 +123,6 @@ def test_collection_install(request, test_data_dir, container_runtime_installed,
         private_data_dir=private_data_dir,
         playbook='project_update.yml',
         inventory=None,
-        verbosity=5,
         settings={
             'process_isolation_executable': container_runtime_installed,
             'process_isolation': True,

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -127,7 +127,7 @@ def test_collection_install(request, test_data_dir, container_runtime_installed,
             'process_isolation_executable': container_runtime_installed,
             'process_isolation': True,
             'container_volume_mounts': [
-                f'{host_folder}:/home/runner/collections:Z'
+                f'{host_folder}:/var/lib/awx/projects/collections:Z'
             ]
         }
     )

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -123,6 +123,7 @@ def test_collection_install(request, test_data_dir, container_runtime_installed,
         private_data_dir=private_data_dir,
         playbook='project_update.yml',
         inventory=None,
+        verbosity=5,
         settings={
             'process_isolation_executable': container_runtime_installed,
             'process_isolation': True,


### PR DESCRIPTION
We are trying to hit a specific permission denied error when writing `MANIFEST.json`. I can't get it with docker or podman in a local container, but hoping that maybe Zuul might hit it.

If not, I might try to parameterize with a user id to see if maybe we can get something more similar to headless podman.