### PR TITLE
Do not mangle roles_path when it is a string

### DIFF
--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -257,7 +257,10 @@ class RunnerConfig(object):
             self.env['CGROUP_DISPLAY_RECAP'] = 'False'
 
         if self.roles_path:
-            self.env['ANSIBLE_ROLES_PATH'] = ':'.join(self.roles_path)
+            if isinstance(self.roles_path, list):
+                self.env['ANSIBLE_ROLES_PATH'] = ':'.join(self.roles_path)
+            else:
+                self.env['ANSIBLE_ROLES_PATH'] = self.roles_path
 
         if self.sandboxed:
             debug('sandbox enabled')


### PR DESCRIPTION
Previously, when providing a single string as a parameter to `roles_path` the value would be mangled to insert colons between every character in the string. Now the assignment checks if the provided value is a single string or a list of strings and processes it into the environment variable accordingly.