### PR TITLE
Remove demo directory from container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ COPY --from=builder /output/ /output
 RUN /output/install-from-bindep \
   && rm -rf /output
 
-# Prepare the /runner folder, seed the folder with demo data
-ADD demo /runner
-
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
 RUN for dir in \

--- a/docs/container.rst
+++ b/docs/container.rst
@@ -9,10 +9,7 @@ is also published to `DockerHub <https://hub.docker.com/r/ansible/ansible-runner
 
 .. code-block:: console
 
-  $ docker run --rm -e RUNNER_PLAYBOOK=test.yml ansible/ansible-runner:latest
-    Unable to find image 'ansible/ansible-runner:latest' locally                                          
-    latest: Pulling from ansible/ansible-runner
-    [...]
+  $ docker run --rm -e RUNNER_PLAYBOOK=test.yml -v $PWD/demo:/runner quay.io/ansible/ansible-runner:latest
     PLAY [all] *********************************************************************
     
     TASK [Gathering Facts] *********************************************************


### PR DESCRIPTION
This is proving to be problematic for us in AWX 18. I'm trying to use /runner as
the private data dir location, but since stuff is already there, the new
ansible-runner streaming interface is blowing up.