### PR TITLE
Fix typo in ansible-upload-container-image job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -17,7 +17,7 @@
     parent: ansible-upload-container-image
     abstract: true
     description: Build ansible-runner container image and upload to quay.io
-    pre-run: playbooks/ansible-runner-build-container-image/pre.yaml
+    pre-run: playbooks/ansible-runner-build-container-image-base/pre.yaml
     required-projects:
       - github.com/ansible/ansible
     timeout: 2700


### PR DESCRIPTION
We referenced the wrong pre-run playbook.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>