### PR TITLE
python3.8 container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Ansible Runner
 [![Ansible Mailing lists](https://img.shields.io/badge/Mailing%20lists-Ansible-orange.svg)](https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information)
 
 
-
 Ansible Runner is a tool and python library that helps when interfacing with Ansible directly or as part of another system whether that be through a container image interface, as a standalone tool, or as a Python module that can be imported. The goal is to provide a stable and consistent interface abstraction to Ansible.
 
 For the latest documentation see: [https://ansible-runner.readthedocs.io](https://ansible-runner.readthedocs.io/en/latest/)


### PR DESCRIPTION
This rebuilds ansible-runner container images using python3.8 as the
base version.

Depends-On: https://github.com/ansible/python-builder-image/pull/17
Signed-off-by: Paul Belanger <pabelanger@redhat.com>