### PR TITLE
Add back glibc-langpack-en into ansible-runner image

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -3,6 +3,7 @@
 
 gcc-c++ [test platform:rpm]
 git
+glibc-langpack-en [platform:rpm]
 openssh-clients
 python3-devel [test !platform:centos-7 platform:rpm]
 python3 [test !platform:centos-7 platform:rpm]


### PR DESCRIPTION
This allows projects to not have to manage UTF-8 locale packages.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>