### PR TITLE
Add ncclient / pypsrp / pywinrm python dependencies

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -13,7 +13,13 @@ python38-pycparser [platform:centos-8]
 python38-six [platform:centos-8]
 python38-yaml [platform:centos-8]
 
+# ncclient
+python38-lxml [platform:centos-8 platform:rhel-8]
+
 # paramiko
 gcc [compile platform:centos-8 platform:rhel-8]
 make [compile platform:centos-8 platform:rhel-8]
 python38-devel [compile platform:centos-8 platform:rhel-8]
+
+# pypsrp
+python38-requests [platform:centos-8 platform:rhel-8]

--- a/tools/cachito/requirements.txt
+++ b/tools/cachito/requirements.txt
@@ -1,3 +1,10 @@
 bcrypt==3.2.0
+ncclient==0.6.10
+ntlm-auth==1.5.0
 paramiko==2.7.2
 pynacl==1.4.0
+pypsrp==0.5.0
+pyspnego==0.1.5
+pywinrm==0.4.1
+requests-ntlm==1.1.0
+xmltodict==0.12.0

--- a/tools/requirements-stable-2.10.txt
+++ b/tools/requirements-stable-2.10.txt
@@ -1,2 +1,5 @@
 ansible-base
+ncclient
 paramiko
+pypsrp
+pywinrm

--- a/tools/requirements-stable-2.11.txt
+++ b/tools/requirements-stable-2.11.txt
@@ -1,2 +1,5 @@
 ansible-core
+ncclient
 paramiko
+pypsrp
+pywinrm

--- a/tools/requirements-stable-2.9.txt
+++ b/tools/requirements-stable-2.9.txt
@@ -1,2 +1,5 @@
 ansible
+ncclient
 paramiko
+pypsrp
+pywinrm

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,2 +1,5 @@
 ansible-core
+ncclient
 paramiko
+pypsrp
+pywinrm


### PR DESCRIPTION
These are dependencies of ansible-core, which we also need to ship for
execution environments.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>