### PR TITLE
Remove more serial markers

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,10 +1,13 @@
+import os
+import shutil
+
 import pytest
 import pexpect
 from ansible_runner.runner_config import RunnerConfig
 
 
 @pytest.fixture(scope='function')
-def rc(request, tmpdir):
+def rc(tmpdir):
     rc = RunnerConfig(str(tmpdir))
     rc.suppress_ansible_output = True
     rc.expect_passwords = {
@@ -13,9 +16,9 @@ def rc(request, tmpdir):
     }
     rc.cwd = str(tmpdir)
     rc.env = {}
-    rc.job_timeout = 2
+    rc.job_timeout = 10
     rc.idle_timeout = 0
-    rc.pexpect_timeout = .1
+    rc.pexpect_timeout = 2.
     rc.pexpect_use_poll = True
     return rc
 
@@ -39,7 +42,7 @@ def container_runtime_available():
 
 # TODO: determine if we want to add docker / podman
 # to zuul instances in order to run these tests
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def container_runtime_installed():
     import subprocess
 
@@ -50,3 +53,21 @@ def container_runtime_installed():
         except FileNotFoundError:
             pass
     pytest.skip('No container runtime is available.')
+
+
+@pytest.fixture(scope='session')
+def clear_integration_artifacts(request):
+    '''Fixture is session scoped to allow parallel runs without error
+    '''
+    if 'PYTEST_XDIST_WORKER' in os.environ:
+        # we never want to clean artifacts if running parallel tests
+        # because we cannot know when all processes are finished and it is
+        # safe to clean up
+        return
+
+    def rm_integration_artifacts():
+        path = "test/integration/artifacts"
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+    request.addfinalizer(rm_integration_artifacts)

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -43,7 +43,6 @@ def get_env_data(res):
         raise RuntimeError('Count not find look_at_environment task from playbook')
 
 
-@pytest.mark.serial
 def test_env_accuracy(request, printenv_example):
     os.environ['SET_BEFORE_TEST'] = 'MADE_UP_VALUE'
 

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -104,7 +104,6 @@ def test_module_run_debug():
             shutil.rmtree('./ping')
 
 
-@pytest.mark.serial
 def test_module_run_clean():
     with temp_directory() as temp_dir:
         rc = main(['run', '-m', 'ping',
@@ -113,13 +112,12 @@ def test_module_run_clean():
     assert rc == 0
 
 
-def test_role_run(skipif_pre_ansible28):
+def test_role_run(skipif_pre_ansible28, clear_integration_artifacts):
     rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/roles',
                "test/integration"])
     assert rc == 0
-    ensure_removed("test/integration/artifacts")
 
 
 def test_role_run_abs():
@@ -131,17 +129,14 @@ def test_role_run_abs():
     assert rc == 0
 
 
-def test_role_logfile(skipif_pre_ansible28):
-    try:
-        rc = main(['run', '-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', 'test/integration/project/roles',
-                   '--logfile', 'new_logfile',
-                   'test/integration'])
-        assert os.path.exists('new_logfile')
-        assert rc == 0
-    finally:
-        ensure_removed("test/integration/artifacts")
+def test_role_logfile(skipif_pre_ansible28, clear_integration_artifacts):
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', 'test/integration/project/roles',
+               '--logfile', 'new_logfile',
+               'test/integration'])
+    assert os.path.exists('new_logfile')
+    assert rc == 0
 
 
 def test_role_logfile_abs():
@@ -175,15 +170,13 @@ def test_role_bad_project_dir():
         ensure_removed("new_logfile")
 
 
-@pytest.mark.serial
-def test_role_run_clean(skipif_pre_ansible28):
+def test_role_run_clean(skipif_pre_ansible28, clear_integration_artifacts):
 
     rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/roles',
                "test/integration"])
     assert rc == 0
-    ensure_removed("test/integration/artifacts")
 
 
 def test_role_run_cmd_line_abs():
@@ -195,14 +188,13 @@ def test_role_run_cmd_line_abs():
     assert rc == 0
 
 
-def test_role_run_artifacts_dir(skipif_pre_ansible28):
+def test_role_run_artifacts_dir(skipif_pre_ansible28, clear_integration_artifacts):
     rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/roles',
                '--artifact-dir', 'otherartifacts',
                "test/integration"])
     assert rc == 0
-    ensure_removed("test/integration/artifacts")
 
 
 def test_role_run_artifacts_dir_abs(skipif_pre_ansible28):
@@ -295,7 +287,6 @@ def test_role_start():
         p.join()
 
 
-@pytest.mark.serial
 def test_playbook_start(skipif_pre_ansible28):
 
     inv = 'inventory/localhost'


### PR DESCRIPTION
I believe this was fixed in a recent PR where the UUID4 method was not ran for each job, so those jobs ran by the python interface all shared the same identifier.