### PR TITLE
Fix private_data_dir and artifact_dir already exists issue

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -118,10 +118,8 @@ class BaseConfig(object):
         else:
             self.cwd = os.getcwd()
 
-        if not os.path.exists(self.private_data_dir):
-            os.makedirs(self.private_data_dir, mode=0o700)
-        if not os.path.exists(self.artifact_dir):
-            os.makedirs(self.artifact_dir, mode=0o700)
+        os.makedirs(self.private_data_dir, exist_ok=True, mode=0o700)
+        os.makedirs(self.artifact_dir, exist_ok=True, mode=0o700)
 
     _CONTAINER_ENGINES = ('docker', 'podman')
 

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -242,7 +242,8 @@ def test_wrap_args_with_ssh_agent_silent():
 
 @patch('os.path.isdir', return_value=False)
 @patch('os.path.exists', return_value=True)
-def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmpdir):
+@patch('os.makedirs', return_value=True)
+def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, mock_makedirs, tmpdir):
     rc = BaseConfig(private_data_dir=str(tmpdir))
     os.path.isdir = Mock()
     rc.container_volume_mounts = ['project_path:project_path:Z']

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -538,7 +538,8 @@ def test_bwrap_process_isolation_and_directory_isolation(mock_makedirs, mock_cop
 
 @patch('os.path.isdir', return_value=False)
 @patch('os.path.exists', return_value=True)
-def test_process_isolation_settings(mock_isdir, mock_exists):
+@patch('os.makedirs', return_value=True)
+def test_process_isolation_settings(mock_isdir, mock_exists, mock_makedirs):
     rc = RunnerConfig('/')
     rc.artifact_dir = '/tmp/artifacts'
     rc.playbook = 'main.yaml'


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-runner/issues/694

*  While running on muliple processor the `os.path.exists()`
   can be bypassed. If private_data_dir and artifact_dir
   already exist can catch the execption and ignore the error.