### PR TITLE
Add upstream cachito requirement files

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -12,3 +12,8 @@ python38-jinja2 [platform:centos-8]
 python38-pycparser [platform:centos-8]
 python38-six [platform:centos-8]
 python38-yaml [platform:centos-8]
+
+# paramiko
+gcc [compile platform:centos-8 platform:rhel-8]
+make [compile platform:centos-8 platform:rhel-8]
+python38-devel [compile platform:centos-8 platform:rhel-8]

--- a/tools/cachito/requirements.txt
+++ b/tools/cachito/requirements.txt
@@ -1,0 +1,3 @@
+bcrypt==3.2.0
+paramiko==2.7.2
+pynacl==1.4.0

--- a/tools/cachito/setup.cfg
+++ b/tools/cachito/setup.cfg
@@ -1,0 +1,5 @@
+# NOTE(pabelanger): This file is needed by cachito, to be able to pull in
+# python requirements.txt files.
+[metadata]
+name = ansible-runner
+version = 0.0.1

--- a/tools/requirements-stable-2.10.txt
+++ b/tools/requirements-stable-2.10.txt
@@ -1,1 +1,2 @@
 ansible-base
+paramiko

--- a/tools/requirements-stable-2.11.txt
+++ b/tools/requirements-stable-2.11.txt
@@ -1,1 +1,2 @@
 ansible-core
+paramiko

--- a/tools/requirements-stable-2.9.txt
+++ b/tools/requirements-stable-2.9.txt
@@ -1,1 +1,2 @@
 ansible
+paramiko

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,2 @@
 ansible-core
+paramiko


### PR DESCRIPTION
For downstream builds, we need a set of pinned requirements to pass
cachito. This is the first step to upstream some of that logic.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>