### PR TITLE
Allow for running EEs as non-root user in rootless podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN /output/install-from-bindep \
 # Prepare the /runner folder, seed the folder with demo data
 ADD demo /runner
 
+RUN groupadd -g 555 runner && useradd -u 555 -g 555 runner && \
+    usermod -aG root runner
+
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN for dir in \
@@ -52,6 +55,8 @@ ENV HOME=/home/runner
 
 ADD utils/entrypoint.sh /bin/entrypoint
 RUN chmod +x /bin/entrypoint
+
+USER runner
 
 ENTRYPOINT ["entrypoint"]
 CMD ["ansible-runner", "run", "/runner"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN /output/install-from-bindep \
 # Prepare the /runner folder, seed the folder with demo data
 ADD demo /runner
 
-RUN groupadd -g 555 runner && useradd -u 555 -g 555 runner && \
-    usermod -aG root runner
+RUN useradd runner && usermod -aG root runner
 
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ARG ANSIBLE_CORE_IMAGE=quay.io/ansible/ansible-core:latest
 ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
+ARG ANSIBLE_BRANCH=""
+ARG ZUUL_SIBLINGS=""
 
 FROM $PYTHON_BUILDER_IMAGE as builder
 # =============================================================================
 
-ARG ANSIBLE_BRANCH=""
-ARG ZUUL_SIBLINGS=""
 COPY . /tmp/src
 RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \
       echo "Installing requirements.txt / upper-constraints.txt for Ansible $ANSIBLE_BRANCH" ; \

--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,8 @@ test:
 docs:
 	cd docs && make html
 
-image: sdist
-	$(CONTAINER_ENGINE) pull $(BASE_IMAGE)
+image:
 	$(CONTAINER_ENGINE) build --rm=true \
-		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
-		--build-arg RUNNER_VERSION=$(VERSION) \
 		--build-arg ANSIBLE_BRANCH=$(ANSIBLE_BRANCH) \
 		-t $(IMAGE_NAME) -f Dockerfile .
 	$(CONTAINER_ENGINE) tag $(IMAGE_NAME) $(IMAGE_NAME_STRIPPED):$(GIT_BRANCH)

--- a/ansible_runner/display_callback/events.py
+++ b/ansible_runner/display_callback/events.py
@@ -69,11 +69,7 @@ class IsolatedFileWrite:
         dropoff_location = os.path.join(self.private_data_dir, 'job_events', filename)
         write_location = '.'.join([dropoff_location, 'tmp'])
         partial_data = json.dumps(value, cls=AnsibleJSONEncoderLocal)
-        perms = (stat.S_IRUSR |
-                 stat.S_IWUSR |
-                 stat.S_IRGRP |
-                 stat.S_IWGRP)
-
+        perms = (stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP)
         with os.fdopen(os.open(write_location, os.O_WRONLY | os.O_CREAT, perms), 'w') as f:
             f.write(partial_data)
         os.rename(write_location, dropoff_location)

--- a/ansible_runner/display_callback/events.py
+++ b/ansible_runner/display_callback/events.py
@@ -69,7 +69,12 @@ class IsolatedFileWrite:
         dropoff_location = os.path.join(self.private_data_dir, 'job_events', filename)
         write_location = '.'.join([dropoff_location, 'tmp'])
         partial_data = json.dumps(value, cls=AnsibleJSONEncoderLocal)
-        with os.fdopen(os.open(write_location, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR), 'w') as f:
+        perms = (stat.S_IRUSR |
+                 stat.S_IWUSR |
+                 stat.S_IRGRP |
+                 stat.S_IWGRP)
+
+        with os.fdopen(os.open(write_location, os.O_WRONLY | os.O_CREAT, perms), 'w') as f:
             f.write(partial_data)
         os.rename(write_location, dropoff_location)
 

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -157,6 +157,22 @@ class Runner(object):
             env_file_host = os.path.join(self.config.artifact_dir, 'env.list')
             with open(env_file_host, 'w') as f:
                 f.write('\n'.join(list(self.config.env.keys())))
+
+            if 'podman' in self.config.process_isolation_executable:
+                for root, dirs, files in os.walk(self.config.artifact_dir):
+                    dir_perms = (stat.S_IRUSR |
+                                 stat.S_IWUSR |
+                                 stat.S_IXUSR |
+                                 stat.S_IRGRP |
+                                 stat.S_IWGRP |
+                                 stat.S_IXGRP |
+                                 stat.S_ISGID)
+
+                    os.chmod(root, dir_perms)
+
+                    for d in dirs:
+                        os.chmod(os.path.join(root, d), dir_perms)
+
         else:
             cwd = self.config.cwd
             pexpect_env = self.config.env

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -158,7 +158,7 @@ class Runner(object):
             env_file_host = os.path.join(env_dir, 'env.list')
             with open(env_file_host, 'w') as f:
                 f.write('\n'.join(
-                     [f"{k}={v}" for k, v in self.config.env.items()]
+                    [f"{k}={v}" for k, v in self.config.env.items()]
                 ))
 
             # This here is the magic sauce. The user inside of the container is in the root

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -168,17 +168,18 @@ class Runner(object):
             # This allows runner's event_handler function to interact with these files outside
             # the container.
             if 'podman' in self.config.process_isolation_executable:
-                for root, dirs, files in os.walk(self.config.artifact_dir):
-                    dir_perms = (stat.S_IRUSR |
-                                 stat.S_IWUSR |
-                                 stat.S_IXUSR |
-                                 stat.S_IRGRP |
-                                 stat.S_IWGRP |
-                                 stat.S_IXGRP |
-                                 stat.S_ISGID)
+                dir_perms = (stat.S_IRUSR |
+                             stat.S_IWUSR |
+                             stat.S_IXUSR |
+                             stat.S_IRGRP |
+                             stat.S_IWGRP |
+                             stat.S_IXGRP |
+                             stat.S_ISGID)
 
-                    os.chmod(root, dir_perms)
+                artifact_dir = os.path.join(self.config.artifact_dir)
+                os.chmod(artifact_dir, dir_perms)
 
+                for root, dirs, _ in os.walk(artifact_dir):
                     for d in dirs:
                         os.chmod(os.path.join(root, d), dir_perms)
 

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -154,9 +154,11 @@ class Runner(object):
             pexpect_env.update(self.config.env)
             # Write the keys to pass into container to expected file in artifacts dir
             # option expecting should have already been written in ansible_runner.runner_config
-            env_file_host = os.path.join(self.config.artifact_dir, 'env.list')
+            env_file_host = os.path.join(self.config.private_data_dir, 'env', 'env.list')
             with open(env_file_host, 'w') as f:
-                f.write('\n'.join(list(self.config.env.keys())))
+                f.write('\n'.join(
+                     [f"{k}={v}" for k, v in self.config.env.items()]
+                ))
 
             # This here is the magic sauce. The user inside of the container is in the root
             # group, which is mapped to the host user's gid. By setting setgid on the artifacts

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -150,8 +150,6 @@ class Runner(object):
             # If this is containerized, the shell environment calling podman has little
             # to do with the actual job environment, but still needs PATH, auth, etc.
             pexpect_env = os.environ.copy()
-            # But we still rely on env vars to pass secrets
-            pexpect_env.update(self.config.env)
             # Write the keys to pass into container to expected file in artifacts dir
             # option expecting should have already been written in ansible_runner.runner_config
             env_file_host = os.path.join(self.config.private_data_dir, 'env', 'env.list')

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -158,6 +158,12 @@ class Runner(object):
             with open(env_file_host, 'w') as f:
                 f.write('\n'.join(list(self.config.env.keys())))
 
+            # This here is the magic sauce. The user inside of the container is in the root
+            # group, which is mapped to the host user's gid. By setting setgid on the artifacts
+            # dir + any subdirectories, any files created inside them will belong to the
+            # (in-container) root / host user's group, rather than the container user's gid.
+            # This allows runner's event_handler function to interact with these files outside
+            # the container.
             if 'podman' in self.config.process_isolation_executable:
                 for root, dirs, files in os.walk(self.config.artifact_dir):
                     dir_perms = (stat.S_IRUSR |

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -103,7 +103,9 @@ class Runner(object):
         command_filename = os.path.join(self.config.artifact_dir, 'command')
 
         try:
-            os.makedirs(self.config.artifact_dir, mode=0o700)
+            original_umask = os.umask(0)
+            os.makedirs(self.config.artifact_dir, mode=0o770)
+            os.umask(original_umask)
         except OSError as exc:
             if exc.errno == errno.EEXIST and os.path.isdir(self.config.artifact_dir):
                 pass
@@ -113,7 +115,9 @@ class Runner(object):
 
         job_events_path = os.path.join(self.config.artifact_dir, 'job_events')
         if not os.path.exists(job_events_path):
-            os.mkdir(job_events_path, 0o700)
+            original_umask = os.umask(0)
+            os.mkdir(job_events_path, 0o770)
+            os.umask(original_umask)
 
         command = self.config.command
         with codecs.open(command_filename, 'w', encoding='utf-8') as f:

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -152,7 +152,10 @@ class Runner(object):
             pexpect_env = os.environ.copy()
             # Write the keys to pass into container to expected file in artifacts dir
             # option expecting should have already been written in ansible_runner.runner_config
-            env_file_host = os.path.join(self.config.private_data_dir, 'env', 'env.list')
+            env_dir = os.path.join(self.config.private_data_dir, 'env')
+            if not os.path.exists(env_dir):
+                os.mkdir(env_dir, 0o700)
+            env_file_host = os.path.join(env_dir, 'env.list')
             with open(env_file_host, 'w') as f:
                 f.write('\n'.join(
                      [f"{k}={v}" for k, v in self.config.env.items()]

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -804,6 +804,7 @@ class RunnerConfig(object):
 
             if 'podman' in self.process_isolation_executable:
                 # container namespace stuff
+                new_args.extend([f'--user={os.getuid()}'])
                 new_args.extend(["--userns=keep-id"])
                 new_args.extend(["--ipc=host"])
 

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -837,7 +837,7 @@ class RunnerConfig(object):
 
         # Reference the file with list of keys to pass into container
         # this file will be written in ansible_runner.runner
-        env_file_host = os.path.join(self.artifact_dir, 'env.list')
+        env_file_host = os.path.join(self.private_data_dir, 'env', 'env.list')
         new_args.extend(['--env-file', env_file_host])
 
         if 'podman' in self.process_isolation_executable:

--- a/ansible_runner/runner_config.py
+++ b/ansible_runner/runner_config.py
@@ -822,7 +822,9 @@ class RunnerConfig(object):
         else:
             subdir_path = os.path.join(self.private_data_dir, 'artifacts')
             if not os.path.exists(subdir_path):
-                os.mkdir(subdir_path, 0o700)
+                original_umask = os.umask(0)
+                os.mkdir(subdir_path, 0o770)
+                os.umask(original_umask)
 
             # Mount the entire private_data_dir
             # custom show paths inside private_data_dir do not make sense
@@ -843,6 +845,9 @@ class RunnerConfig(object):
         if 'podman' in self.process_isolation_executable:
             # docker doesnt support this option
             new_args.extend(['--quiet'])
+
+            # Podman < 2.2 does not respect extra groups added in the Dockerfile
+            new_args.extend(['--group-add=root'])
 
         if 'docker' in self.process_isolation_executable:
             new_args.extend([f'--user={os.getuid()}'])

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -233,7 +233,9 @@ class Processor(object):
     def run(self):
         job_events_path = os.path.join(self.artifact_dir, 'job_events')
         if not os.path.exists(job_events_path):
-            os.makedirs(job_events_path, 0o700, exist_ok=True)
+            original_umask = os.umask(0)
+            os.makedirs(job_events_path, 0o770, exist_ok=True)
+            os.umask(original_umask)
 
         while True:
             try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,12 +12,13 @@
 # W291 - Trailing whitespace
 # W391 - Blank line at end of file
 # W293 - Blank line contains whitespace
-ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,W291,W391,W293
+# W504 - Line break before binary operator
+ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,W291,W391,W293,W504
 exclude=.tox,venv
 
 [flake8]
 max-line-length=160
-ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,W291,W391,W293,E731,F405
+ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,W291,W391,W293,E731,F405,W504
 exclude=.tox,venv
 
 [metadata]

--- a/test/unit/test_runner_config.py
+++ b/test/unit/test_runner_config.py
@@ -643,7 +643,7 @@ def test_containerization_settings(tmpdir, container_runtime):
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
         ['-v', '{}:/runner:Z'.format(rc.private_data_dir)] + \
         ['-v', '/host1:/container1', '-v', 'host2:/container2'] + \
-        ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
+        ['--env-file', '{}'.format(os.path.join(rc.private_data_dir, 'env', 'env.list'))] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \
         ['my_container', 'ansible-playbook', '-i', '/runner/inventory/hosts', 'main.yaml']

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -15,12 +15,12 @@ cat << EOF > /etc/passwd
 root:x:0:0:root:/root:/bin/bash
 runner:x:`id -u`:`id -g`:,,,:/home/runner:/bin/bash
 EOF
-    fi
 
 cat <<EOF > /etc/group
 root:x:0:runner
 runner:x:`id -g`:
 EOF
+    fi
 
 fi
 


### PR DESCRIPTION
Potential solution for https://github.com/ansible/ansible-runner/issues/611

### Testing

#### Podman

```
$ CONTAINER_ENGINE=podman make image
$ ansible-runner run --process-isolation demo -p test.yml
$ ansible-runner playbook demo/project/test.yml -i 'localhost,' -c local
```

#### Docker

```
$ make image
$ ansible-runner run --process-isolation --process-isolation-executable=docker demo -p test.yml
$ ansible-runner playbook --keep-files --container-runtime=docker demo/project/test.yml -i 'localhost,' -c local
```
