### PR TITLE
POC for making stream_dir work without loading into memory

### DIFF
--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -50,7 +50,7 @@ class Transmitter(object):
         self._output.flush()
 
         if not self.only_transmit_kwargs:
-            self._output.write(utils.stream_dir(self.private_data_dir))
+            utils.stream_dir(self.private_data_dir, self._output)
 
         self._output.write(json.dumps({'eof': True}).encode('utf-8'))
         self._output.write(b'\n')
@@ -145,7 +145,7 @@ class Worker(object):
         self._output.flush()
 
     def artifacts_handler(self, artifact_dir):
-        self._output.write(utils.stream_dir(artifact_dir))
+        utils.stream_dir(artifact_dir, self._output)
         self._output.flush()
 
     def finished_callback(self, runner_obj):

--- a/ansible_runner/utils.py
+++ b/ansible_runner/utils.py
@@ -83,9 +83,9 @@ def check_isolation_executable_installed(isolation_executable):
         return False
 
 
-def stream_dir(directory):
-    buf = BytesIO()
-    with zipfile.ZipFile(buf, 'w', compression=zipfile.ZIP_DEFLATED, allowZip64=True) as archive:
+def stream_dir(directory, buf):
+    local_buf = BytesIO()
+    with zipfile.ZipFile(local_buf, 'w', compression=zipfile.ZIP_DEFLATED, allowZip64=True) as archive:
         if directory:
             for dirpath, dirs, files in os.walk(directory):
                 relpath = os.path.relpath(dirpath, directory)
@@ -95,8 +95,9 @@ def stream_dir(directory):
                     archive.write(os.path.join(dirpath, fname), arcname=os.path.join(relpath, fname))
         archive.close()
 
-    payload = buf.getvalue()
-    return b'\n'.join((json.dumps({'zipfile': len(payload)}).encode('utf-8'), payload))
+    payload = local_buf.getvalue()
+    data = b'\n'.join((json.dumps({'zipfile': len(payload)}).encode('utf-8'), payload))
+    buf.write(data)
 
 
 def unstream_dir(data, directory):


### PR DESCRIPTION
This is still incomplete because it only address `stream_dir` and not `unstream_dir`, but I want to open it up to feedback about the general method, and confirm tests are passing.

I will also prefer to break this up into multiple functions and test them separate from the full integration test.