### PR TITLE
Remove ubi8 images from ansible-runner

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -5,7 +5,7 @@
     description: Base ansible-runner container image
     required-projects:
       - name: github.com/ansible/ansible-runner
-    timeout: 2700
+    timeout: 3600
     vars:
       zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-runner'].src_dir }}"
 
@@ -41,43 +41,6 @@
     requires:
       - ansible-core-container-image
     vars: *ansible_runner_image_vars
-
-- job:
-    name: ansible-runner-upload-container-image
-    parent: ansible-runner-container-image-base
-
-# =============================================================================
-
-- job:
-    name: ansible-runner-ubi8-build-container-image
-    parent: ansible-build-container-image
-    provides:
-      - ansible-runner-ubi8-container-image
-    requires:
-      - ansible-core-ubi8-container-image
-    vars: &ansible_runner_ubi8_image_vars
-      container_images: &container_images_ubi8
-        - context: .
-          build_args:
-            - ANSIBLE_CORE_IMAGE=quay.io/ansible/ansible-core:ubi8
-            - PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:ubi8
-          registry: quay.io
-          repository: quay.io/ansible/ansible-runner
-          tags: ['ubi8']
-      docker_images: *container_images_ubi8
-
-- job:
-    name: ansible-runner-ubi8-build-container-image
-    parent: ansible-runner-container-image-base
-
-- job:
-    name: ansible-runner-ubi8-upload-container-image
-    parent: ansible-upload-container-image
-    provides:
-      - ansible-runner-ubi8-container-image
-    requires:
-      - ansible-core-ubi8-container-image
-    vars: *ansible_runner_ubi8_image_vars
 
 - job:
     name: ansible-runner-upload-container-image

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,7 +3,6 @@
     check:
       jobs: &id001
         - ansible-runner-build-container-image
-        - ansible-runner-ubi8-build-container-image
         - ansible-runner-build-container-image-stable-2.9
         - ansible-runner-build-container-image-stable-2.10
     gate:
@@ -11,9 +10,6 @@
     post:
       jobs: &id002
         - ansible-runner-upload-container-image:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-ubi8-upload-container-image:
             vars:
               upload_container_image_promote: false
         - ansible-runner-upload-container-image-stable-2.9:


### PR DESCRIPTION
Due to how EULA and ubi8 works, we really cannot support / redistribute
all the needed RHEL packages. Lets drop this and focus on centos8
stream.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>