### PR TITLE
Add libyaml-devel dependency for ansible / ansible-test

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,11 +1,13 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
-gcc-c++ [test platform:rpm]
+gcc-c++ [compile test platform:rpm]
 git
 glibc-langpack-en [platform:rpm]
+libyaml-devel [compile platform:rpm]
 openssh-clients
 python3-devel [test !platform:centos-7 platform:rpm]
+python38-devel [compile platform:centos-8]
 python3 [test !platform:centos-7 platform:rpm]
 python36 [test !platform:centos-7 !platform:fedora-28]
 podman [test platform:rpm]


### PR DESCRIPTION
This fixes PyYAML not being compiled properly:

  WARNING: PyYAML will be slow due to installation without libyaml support for
  interpreter ...

Depends-On: https://github.com/ansible/python-builder-image/pull/18
Signed-off-by: Paul Belanger <pabelanger@redhat.com>