### PR TITLE
Create PYTHON_BUILDER_IMAGE build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG ANSIBLE_CORE_IMAGE=quay.io/ansible/ansible-core:latest
+ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
 
-FROM quay.io/ansible/python-builder:latest as builder
+FROM $PYTHON_BUILDER_IMAGE as builder
 # =============================================================================
 
 ARG ANSIBLE_BRANCH=""


### PR DESCRIPTION
This allows a user, do define their own python-builder image, say to
support Fedora or UBI.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>