### PR TITLE
fix duplicate volume mounts for containers, simplify conditional

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -314,6 +314,14 @@ class BaseConfig(object):
 
         self._ensure_path_safe_to_mount(src_mount_path)
 
+        def _add_trailing_slash_if_neeeded(some_path):
+            if os.path.isdir(src_mount_path):
+                return some_path + '/' if (some_path[-1] != '/') else some_path
+            else:
+                return some_path
+
+        src_mount_path = _add_trailing_slash_if_neeeded(src_mount_path)
+
         if os.path.isabs(src_mount_path):
             if os.path.isdir(src_mount_path):
                 volume_mount_path = "{}:{}".format(src_mount_path, dest_mount_path)
@@ -332,7 +340,7 @@ class BaseConfig(object):
             volume_mount_path += labels
 
         # check if mount path already added in args list
-        if ', '.join(map(str, ['-v', volume_mount_path])) not in ', '.join(map(str, args_list)):
+        if volume_mount_path not in args_list:
             args_list.extend(['-v', volume_mount_path])
 
     def _handle_ansible_cmd_options_bind_mounts(self, args_list, cmdline_args):

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -303,6 +303,14 @@ class BaseConfig(object):
 
         return _playbook
 
+
+    def _add_trailing_slash_if_neeeded(self, some_path):
+        if os.path.isdir(some_path):
+            return some_path + '/' if (some_path[-1] != '/') else some_path
+        else:
+            return some_path
+
+
     def _update_volume_mount_paths(self, args_list, src_mount_path, dest_mount_path=None, labels=None):
 
         if src_mount_path is None or not os.path.exists(src_mount_path):
@@ -314,13 +322,7 @@ class BaseConfig(object):
 
         self._ensure_path_safe_to_mount(src_mount_path)
 
-        def _add_trailing_slash_if_neeeded(some_path):
-            if os.path.isdir(src_mount_path):
-                return some_path + '/' if (some_path[-1] != '/') else some_path
-            else:
-                return some_path
-
-        src_mount_path = _add_trailing_slash_if_neeeded(src_mount_path)
+        src_mount_path = self._add_trailing_slash_if_neeeded(src_mount_path)
 
         if os.path.isabs(src_mount_path):
             if os.path.isdir(src_mount_path):


### PR DESCRIPTION
Uniformally handle dir paths that do have a trailing / and don't, but
are in fact the same path which are passed in or detected as duplicates
when constructing the list of volume mounts for containerized process
 isolation.

Previously the BaseConfig._update_volume_mount_paths() method was using
this expression to check for a potentially duplicate path but the extra
processing of the map() and join() function calls are not needed since
the format src_mount_path:dest_mount_path stored in volume_mount_path is
already an element of arg_list and no transformation is necessary.

```
-        if ', '.join(map(str, ['-v', volume_mount_path])) not in ', '.join(map(str, args_list)):
+        if volume_mount_path not in args_list:
```

Signed-off-by: Adam Miller <admiller@redhat.com>