### PR TITLE
Parent to quay.io/ansible/ansible-core for Dockerfile

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -4,38 +4,25 @@
     parent: ansible-build-container-image
     abstract: true
     description: Build ansible-runner container image
-    pre-run: playbooks/ansible-runner-build-container-image-base/pre.yaml
-    required-projects:
-      - github.com/ansible/ansible
     timeout: 2700
-    requires:
-      - python-builder-container-image
-      - python-base-container-image
 
 - job:
     name: ansible-runner-upload-container-image-base
     parent: ansible-upload-container-image
     abstract: true
     description: Build ansible-runner container image and upload to quay.io
-    pre-run: playbooks/ansible-runner-build-container-image-base/pre.yaml
-    required-projects:
-      - github.com/ansible/ansible
     timeout: 2700
-    requires:
-      - python-builder-container-image
-      - python-base-container-image
 
 - job:
     name: ansible-runner-build-container-image
     parent: ansible-runner-build-container-image-base
     provides: ansible-runner-container-image
+    requires: ansible-core-container-image
     vars: &ansible_runner_image_vars
       container_images: &container_images
         - context: .
           registry: quay.io
           repository: quay.io/ansible/ansible-runner
-          siblings:
-            - github.com/ansible/ansible
           tags:
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
             # Otherwise: ['devel']
@@ -46,12 +33,16 @@
     name: ansible-runner-upload-container-image
     parent: ansible-runner-upload-container-image-base
     provides: ansible-runner-container-image
+    requires: ansible-core-container-image
     vars: *ansible_runner_image_vars
 
 - job:
     name: ansible-runner-build-container-image-stable-2.9
     parent: ansible-runner-build-container-image-base
     provides: ansible-runner-stable-2.9-container-image
+    requires:
+      - python-base-container-image
+      - python-builder-container-image
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
@@ -60,6 +51,8 @@
         - context: .
           build_args:
             - ANSIBLE_BRANCH=stable-2.9
+            # NOTE(pabelanger): There is no ansible-core 2.9, so we have to build ansible 2.9 ourself.
+            - ANSIBLE_CORE_IMAGE=quay.io/ansible/python-base:latest
           registry: quay.io
           repository: quay.io/ansible/ansible-runner
           siblings:
@@ -71,6 +64,9 @@
     name: ansible-runner-upload-container-image-stable-2.9
     parent: ansible-runner-upload-container-image-base
     provides: ansible-runner-stable-2.9-container-image
+    requires:
+      - python-base-container-image
+      - python-builder-container-image
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,16 @@ FROM quay.io/ansible/python-builder:latest as builder
 ARG ANSIBLE_BRANCH=""
 ARG ZUUL_SIBLINGS=""
 COPY . /tmp/src
-RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \
+RUN if [ "$ANSIBLE_BRANCH" == "stable-2.9" ] ; then \
       echo "Installing requirements.txt / upper-constraints.txt for Ansible $ANSIBLE_BRANCH" ; \
+      cp /tmp/src/tools/bindep-$ANSIBLE_BRANCH.txt /tmp/src/bindep.txt ; \
       cp /tmp/src/tools/requirements-$ANSIBLE_BRANCH.txt /tmp/src/requirements.txt ; \
       cp /tmp/src/tools/upper-constraints-$ANSIBLE_BRANCH.txt /tmp/src/upper-constraints.txt ; \
     fi
 RUN assemble
 
-FROM quay.io/ansible/python-base:latest as base
+ARG ANSIBLE_CORE_IMAGE=quay.io/ansible/ansible-core:latest
+FROM $ANSIBLE_CORE_IMAGE as ansible-core
 # =============================================================================
 
 COPY --from=builder /output/ /output

--- a/playbooks/ansible-runner-build-container-image-base/pre.yaml
+++ b/playbooks/ansible-runner-build-container-image-base/pre.yaml
@@ -1,9 +1,0 @@
----
-- hosts: all
-  tasks:
-    # NOTE(pabelanger): Remove option to download ansible-core from github
-    # directly. We've already cloned the contents locally.
-    - name: Update requirements.txt file
-      args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
-      shell: sed -e 's|.*egg=||g' -i requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/ansible/ansible.git@devel#egg=ansible-core

--- a/tools/bindep-stable-2.9.txt
+++ b/tools/bindep-stable-2.9.txt
@@ -1,11 +1,15 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
-
-gcc-c++ [test platform:rpm]
+git
+glibc-langpack-en [platform:rpm]
 openssh-clients
-podman [test platform:rpm]
-python36 [test !platform:centos-7 !platform:fedora-28]
+rsync
+sshpass [epel]
+
+# ansible
+python38-cffi [platform:centos-8]
+python38-cryptography [platform:centos-8]
+python38-jinja2 [platform:centos-8]
+python38-pycparser [platform:centos-8]
 python38-six [platform:centos-8]
 python38-yaml [platform:centos-8]
-python3-devel [test !platform:centos-7 platform:rpm]
-python3 [test !platform:centos-7 platform:rpm]


### PR DESCRIPTION
Now that we have a container image of ansible-core, we can use it rather
then building ansible-core ourself.

Depends-On: https://github.com/ansible/ansible-core-image/pull/1
Signed-off-by: Paul Belanger <pabelanger@redhat.com>