### PR TITLE
Fix & tests for standard out corruption to console

### DIFF
--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -295,13 +295,6 @@ class OutputEventFilter(object):
 
             self._last_chunk = remainder
         else:
-            if not self.suppress_ansible_output:
-                sys.stdout.write(
-                    data.encode('utf-8') if PY2 else data
-                )
-            self._handle.write(data)
-            self._handle.flush()
-
             # Verbose stdout outside of event data context
             if data and '\n' in data and self._current_event_data is None:
                 # emit events for all complete lines we know about
@@ -313,6 +306,12 @@ class OutputEventFilter(object):
                 # emit all complete lines
                 for line in lines:
                     self._emit_event(line)
+                    if not self.suppress_ansible_output:
+                        sys.stdout.write(
+                            line.encode('utf-8') if PY2 else line
+                        )
+                    self._handle.write(line)
+                    self._handle.flush()
                 self._buffer = StringIO()
                 # put final partial line back on buffer
                 if remainder:

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -351,3 +351,46 @@ def test_output_when_given_invalid_playbook(tmpdir):
     stdout = executor.stdout.read()
     assert "ERROR! the playbook:" in stdout
     assert "could not be found" in stdout
+
+
+def test_output_when_given_non_playbook_script(private_data_dir):
+    # As shown in the following pull request:
+    #
+    #   https://github.com/ansible/ansible-runner/pull/256
+    #
+    # This ports some functionality that previously lived in awx and allows raw
+    # lines of stdout to be treated as event lines.
+    #
+    # As mentioned in the pull request as well, there were no specs added, and
+    # this is a retro-active test based on the sample repo provided in the PR:
+    #
+    #   https://github.com/AlanCoding/ansible-runner-examples/tree/master/non_playbook/sleep_with_writes
+
+    with open(os.path.join(private_data_dir, "args"), 'w') as args_file:
+        args_file.write("bash sleep_and_write.sh\n")
+    with open(os.path.join(private_data_dir, "sleep_and_write.sh"), 'w') as script_file:
+        script_file.write("echo 'hi world'\nsleep 0.5\necho 'goodbye world'\n")
+
+    # Update the settings to make this test a bit faster :)
+    os.mkdir(os.path.join(private_data_dir, "env"))
+    with open(os.path.join(private_data_dir, "env", "settings"), 'w') as settings_file:
+        settings_file.write("pexpect_timeout: 0.2")
+
+    executor = init_runner(
+        private_data_dir=private_data_dir,
+        inventory="localhost ansible_connection=local",
+        envvars={"ANSIBLE_DEPRECATION_WARNINGS": "False"}
+    )
+
+    executor.run()
+    stdout = executor.stdout.readlines()
+    assert stdout[0].strip() == "hi world"
+    assert stdout[1].strip() == "goodbye world"
+
+    events = list(executor.events)
+
+    assert len(events) == 2
+    assert events[0]['event'] == 'verbose'
+    assert events[0]['stdout'] == 'hi world'
+    assert events[1]['event'] == 'verbose'
+    assert events[1]['stdout'] == 'goodbye world'

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -36,12 +36,11 @@ def executor(request, private_data_dir):
     else:
         inventory = 'localhost ansible_connection=local'
 
-
     r = init_runner(
         private_data_dir=private_data_dir,
         inventory=inventory,
         envvars=envvars,
-        playbook=yaml.safe_load(playbook)
+        playbook=yaml.safe_load(playbook),
     )
 
     return r
@@ -394,3 +393,28 @@ def test_output_when_given_non_playbook_script(private_data_dir):
     assert events[0]['stdout'] == 'hi world'
     assert events[1]['event'] == 'verbose'
     assert events[1]['stdout'] == 'goodbye world'
+
+
+@pytest.mark.parametrize('json_mode', [True])
+@pytest.mark.parametrize('playbook', [
+{'listvars.yml': '''
+- name: List Variables
+  connection: local
+  hosts: all
+  tasks:
+    - name: Display all variables/facts known for a host
+      debug:
+        var: hostvars[inventory_hostname]
+'''},  # noqa
+])
+def test_large_stdout_parsing_when_using_json_output(executor, playbook, json_mode):
+    # When the json flag is used, it is possible to output more data than
+    # pexpect's maxread default of 2000 characters.  As a result, if not
+    # handled properly, the stdout can end up being corrupted with partial
+    # non-event matches with raw "non-json" lines being intermixed with json
+    # ones.
+    #
+    # This tests to confirm we don't polute the stdout output with non-json
+    # lines when a single event has a lot of output.
+    executor.run()
+    assert all(line[0] == "{" for line in executor.stdout.readlines())

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -414,6 +414,8 @@ def test_large_stdout_parsing_when_using_json_output(executor, playbook):
     #
     # This tests to confirm we don't polute the stdout output with non-json
     # lines when a single event has a lot of output.
+    if six.PY2:
+        pytest.skip('Ansible in python2 uses different syntax.')
     executor.config.env['ANSIBLE_NOCOLOR'] = str(True)
     executor.run()
     text = executor.stdout.read()

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -18,9 +18,6 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 def executor(tmpdir, request, is_pre_ansible28):
     private_data_dir = six.text_type(tmpdir.mkdir('foo'))
 
-
-@pytest.fixture()
-def executor(request, private_data_dir):
     playbooks = request.node.callspec.params.get('playbook')
     playbook = list(playbooks.values())[0]
     envvars = request.node.callspec.params.get('envvars')
@@ -36,11 +33,12 @@ def executor(request, private_data_dir):
     else:
         inventory = 'localhost ansible_connection=local'
 
+
     r = init_runner(
         private_data_dir=private_data_dir,
         inventory=inventory,
         envvars=envvars,
-        playbook=yaml.safe_load(playbook),
+        playbook=yaml.safe_load(playbook)
     )
 
     return r
@@ -352,7 +350,7 @@ def test_output_when_given_invalid_playbook(tmpdir):
     assert "could not be found" in stdout
 
 
-def test_output_when_given_non_playbook_script(private_data_dir):
+def test_output_when_given_non_playbook_script(tmpdir):
     # As shown in the following pull request:
     #
     #   https://github.com/ansible/ansible-runner/pull/256
@@ -364,7 +362,7 @@ def test_output_when_given_non_playbook_script(private_data_dir):
     # this is a retro-active test based on the sample repo provided in the PR:
     #
     #   https://github.com/AlanCoding/ansible-runner-examples/tree/master/non_playbook/sleep_with_writes
-
+    private_data_dir = str(tmpdir)
     with open(os.path.join(private_data_dir, "args"), 'w') as args_file:
         args_file.write("bash sleep_and_write.sh\n")
     with open(os.path.join(private_data_dir, "sleep_and_write.sh"), 'w') as script_file:

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -405,7 +405,7 @@ def test_output_when_given_non_playbook_script(tmpdir):
         msg: "{{ ('F' * 150) | list }}"
 '''},  # noqa
 ])
-def test_large_stdout_parsing_when_using_json_output(executor, playbook):
+def test_large_stdout_parsing_when_using_json_output(executor, playbook, skipif_pre_ansible28):
     # When the json flag is used, it is possible to output more data than
     # pexpect's maxread default of 2000 characters.  As a result, if not
     # handled properly, the stdout can end up being corrupted with partial


### PR DESCRIPTION
Replaces https://github.com/ansible/ansible-runner/pull/335

I believe this may be related to other reported issues of broken stdout, for example https://github.com/ansible/ansible-runner/issues/386