### PR TITLE
Add missing ARG ANSIBLE_BRANCH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG ZUUL_SIBLINGS=""
 
 FROM $PYTHON_BUILDER_IMAGE as builder
 # =============================================================================
+ARG ANSIBLE_BRANCH
+ARG ZUUL_SIBLINGS
 
 COPY . /tmp/src
 RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \


### PR DESCRIPTION
We were referecing a missing ARG, which breaks on newer versions of
podman.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>