### PR TITLE
Switch to centos:8 for BASE container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
-ARG BASE_IMAGE=docker.io/fedora:32
+ARG BASE_IMAGE=quay.io/centos/centos:8
 
 FROM ${BASE_IMAGE}
 
 # Install system packages for use in all images
 RUN dnf install -y \
+    epel-release \
+    dnf-plugins-core && \
+    dnf config-manager --set-disabled epel && \
+    dnf install -y --enablerepo epel \
+    sshpass && \
+    dnf install -y \
     python3-pip \
     gcc \
     rsync \
     openssh-clients \
-    sshpass \
     glibc-langpack-en \
     git \
     https://github.com/krallin/tini/releases/download/v0.19.0/tini_0.19.0-amd64.rpm && \
     rm -rf /var/cache/dnf
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 # Install python packages for use in all images
 RUN pip3 install --no-cache-dir bindep


### PR DESCRIPTION
This is the first step towards multi-stage builds. We'll be basing our
images off centos-8, which gets us one step closer to using UBI8
container images.  Given that fedora is fast moving, every 6 month we'd
have to update this image or hit EOL.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>