### PR TITLE
Install python38 distro dependencies when possible

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,15 +1,21 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
-gcc-c++ [compile test platform:rpm]
+gcc-c++ [test platform:rpm]
 git
 glibc-langpack-en [platform:rpm]
-libyaml-devel [compile platform:rpm]
 openssh-clients
-python3-devel [test !platform:centos-7 platform:rpm]
-python38-devel [compile platform:centos-8]
-python3 [test !platform:centos-7 platform:rpm]
-python36 [test !platform:centos-7 !platform:fedora-28]
 podman [test platform:rpm]
-sshpass [epel]
+python36 [test !platform:centos-7 !platform:fedora-28]
+python3-devel [test !platform:centos-7 platform:rpm]
+python3 [test !platform:centos-7 platform:rpm]
 rsync
+sshpass [epel]
+
+# ansible-core
+python38-cffi [platform:centos-8]
+python38-cryptography [platform:centos-8]
+python38-jinja2 [platform:centos-8]
+python38-pycparser [platform:centos-8]
+python38-six [platform:centos-8]
+python38-yaml [platform:centos-8]


### PR DESCRIPTION
Given we want to use our container images downstream, we should try to
be friendly as possible. This allows us to use distro python packages
over always pip installing them from pypi.

Depends-On: https://github.com/ansible/python-builder-image/pull/19
Signed-off-by: Paul Belanger <pabelanger@redhat.com>