### PR TITLE
Bump timeout on container build jobs

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -5,7 +5,7 @@
     description: Base ansible-runner container image
     required-projects:
       - name: github.com/ansible/ansible-runner
-    timeout: 3600
+    timeout: 5400
     vars:
       zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-runner'].src_dir }}"
 


### PR DESCRIPTION
Give us a little more buffer when running container jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>