### PR TITLE
Add zuul container CI jobs

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: ansible-runner-build-container-image
+    parent: ansible-build-container-image
+    description: Build ansible-runner container image
+    pre-run: playbooks/ansible-runner-build-container-image/pre.yaml
+    timeout: 2700
+    provides: ansible-runner-container-image
+    vars: &ansible_runner_image_vars
+      container_images:
+        - context: .
+          registry: quay.io
+          repository: quay.io/ansible/ansible-runner
+          tags:
+            # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
+            # Otherwise: ['latest']
+            &imagetag "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['devel']) }}"
+
+- job:
+    name: ansible-runner-upload-container-image
+    parent: ansible-upload-container-image
+    description: Build ansible-runner container image and upload to quay.io
+    allowed-projects: ansible/ansible-runner
+    pre-run: playbooks/ansible-runner-build-container-image/pre.yaml
+    timeout: 2700
+    provides: ansible-runner-container-image
+    vars: *ansible_runner_image_vars

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,0 +1,13 @@
+---
+- project:
+    check:
+      jobs:
+        - ansible-buildset-registry
+        - ansible-runner-build-container-image
+    gate:
+      jobs:
+        - ansible-buildset-registry
+        - ansible-runner-build-container-image
+    post:
+      jobs:
+        - ansible-runner-upload-container-image

--- a/playbooks/ansible-runner-build-container-image/pre.yaml
+++ b/playbooks/ansible-runner-build-container-image/pre.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  tasks:
+    # NOTE(pabelanger): We should consider pushing this into bindep.txt file, as build dependency.
+    - name: Ensure python3-wheel is installed
+      become: true
+      package:
+        name: python3-wheel
+        state: present
+
+    - name: Run build-python-release role
+      include_role:
+        name: build-python-release
+      vars:
+        release_python: python3


### PR DESCRIPTION
This adds zuul job configuration for building / publishing container
images. This is the first step to using execution environments for
ansible-collections content team.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/721
Signed-off-by: Paul Belanger <pabelanger@redhat.com>