### PR TITLE
Fix passwords regex in docs

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -102,8 +102,8 @@ In order for **Runner** to respond with the correct password, it needs to be abl
 by providing a yaml or json formatted file with a regular expression and a value to emit, for example::
 
   ---
-  "^SSH [pP]assword:$": "some_password"
-  "^BECOME [pP]assword:$": "become_password"
+  "^SSH [pP]assword: $": "some_password"
+  "^BECOME [pP]assword.*: $": "become_password"
 
 ``env/cmdline``
 ---------------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -102,8 +102,8 @@ In order for **Runner** to respond with the correct password, it needs to be abl
 by providing a yaml or json formatted file with a regular expression and a value to emit, for example::
 
   ---
-  "^SSH [pP]assword: $": "some_password"
-  "^BECOME [pP]assword.*: $": "become_password"
+  "^SSH password:\\s*?$": "some_password"
+  "^BECOME password.*:\\s*?$": "become_password"
 
 ``env/cmdline``
 ---------------


### PR DESCRIPTION
For me regex from docs for SSH and BECOME in `env/passwords` file didn't work. I used docker container `ansible/ansible-runner:1.4.6`.

BECOME looked like this:
```
BECOME password[defaults to SSH password]:
```

It was necessary to add a space after the semicolon for both.
Took some time to figure that out because I am new to ansible and if you use wrong regex you don't see any useful output, it's just stops printing.

I hope it helps others.