### PR TITLE
Don't use wheels for ansible-runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,13 @@ RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \
     else \
       echo "Installing requirements.txt" ; \
       cp /tmp/src/tools/requirements.txt /tmp/src/requirements.txt ; \
-    fi
+    fi \
+    && cp /tmp/src/tools/build-requirements.txt /tmp/src/build-requirements.txt
+
+# NOTE(pabelanger): For downstream builds, we compile everything from source
+# over using existing wheels. Do this upstream too so we can better catch
+# issues.
+ENV PIP_OPTS="--no-binary :all: --no-build-isolation"
 RUN assemble
 
 FROM $PYTHON_BASE_IMAGE

--- a/tools/build-requirements.txt
+++ b/tools/build-requirements.txt
@@ -1,0 +1,1 @@
+flit-core  # ptyprocess


### PR DESCRIPTION
This brings upstream / downstream builds closer into alignment.
Hopefully helping us catch issues upstream before downstream.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>