### PR TITLE
[WIP] Change ansible-base to ansible-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,5 @@ pathlib2 = "*"
 scandir = "*"
 
 [build-system]
-requires = ["setuptools", "poetry>=1.0.5", "ansible-base"]
+requires = ["setuptools", "poetry>=1.0.5", "ansible-core"]
 build-backend = "poetry.masonry.api"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,7 +15,7 @@ def is_pre_ansible28():
         if LooseVersion(pkg_resources.get_distribution('ansible').version) < LooseVersion('2.8'):
             return True
     except pkg_resources.DistributionNotFound:
-        # ansible-base (e.g. ansible 2.10 and beyond) is not accessible in this way
+        # ansible-base and ansible-core (e.g. ansible 2.10 and beyond) is not accessible in this way
         pass
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps = poetry >= 1.0.5
        ansible27: ansible<2.8
        ansible28: ansible<2.9
        ansible29: ansible<2.10
-       ansible-base: ansible-base
+       ansible-core: ansible-core
 passenv = HOME
 skip_install = true
 commands=


### PR DESCRIPTION
Ansible changed its package name from ansible-base to ansible-core.

However, I think this may leave us in a bit of a catch 22.

https://pypi.org/project/ansible-base/   last release 1 hour ago

https://pypi.org/project/ansible-core/ last release Oct 27

So this may still not be right. I know that if you pip install from source, you get ansible-core.