### PR TITLE
Report correct cwd for containerized runs in config

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -140,6 +140,8 @@ class Runner(object):
 
         # Use a copy so as not to cause problems when serializing the job_env.
         if self.config.containerized:
+            # We call the actual docker or podman executable right where we are
+            cwd = os.getcwd()
             # If this is containerized, the shell environment calling podman has little
             # to do with the actual job environment, but still needs PATH, auth, etc.
             pexpect_env = os.environ.copy()
@@ -151,6 +153,7 @@ class Runner(object):
             with open(env_file_host, 'w') as f:
                 f.write('\n'.join(list(self.config.env.keys())))
         else:
+            cwd = self.config.cwd
             pexpect_env = self.config.env
         env = {
             ensure_str(k): ensure_str(v) if k != 'PATH' and isinstance(v, six.text_type) else v
@@ -183,7 +186,7 @@ class Runner(object):
             child = pexpect.spawn(
                 command[0],
                 command[1:],
-                cwd=self.config.cwd,
+                cwd=cwd,
                 env=env,
                 ignore_sighup=True,
                 encoding='utf-8',

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -416,9 +416,9 @@ class RunnerConfig(object):
         else:
             if self.cli_execenv_cmd:
                 if self.cli_execenv_cmd == 'adhoc':
-                    self.command = ['ansible'] + self.cmdline_args 
+                    self.command = ['ansible'] + self.cmdline_args
                 elif self.cli_execenv_cmd == 'playbook':
-                    self.command = ['ansible-playbook'] + self.cmdline_args 
+                    self.command = ['ansible-playbook'] + self.cmdline_args
                 self.execution_mode = ExecutionMode.CLI_EXECENV
 
 
@@ -625,7 +625,9 @@ class RunnerConfig(object):
     def wrap_args_for_containerization(self, args):
         new_args = [self.process_isolation_executable]
         new_args.extend(['run', '--rm', '--tty', '--interactive'])
-        new_args.extend(["--workdir", "/runner/project"])
+        container_workdir = "/runner/project"
+        new_args.extend(["--workdir", container_workdir])
+        self.cwd = container_workdir
 
         def _ensure_path_safe_to_mount(path):
             if path in ('/home', '/usr'):

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -88,7 +88,8 @@ def test_env_accuracy_inside_container(request, printenv_example, container_runt
     )
     assert res.rc == 0, res.stdout.read()
 
-    actual_env = get_env_data(res)['environment']
+    env_data = get_env_data(res)
+    actual_env = env_data['environment']
 
     expected_env = res.config.env.copy()
 
@@ -98,7 +99,7 @@ def test_env_accuracy_inside_container(request, printenv_example, container_runt
         assert key in actual_env
         assert actual_env[key] == value, 'Reported value wrong for {0} env var'.format(key)
 
-    assert '/tmp' == res.config.cwd
+    assert env_data['cwd'] == res.config.cwd
 
 
 def test_multiple_inventories(test_data_dir):


### PR DESCRIPTION
I hit this inside of the AWX tests.

There was still not a clear separation of the directory from which `podman` is called versus the directory (inside the container) where `ansible-playbook` is called. I think we assume the user cares about the latter. This makes the `status_callback` return that, while at the same time not breaking everything.