### PR TITLE
Revert "Move ARGs to top of Dockerfile to make it build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-ARG ANSIBLE_BRANCH=""
-ARG ZUUL_SIBLINGS=""
 ARG ANSIBLE_CORE_IMAGE=quay.io/ansible/ansible-core:latest
 
 FROM quay.io/ansible/python-builder:latest as builder
 # =============================================================================
 
+ARG ANSIBLE_BRANCH=""
+ARG ZUUL_SIBLINGS=""
 COPY . /tmp/src
 RUN if [ "$ANSIBLE_BRANCH" == "stable-2.9" ] ; then \
       echo "Installing requirements.txt / upper-constraints.txt for Ansible $ANSIBLE_BRANCH" ; \


### PR DESCRIPTION
This partially reverts commit ea43488b728f7ecaa030d2e5178b4266220f85de.

We only need to move our ANSIBLE_CORE_IMAGE ARG to the top of the file,
we still need ZUUL_SIGLINGS / ANSIBLE_BRANCH scoped for the first layer.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>