### PR TITLE
Don't try to promote ansible-runner image

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -10,4 +10,6 @@
         - ansible-runner-build-container-image
     post:
       jobs:
-        - ansible-runner-upload-container-image
+        - ansible-runner-upload-container-image:
+            vars:
+              upload_container_image_promote: false


### PR DESCRIPTION
Right now, we do not have a promote pipeline job running for container
uploads. This means, we only want to tag 'devel' releases on upload.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/723
Signed-off-by: Paul Belanger <pabelanger@redhat.com>