### PR TITLE
[WIP]Add runner API support for command line execution

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -813,7 +813,10 @@ def main(sys_args=None):
     cli_execenv_cmd = ""
 
     if vargs.get('command') in ('adhoc', 'playbook'):
-        cli_execenv_cmd = vargs.get('command')
+        cli_execenv_cmd = {
+            'adhoc': 'ansible adhoc',
+            'playbook': 'ansible-playbook'
+        }.get(vargs['command'])
 
         if not leftover_args:
             parser.exit(

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -814,7 +814,7 @@ def main(sys_args=None):
 
     if vargs.get('command') in ('adhoc', 'playbook'):
         cli_execenv_cmd = {
-            'adhoc': 'ansible adhoc',
+            'adhoc': 'ansible',
             'playbook': 'ansible-playbook'
         }.get(vargs['command'])
 
@@ -929,7 +929,10 @@ def main(sys_args=None):
                                    cli_execenv_cmd=cli_execenv_cmd
                                    )
                 if vargs.get('command') in ('adhoc', 'playbook'):
-                    run_options['cmdline'] = sys.argv[sys.argv.index(leftover_args[0]):]
+                    if vargs.get('command') == 'adhoc':
+                        run_options['cmdline'] = 'adhoc' + sys.argv[sys.argv.index(leftover_args[0]):]
+                    else:
+                        run_options['cmdline'] = sys.argv[sys.argv.index(leftover_args[0]):]
                     run_options['process_isolation']=True
                     run_options['process_isolation_executable']=vargs.get('container_runtime')
 

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -190,7 +190,9 @@ def run(**kwargs):
     :param only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
     :param cli_execenv_cmd: Tells Ansible Runner to emulate the CLI of Ansible by prepping an Execution Environment and then passing the user provided cmdline.
                             Allows executing a python script by passing the full executable path and aribary pass through commands.
-    :param cli_execenv_cmd_cwd: Tells Ansible Runner the current working directory for the command provided by ``cli_execenv_cmd``.
+    :param cli_execenv_cmd_cwd: Tells Ansible Runner the current local working directory for the command provided by ``cli_execenv_cmd``.
+    :param cli_execenv_cmd_containter_workdir: Applicable only for command provided by ``cli_execenv_cmd`` parameter and running within a container.
+                                               Tells Ansible Runner the work directory to use within container.
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -239,6 +241,7 @@ def run(**kwargs):
     :type only_failed_event_data: bool
     :type cli_execenv_cmd: str
     :type cli_execenv_cmd_cwd: str
+    : type cli_execenv_cmd_containter_workdir: str
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing `rc` if run remotely
     '''

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -188,7 +188,9 @@ def run(**kwargs):
     :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
     :param only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
-    :param cli_execenv_cmd: Tells Ansible Runner to emulate the CLI of Ansible by prepping an Execution Environment and then passing the user provided cmdline
+    :param cli_execenv_cmd: Tells Ansible Runner to emulate the CLI of Ansible by prepping an Execution Environment and then passing the user provided cmdline.
+                            Allows executing a python script by passing the full executable path and aribary pass through commands.
+    :param cli_execenv_cmd_cwd: Tells Ansible Runner the current working directory for the command provided by ``cli_execenv_cmd``.
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -236,6 +238,7 @@ def run(**kwargs):
     :type omit_event_data: bool
     :type only_failed_event_data: bool
     :type cli_execenv_cmd: str
+    :type cli_execenv_cmd_cwd: str
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing `rc` if run remotely
     '''

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -11,6 +11,8 @@ interface to the results of executing the **Ansible** command.
 **Ansible Runner** itself is a wrapper around **Ansible** execution and so adds plugins and interfaces to the system in order to gather extra information and
 process/store it for use later.
 
+**Ansible Runner** can be used to execute ansible command line utilities either within an execution enviornment or on the local system usinf API.
+
 Helper Interfaces
 -----------------
 
@@ -51,6 +53,14 @@ properties:
 
 The :class:`Runner <ansible_runner.runner.Runner>` object contains a property :attr:`ansible_runner.runner.Runner.stdout` which will return an open file
 handle containing the ``stdout`` of the **Ansible** process.
+
+``Runner.stderr``
+-----------------
+
+The :class:`Runner <ansible_runner.runner.Runner>` object contains a property :attr:`ansible_runner.runner.Runner.stderr` which will return an open file
+handle containing the ``stderr`` of the **Ansible** process to output the error. This is applicable only when runner is used to run command line utilites in non interactive mode 
+like ``ansible-config``, ``ansible-doc``, ``ansible-galaxy``, ``ansible-inventory``, ``ansible-vault`` and ``ansible`` --version that does not require handling of CLI
+prompts.
 
 ``Runner.events``
 -----------------
@@ -127,6 +137,74 @@ Usage examples
       print(each_host_event['event'])
   print("Final status:")
   print(r.stats)
+
+.. code-block:: python
+
+  # run ansible-doc command within execution enviornment in non interactive mode
+  import ansible_runner
+  r = ansible_runner.run(
+      private_data_dir='/tmp/demo',
+      cli_execenv_cmd='ansible-doc',
+      cmdline=['-j', '-F'],
+      process_isolation=True,
+      container_image='network-ee'
+    )
+  print("STDOUT: {}".format(r.stdout.read()))
+  print("STDERR: {}".format(r.stderr.read()))
+
+.. code-block:: python
+
+  # run ansible-doc command within local environment
+  import ansible_runner
+  r = ansible_runner.run(
+      private_data_dir='/tmp/demo',
+      cli_execenv_cmd='ansible-doc',
+      cmdline=['-j', '-F'],
+    )
+  print("STDOUT: {}".format(r.stdout.read()))
+  print("STDERR: {}".format(r.stderr.read()))
+
+.. code-block:: python
+
+  # run python script within execution environment in non interactive mode
+  import ansible_runner
+  r = ansible_runner.run(
+      private_data_dir='/tmp/demo',
+      cli_execenv_cmd='/usr/bin/python3.8',
+      cmdline=['test_ee.py'],
+      process_isolation=True,
+      container_image='network-ee'
+    )
+  print("STDOUT: {}".format(r.stdout.read()))
+  print("STDERR: {}".format(r.stderr.read()))
+
+.. code-block:: python
+
+  # run command within execution environment in non interactive mode
+  import ansible_runner
+  r = ansible_runner.run(
+      private_data_dir='/tmp/demo',
+      cli_execenv_cmd='/usr/bin/cat',
+      cmdline=['/etc/os-release'],
+      process_isolation=True,
+      container_image='network-ee'
+    )
+  print("STDOUT: {}".format(r.stdout.read()))
+  print("STDERR: {}".format(r.stderr.read()))
+
+.. code-block:: python
+
+  # run command within execution environment in non interactive mode
+  import ansible_runner
+  r = ansible_runner.run(
+      private_data_dir='/tmp/demo',
+      cli_execenv_cmd='/usr/bin/cat',
+      cmdline=['/etc/os-release'],
+      process_isolation=True,
+      container_image='network-ee'
+    )
+  print("STDOUT: {}".format(r.stdout.read()))
+  print("STDERR: {}".format(r.stderr.read()))
 
 Providing custom behavior and inputs
 ------------------------------------


### PR DESCRIPTION
* Update runner API's to support executing commands
  within EE and locally

* Add `CLI_EXECENV_NON_INTERACTIVE` execution mode to support
  running ansible command-line utilities within EE
  and local environments in non-interactive mode
  (that is commands that don't require CLI prompt handling)

* Add `CLI_EXECENV_SCRIPT_EXECUTION` execution mode to support
  running python script within EE

* Add `CLI_EXECENV_PASS_THROUGH_COMMAND` execution mode to support
  executing arbitrary commands within EE

* Update docs