### PR TITLE
Make sure we import from non-deprecated module

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -3,7 +3,7 @@ import shutil
 
 import pytest
 import pexpect
-from ansible_runner.runner_config import RunnerConfig
+from ansible_runner.config.runner import RunnerConfig
 
 
 @pytest.fixture(scope='function')

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -11,7 +11,7 @@ from pexpect import TIMEOUT, EOF
 import pytest
 from unittest.mock import (Mock, patch, PropertyMock)
 
-from ansible_runner.runner_config import RunnerConfig, ExecutionMode
+from ansible_runner.config.runner import RunnerConfig, ExecutionMode
 from ansible_runner.interface import init_runner
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.exceptions import ConfigurationError

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -12,7 +12,7 @@ import sys
 
 from ansible_runner import Runner
 from ansible_runner.exceptions import CallbackError
-from ansible_runner.runner_config import RunnerConfig
+from ansible_runner.config.runner import RunnerConfig
 
 HERE, FILENAME = os.path.split(__file__)
 


### PR DESCRIPTION
https://github.com/ansible/ansible-runner/blob/830c82809fbb37085c09bdfc1f51fe6c2158e826/ansible_runner/runner_config.py#L20-L21

Just as a matter of consistent messaging I'd prefer to nuke the old import pattern.

Ping @ganeshrn