### PR TITLE
Partial revert "Don't use wheels for ansible-runner image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \
 # NOTE(pabelanger): For downstream builds, we compile everything from source
 # over using existing wheels. Do this upstream too so we can better catch
 # issues.
-ENV PIP_OPTS="--no-binary :all: --no-build-isolation"
+ENV PIP_OPTS=--no-build-isolation
 RUN assemble
 
 FROM $PYTHON_BASE_IMAGE


### PR DESCRIPTION
It seems --no-binary :all: had a side effect I didn't fully understand.
Given we don't actually pass that downstream, just --no-build-isolation
lets do that.

We'll deal with skipping wheels in another patch.

This reverts commit 305fcf358e8de3f1659e74c73fa3cc599e93f004.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>