### PR TITLE
Fix ZUUL_SIBLINGS and ANSIBLE_BRANCH ARGs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ARG ZUUL_SIBLINGS=""
 
 FROM $PYTHON_BUILDER_IMAGE as builder
 # =============================================================================
+ARG ANSIBLE_BRANCH
+ARG ZUUL_SIBLINGS
 
 COPY . /tmp/src
 RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \


### PR DESCRIPTION
We didn't correctly expose these 2 ARGs for our Dockerfile to work
properly. This should mean depends-on again for Zuul CI works, along
with the proper version of ansible in our images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>