### PR TITLE
Remove ansible-buildset-registry job

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -2,11 +2,9 @@
 - project:
     check:
       jobs:
-        - ansible-buildset-registry
         - ansible-runner-build-container-image
     gate:
       jobs:
-        - ansible-buildset-registry
         - ansible-runner-build-container-image
     post:
       jobs:


### PR DESCRIPTION
This is currently not needed, lets remove it to save testing capacity.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>