### PR TITLE
Fix ansible-runner-upload-container-image job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -28,8 +28,12 @@
     name: ansible-runner-upload-container-image
     parent: ansible-upload-container-image
     description: Build ansible-runner container image and upload to quay.io
-    allowed-projects: ansible/ansible-runner
     pre-run: playbooks/ansible-runner-build-container-image/pre.yaml
+    required-projects:
+      - github.com/ansible/ansible
     timeout: 2700
     provides: ansible-runner-container-image
+    requires:
+      - python-builder-container-image
+      - python-base-container-image
     vars: *ansible_runner_image_vars


### PR DESCRIPTION
We forgot to add the new job setting to our upload job. This will fix
the failure in post pipeline.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>