### PR TITLE
Add the latest tag to 2.11 image

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -122,7 +122,9 @@
           repository: quay.io/ansible/ansible-runner
           siblings:
             - github.com/ansible/ansible
-          tags: ['stable-2.11-devel']
+          tags:
+            - stable-2.11-devel
+            - latest
       docker_images: *container_images_stable_2_11
 
 - job:


### PR DESCRIPTION
Alternatively, maybe we could add a `release:` job.

I have some issues either way. Here, we are using `devel` of ansible-runner and `stable-2.11` branch of ansible/ansible.

It might be preferable, for the latest tag, to use the ansible-core on PyPI and the latest tagged ansible-runner. As of now, we don't have any ansible-runner tags that work for this, and I also don't know how to re-configure the job to Ansible in some way other than a checkout.

Maybe this works for now.