### PR TITLE
Kill-on-cancel for containers launched from programatic interface

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -218,7 +218,7 @@ class Runner(object):
             if password is not None:
                 child.sendline(password)
                 self.last_stdout_update = time.time()
-            if self.cancel_callback:
+            if (not self.canceled) and self.cancel_callback:
                 try:
                     self.canceled = self.cancel_callback()
                 except Exception as e:
@@ -231,8 +231,10 @@ class Runner(object):
                 # if isinstance(extra_update_fields, dict):
                 #     extra_update_fields['job_explanation'] = "Job terminated due to timeout"
             if self.canceled or self.timed_out or self.errored:
+                self.kill_container()
                 Runner.handle_termination(child.pid, is_cancel=self.canceled)
             if self.config.idle_timeout and (time.time() - self.last_stdout_update) > self.config.idle_timeout:
+                self.kill_container()
                 Runner.handle_termination(child.pid, is_cancel=False)
                 self.timed_out = True
 
@@ -388,6 +390,21 @@ class Runner(object):
         all_host_events = filter(lambda x: 'event_data' in x and 'host' in x['event_data'] and x['event_data']['host'] == host,
                                  self.events)
         return all_host_events
+
+    def kill_container(self):
+        '''
+        Internal method to terminate a container being used for job isolation
+        '''
+        container_name = self.config.container_name
+        if container_name:
+            container_cli = self.config.process_isolation_executable
+            cmd = '{} kill {}'.format(container_cli, container_name)
+            proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=True)
+            _, stderr = proc.communicate()
+            if proc.returncode:
+                logger.info('Error from {} kill {} command:\n{}'.format(container_cli, container_name, stderr))
+            else:
+                logger.info("Killed container {}".format(container_name))
 
     @classmethod
     def handle_termination(cls, pid, pidfile=None, is_cancel=True):

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -218,7 +218,7 @@ class Runner(object):
             if password is not None:
                 child.sendline(password)
                 self.last_stdout_update = time.time()
-            if (not self.canceled) and self.cancel_callback:
+            if self.cancel_callback:
                 try:
                     self.canceled = self.cancel_callback()
                 except Exception as e:

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -390,3 +390,12 @@ def ensure_str(s, encoding='utf-8', errors='strict'):
     elif PY3 and isinstance(s, binary_type):
         s = s.decode(encoding, errors)
     return s
+
+
+def sanitize_container_name(original_name):
+    """
+    Docker and podman will only accept certain characters in container names
+    This takes a given name from user-specified values and replaces the
+    invalid characters so it can be used in docker/podman CLI commands
+    """
+    return re.sub('[^a-zA-Z0-9_-]', '_', text_type(original_name))

--- a/docs/execution_environments.rst
+++ b/docs/execution_environments.rst
@@ -74,6 +74,19 @@ how Ansible AWX and Tower manage this information.
 
 See :ref:`inputdir` for more information
 
+Container Names
+^^^^^^^^^^^^^^^
+
+Like all ansible-runner jobs, each job has an identifier associated with it
+which is also the name of the artifacts subfolder where results are saved to.
+When a container for job isolation is launched, it will be given a name
+of ``ansible_runner_<job identifier>``. Some characters from the job
+identifier may be replaced with underscores for compatibility with
+names that podman and docker allow.
+
+This name is used internally if a command needs to be ran against the container
+at a later time, for instance, to stop the container when the job is canceled.
+
 ~/.ssh/ symlinks
 ^^^^^^^^^^^^^^^^
 

--- a/test/data/sleep/project/sleep.yml
+++ b/test/data/sleep/project/sleep.yml
@@ -1,0 +1,11 @@
+---
+- name: Sleep playbook for testing things while process is running
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    sleep_interval: 30
+
+  tasks:
+    - name: sleep for a specified interval
+      command: 'sleep {{ sleep_interval }}'

--- a/test/integration/containerized/conftest.py
+++ b/test/integration/containerized/conftest.py
@@ -44,7 +44,8 @@ class CompletedProcessProxy(object):
 @pytest.fixture(scope='function')
 def cli(request):
     def run(args, *a, **kw):
-        args = ['ansible-runner',] + args
+        if not kw.pop('bare', None):
+            args = ['ansible-runner',] + args
         kw['encoding'] = 'utf-8'
         if 'check' not in kw:
             # By default we want to fail if a command fails to run. Tests that

--- a/test/integration/containerized/test_container_management.py
+++ b/test/integration/containerized/test_container_management.py
@@ -7,6 +7,43 @@ import pytest
 from ansible_runner.interface import run
 
 
+def is_running(cli, container_runtime_installed, container_name):
+    cmd = [container_runtime_installed, 'ps', '-aq', '--filter', 'name=ansible_runner_foo_bar']
+    r = cli(cmd, bare=True)
+    output = '{}{}'.format(r.stdout, r.stderr)
+    print(' '.join(cmd))
+    print(output)
+    return output.strip()
+
+
+class CancelStandIn:
+    def __init__(self, runtime, cli, delay=0.2):
+        self.runtime = runtime
+        self.cli = cli
+        self.delay = 0.2
+        self.checked_running = False
+        self.start_time = None
+
+    def cancel(self):
+        # Avoid checking for some initial delay to allow container startup
+        if not self.start_time:
+            self.start_time = time.time()
+        if time.time() - self.start_time < self.delay:
+            return False
+        # guard against false passes by checking for running container
+        if not self.checked_running:
+            for i in range(5):
+                if is_running(self.cli, self.runtime, 'ansible_runner_foo_bar'):
+                    break
+                time.sleep(0.2)
+            else:
+                print(self.cli([self.runtime, 'ps', '-a'], bare=True).stdout)
+                raise Exception('Never spawned expected container')
+            self.checked_running = True
+        # Established that container was running, now we cancel job
+        return True
+
+
 @pytest.mark.serial
 def test_cancel_will_remove_container(test_data_dir, container_runtime_installed, cli):
     private_data_dir = os.path.join(test_data_dir, 'sleep')
@@ -15,24 +52,7 @@ def test_cancel_will_remove_container(test_data_dir, container_runtime_installed
     if os.path.exists(env_dir):
         shutil.rmtree(env_dir)
 
-    def is_running(container_name):
-        cmd = [container_runtime_installed, 'ps', '-aq', '--filter', 'name=ansible_runner_foo_bar']
-        r = cli(cmd, bare=True)
-        output = '{}{}'.format(r.stdout, r.stderr)
-        print(' '.join(cmd))
-        print(output)
-        return output.strip()
-
-    def cancel():
-        # guard against false passes by checking for running container
-        for i in range(5):
-            if is_running('ansible_runner_foo_bar'):
-                break
-            time.sleep(0.2)
-        else:
-            print(cli([container_runtime_installed, 'ps', '-a'], bare=True).stdout)
-            raise Exception('Never spawned expected container')
-        return True
+    cancel_standin = CancelStandIn(container_runtime_installed, cli)
 
     res = run(
         private_data_dir=private_data_dir,
@@ -41,10 +61,12 @@ def test_cancel_will_remove_container(test_data_dir, container_runtime_installed
             'process_isolation_executable': container_runtime_installed,
             'process_isolation': True
         },
-        cancel_callback=cancel,
+        cancel_callback=cancel_standin.cancel,
         ident='foo?bar'  # question mark invalid char, but should still work
     )
     assert res.rc == 254, res.stdout.read()
     assert res.status == 'canceled'
 
-    assert not is_running('ansible_runner_foo_bar'), 'Found a running container, they should have all been stopped'
+    assert not is_running(
+        cli, container_runtime_installed, 'ansible_runner_foo_bar'
+    ), 'Found a running container, they should have all been stopped'

--- a/test/integration/containerized/test_container_management.py
+++ b/test/integration/containerized/test_container_management.py
@@ -1,0 +1,50 @@
+import os
+import shutil
+import time
+
+import pytest
+
+from ansible_runner.interface import run
+
+
+@pytest.mark.serial
+def test_cancel_will_remove_container(test_data_dir, container_runtime_installed, cli):
+    private_data_dir = os.path.join(test_data_dir, 'sleep')
+
+    env_dir = os.path.join(private_data_dir, 'env')
+    if os.path.exists(env_dir):
+        shutil.rmtree(env_dir)
+
+    def is_running(container_name):
+        cmd = [container_runtime_installed, 'ps', '-aq', '--filter', 'name=ansible_runner_foo_bar']
+        r = cli(cmd, bare=True)
+        output = '{}{}'.format(r.stdout, r.stderr)
+        print(' '.join(cmd))
+        print(output)
+        return output.strip()
+
+    def cancel():
+        # guard against false passes by checking for running container
+        for i in range(5):
+            if is_running('ansible_runner_foo_bar'):
+                break
+            time.sleep(0.2)
+        else:
+            print(cli([container_runtime_installed, 'ps', '-a'], bare=True).stdout)
+            raise Exception('Never spawned expected container')
+        return True
+
+    res = run(
+        private_data_dir=private_data_dir,
+        playbook='sleep.yml',
+        settings={
+            'process_isolation_executable': container_runtime_installed,
+            'process_isolation': True
+        },
+        cancel_callback=cancel,
+        ident='foo?bar'  # question mark invalid char, but should still work
+    )
+    assert res.rc == 254, res.stdout.read()
+    assert res.status == 'canceled'
+
+    assert not is_running('ansible_runner_foo_bar'), 'Found a running container, they should have all been stopped'

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -595,6 +595,7 @@ def test_profiling_plugin_settings_with_custom_intervals(mock_mkdir):
 def test_container_volume_mounting_with_Z(tmpdir):
     rc = RunnerConfig(str(tmpdir))
     rc.container_volume_mounts = ['project_path:project_path:Z']
+    rc.container_name = 'foo'
     rc.env = {}
     new_args = rc.wrap_args_for_containerization(['ansible-playbook', 'foo.yml'])
     assert new_args[0] == 'podman'
@@ -611,6 +612,7 @@ def test_container_volume_mounting_with_Z(tmpdir):
 def test_containerization_settings(tmpdir, container_runtime):
     with patch('ansible_runner.runner_config.RunnerConfig.containerized', new_callable=PropertyMock) as mock_containerized:
         rc = RunnerConfig(tmpdir)
+        rc.ident = 'foo'
         rc.playbook = 'main.yaml'
         rc.command = 'ansible-playbook'
         rc.process_isolation = True
@@ -631,6 +633,7 @@ def test_containerization_settings(tmpdir, container_runtime):
         ['-v', '/host1:/container1', '-v', 'host2:/container2'] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
+        ['--name', 'ansible_runner_foo'] + \
         ['my_container', 'ansible-playbook', '-i', '/runner/inventory/hosts', 'main.yaml']
 
     for index, element in enumerate(expected_command_start):


### PR DESCRIPTION
Connect https://github.com/ansible/ansible-runner/issues/506

This does _not_ solve the problem for using the CLI, which is specifically the steps I gave in the issue:

```
ansible-runner start test/data/pytz --playbook=pytz.yml
ansible-runner stop test/data/pytz
```

However, I realize that involves a redesign of the `ansible-runner` contract with the user.

Reason is that the pidfile is saved in `<private_data_dir>/pid`... as opposed to:

 - `<private_data_dir>/artifacts/pid`
 - `<private_data_dir>/artifacts/<ident_value>/pid`

This is because the `ansible-runner stop` kind of commands give the private data dir. Well, multiple jobs could be running using the same private data dir (although not entirely correctly). Putting that aside, how would we go from the pid value to the container it is running in? I don't think we would, we would probably write a new file to save the container name.

I am absolutely not going to introduce a new temporary file to the top-level of the private data dir without specific agreement on the broader architectural direction. If anything, I'd expect that we would move away from addressing with the private data dir and use user-provided `ident` on top of that.

----

This solution should probably solve it for the AWX use case... for now. We can come back to the CLI fix if in the receptor integration it loses the parent ansible-runner process (which I don't think it will).

Also, we do SIGKILL for ordinary Ansible processes, so I will not weep for the undignified demise of these containers.