### PR TITLE
Add return code for run_command interface

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -366,14 +366,15 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :type status_handler: function
     :type artifacts_handler: function
 
-    :returns: Returns a tuple of return code, response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
+    :returns: Returns a tuple of response, error string and return code.
+              In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
               ``pexpect`` uses same output descriptor for stdout and stderr.
     '''
     r = init_command_config(executable_cmd, cmdline_args=cmdline_args, **kwargs)
     r.run()
     response = r.stdout.read()
     error = r.stderr.read()
-    return r.rc, response, error
+    return response, error, r.rc
 
 
 def run_command_async(executable_cmd, cmdline_args=None, **kwargs):

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -366,7 +366,7 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :type status_handler: function
     :type artifacts_handler: function
 
-    :returns: Retunes a tuple of return code, response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
+    :returns: Returns a tuple of return code, response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
               ``pexpect`` uses same output descriptor for stdout and stderr.
     '''
     r = init_command_config(executable_cmd, cmdline_args=cmdline_args, **kwargs)

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -366,14 +366,14 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :type status_handler: function
     :type artifacts_handler: function
 
-    :returns: Retunes a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
+    :returns: Retunes a tuple of return code, response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
               ``pexpect`` uses same output descriptor for stdout and stderr.
     '''
     r = init_command_config(executable_cmd, cmdline_args=cmdline_args, **kwargs)
     r.run()
     response = r.stdout.read()
     error = r.stderr.read()
-    return response, error
+    return r.rc, response, error
 
 
 def run_command_async(executable_cmd, cmdline_args=None, **kwargs):

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -142,12 +142,13 @@ def test_run_command(test_data_dir):
     private_data_dir = os.path.join(test_data_dir, 'debug')
     inventory = os.path.join(private_data_dir, 'inventory', 'inv_1')
     playbook = os.path.join(private_data_dir, 'project', 'debug.yml')
-    out, err = run_command(
+    rc, out, err = run_command(
         private_data_dir=private_data_dir,
         executable_cmd='ansible-playbook',
         cmdline_args=[playbook, '-i', inventory]
     )
     assert "Hello world!" in out
+    assert rc == 0
     assert err == ''
 
 
@@ -160,13 +161,14 @@ def test_run_ansible_command_within_container(test_data_dir, container_runtime_i
         'process_isolation': True,
         'container_image': defaults.default_container_image
     }
-    out, err = run_command(
+    rc, out, err = run_command(
         private_data_dir=private_data_dir,
         executable_cmd='ansible-playbook',
         cmdline_args=[playbook, '-i', inventory],
         **container_kwargs
     )
     assert "Hello world!" in out
+    assert rc == 0
     assert err == ''
 
 
@@ -180,7 +182,7 @@ def test_run_script_within_container(test_data_dir, container_runtime_installed)
         'container_image': defaults.default_container_image,
         'container_volume_mounts': container_volume_mounts
     }
-    out, _ = run_command(
+    rc, out, _ = run_command(
         private_data_dir=private_data_dir,
         executable_cmd='python3',
         cmdline_args=[os.path.join(script_path, 'test_ee.py')],
@@ -188,6 +190,7 @@ def test_run_script_within_container(test_data_dir, container_runtime_installed)
     )
 
     assert "os-release" in out
+    assert rc == 0
 
 
 def test_run_command_async(test_data_dir):

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -142,7 +142,7 @@ def test_run_command(test_data_dir):
     private_data_dir = os.path.join(test_data_dir, 'debug')
     inventory = os.path.join(private_data_dir, 'inventory', 'inv_1')
     playbook = os.path.join(private_data_dir, 'project', 'debug.yml')
-    rc, out, err = run_command(
+    out, err, rc = run_command(
         private_data_dir=private_data_dir,
         executable_cmd='ansible-playbook',
         cmdline_args=[playbook, '-i', inventory]
@@ -182,7 +182,7 @@ def test_run_script_within_container(test_data_dir, container_runtime_installed)
         'container_image': defaults.default_container_image,
         'container_volume_mounts': container_volume_mounts
     }
-    rc, out, _ = run_command(
+    out, _, rc = run_command(
         private_data_dir=private_data_dir,
         executable_cmd='python3',
         cmdline_args=[os.path.join(script_path, 'test_ee.py')],


### PR DESCRIPTION
*  Update the return value to run_command
   interface API to return the return code
   from the process that excecutes the command