### PR TITLE
Create tox -evenv entry point

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,3 +56,6 @@ commands=
     poetry env info
     poetry run py.test -v -n 4 -m "not serial" test
     poetry run py.test -v test -m serial
+
+[testenv:venv]
+commands = {posargs}


### PR DESCRIPTION
This allows a user to quickly install the tox requirement files, to then
source ~/.tox/venv/bin/avtivate, to run make dist.

Helpful to quickly create a tarball.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>