### PR TITLE
Create tox -evenv entry point

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,6 @@ commands =
 commands =
     pipenv --python 3
     {[testenv]commands}
+
+[testenv:venv]
+commands = {posargs}


### PR DESCRIPTION
This allows a user to quickly install the tox requirement files, to then
source ~/.tox/venv/bin/avtivate, to run make dist.

Helpful to quickly create a tarball.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>