### PR TITLE
Add timeout parameter in the interface

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -167,8 +167,10 @@ class BaseConfig(object):
                 self.expect_passwords.update(self.passwords)
 
             self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
-
+            self.pexpect_timeout = self.settings.get('pexpect_timeout', 5)
+            self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
             self.idle_timeout = self.settings.get('idle_timeout', None)
+ 
             if self.timeout:
                 self.job_timeout = int(self.timeout)
             else:

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -162,10 +162,6 @@ class BaseConfig(object):
             self.expect_passwords[pexpect.EOF] = None
 
             self.pexpect_timeout = self.settings.get('pexpect_timeout', 5)
-
-            if self.passwords:
-                self.expect_passwords.update(self.passwords)
-
             self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
             self.pexpect_timeout = self.settings.get('pexpect_timeout', 5)
             self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -58,7 +58,7 @@ class BaseConfig(object):
                  project_dir=None, artifact_dir=None, fact_cache_type='jsonfile', fact_cache=None,
                  process_isolation=False, process_isolation_executable=None,
                  container_image=None, container_volume_mounts=None, container_options=None, container_workdir=None,
-                 ident=None, rotate_artifacts=0, ssh_key=None, quiet=False, json_mode=False):
+                 ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False):
         # common params
         self.host_cwd = host_cwd
         self.envvars = envvars
@@ -81,6 +81,7 @@ class BaseConfig(object):
         self.json_mode=json_mode
         self.passwords = passwords
         self.settings = settings
+        self.timeout = timeout
 
         # setup initial environment
         if private_data_dir:
@@ -161,13 +162,23 @@ class BaseConfig(object):
             self.expect_passwords[pexpect.EOF] = None
 
             self.pexpect_timeout = self.settings.get('pexpect_timeout', 5)
+
+            if self.passwords:
+                self.expect_passwords.update(self.passwords)
+
             self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
 
             self.idle_timeout = self.settings.get('idle_timeout', None)
-            self.job_timeout = self.settings.get('job_timeout', None)
+            if self.timeout:
+                self.job_timeout = int(self.timeout)
+            else:
+                self.job_timeout = self.settings.get('job_timeout', None)
 
         elif self.runner_mode == 'subprocess':
-            self.subprocess_timeout = self.settings.get('subprocess_timeout', None)
+            if self.timeout:
+                self.subprocess_timeout = int(self.timeout)
+            else:
+                self.subprocess_timeout = self.settings.get('subprocess_timeout', None)
 
         self.process_isolation = self.settings.get('process_isolation', self.process_isolation)
         self.process_isolation_executable = self.settings.get('process_isolation_executable', self.process_isolation_executable)

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -165,7 +165,8 @@ def run(**kwargs):
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
     :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
-                    (based on ``runner_mode`` selected) while executing command.
+                    (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
+                    execution.
     :param streamer: Optionally invoke ansible-runner as one of the steps in the streaming pipeline
     :param _input: An optional file or file-like object for use as input in a streaming pipeline
     :param _output: An optional file or file-like object for use as output in a streaming pipeline
@@ -319,7 +320,8 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
     :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
-                    (based on ``runner_mode`` selected) while executing command.
+                    (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
+                    execution.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -449,7 +451,8 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
     :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
-                    (based on ``runner_mode`` selected) while executing command.
+                    (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
+                    execution.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -560,7 +563,8 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
     :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
-                    (based on ``runner_mode`` selected) while executing command.
+                    (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
+                    execution.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -673,7 +677,8 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
     :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
-                    (based on ``runner_mode`` selected) while executing command.
+                    (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
+                    execution.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -782,7 +787,8 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
     :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
-                    (based on ``runner_mode`` selected) while executing command.
+                    (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
+                    execution.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -164,6 +164,8 @@ def run(**kwargs):
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+                    (based on ``runner_mode`` selected) while executing command.
     :param streamer: Optionally invoke ansible-runner as one of the steps in the streaming pipeline
     :param _input: An optional file or file-like object for use as input in a streaming pipeline
     :param _output: An optional file or file-like object for use as output in a streaming pipeline
@@ -207,6 +209,7 @@ def run(**kwargs):
     :type artifact_dir: str
     :type project_dir: str
     :type rotate_artifacts: int
+    :type timeout: int
     :type cmdline: str
     :type limit: str
     :type forks: int
@@ -315,6 +318,8 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+                    (based on ``runner_mode`` selected) while executing command.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -356,6 +361,7 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :type container_workdir: str
     :type ident: str
     :type rotate_artifacts: int
+    :type timeout: int
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
@@ -442,6 +448,8 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+                    (based on ``runner_mode`` selected) while executing command.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -484,6 +492,7 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :type container_workdir: str
     :type ident: str
     :type rotate_artifacts: int
+    :type timeout: int
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
@@ -550,6 +559,8 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+                    (based on ``runner_mode`` selected) while executing command.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -591,6 +602,7 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :type container_workdir: str
     :type ident: str
     :type rotate_artifacts: int
+    :type timeout: int
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
@@ -660,6 +672,8 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+                    (based on ``runner_mode`` selected) while executing command.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -705,6 +719,7 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :type container_workdir: str
     :type ident: str
     :type rotate_artifacts: int
+    :type timeout: int
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
@@ -766,6 +781,8 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
     :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
     :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+                    (based on ``runner_mode`` selected) while executing command.
     :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
     :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
@@ -805,6 +822,7 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :type container_workdir: str
     :type ident: str
     :type rotate_artifacts: int
+    :type timeout: int
     :type ssh_key: str
     :type quiet: bool
     :type: json_mode: bool

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -110,8 +110,14 @@ def test_prepare_env_passwords():
 def test_prepare_environment_subprocess_defaults():
     rc = BaseConfig(private_data_dir="/tmp")
     rc._prepare_env(runner_mode="subprocess")
-
     assert rc.subprocess_timeout is None
+
+
+def test_prepare_environment_subprocess_timeout():
+    rc = BaseConfig(private_data_dir="/tmp", timeout=100)
+    rc._prepare_env(runner_mode="subprocess")
+
+    assert rc.subprocess_timeout == 100
 
 
 def test_prepare_env_settings_defaults():


### PR DESCRIPTION
*  All timeout parameter for pexpect/subprocess to be passed through
   runner interface
*  Remove default value for subprocess timeout as it results
   in timeout for long running playbooks