### PR TITLE
Fix editable installations using `pip install -e .`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,5 +57,5 @@ pathlib2 = "*"
 scandir = "*"
 
 [build-system]
-requires = ["poetry>=1.0.5", "ansible-base"]
+requires = ["setuptools", "poetry>=1.0.5", "ansible-base"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
When doing `pip install -e .`, the build process needs setuptools before
reading setup.py, which means it needs to be specified in pyproject.toml's
build-system table.

This addresses the problem mentioned in pypa/pip#8986

cc @AlanCoding 