### PR TITLE
Raise exception if not able to read partial event data

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -58,7 +58,7 @@ class BaseConfig(object):
                  project_dir=None, artifact_dir=None, fact_cache_type='jsonfile', fact_cache=None,
                  process_isolation=False, process_isolation_executable=None,
                  container_image=None, container_volume_mounts=None, container_options=None, container_workdir=None,
-                 ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False):
+                 ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False, check_job_event_data=False):
         # common params
         self.host_cwd = host_cwd
         self.envvars = envvars
@@ -82,6 +82,7 @@ class BaseConfig(object):
         self.passwords = passwords
         self.settings = settings
         self.timeout = timeout
+        self.check_job_event_data = check_job_event_data
 
         # setup initial environment
         if private_data_dir:

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -197,6 +197,9 @@ def run(**kwargs):
     :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
     :param only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
+    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+                                 value is set to 'True' it will raise 'AnsibleRunnerException' exception,
+                                 if set to 'False' it log a debug message and continue execution. Default value is 'False'
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
@@ -244,6 +247,7 @@ def run(**kwargs):
     :type fact_cache_type: str
     :type omit_event_data: bool
     :type only_failed_event_data: bool
+    :type check_job_event_data: bool
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing `rc` if run remotely
     '''
@@ -340,6 +344,10 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
     :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
     :param artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+                                 value is set to 'True' it will raise 'AnsibleRunnerException' exception,
+                                 if set to 'False' it log a debug message and continue execution. Default value is 'False'
+
     :type executable_cmd: str
     :type cmdline_args: list
     :type input_fd: file descriptor
@@ -372,6 +380,7 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :type finished_callback: function
     :type status_handler: function
     :type artifacts_handler: function
+    :type check_job_event_data: bool
 
     :returns: Returns a tuple of response, error string and return code.
               In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
@@ -472,6 +481,10 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
     :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
     :param artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+                                 value is set to 'True' it will raise 'AnsibleRunnerException' exception,
+                                 if set to 'False' it log a debug message and continue execution. Default value is 'False'
+
     :type plugin_names: list
     :type plugin_type: str
     :type response_format: str
@@ -505,6 +518,7 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :type finished_callback: function
     :type status_handler: function
     :type artifacts_handler: function
+    :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
               ``pexpect`` uses same output descriptor for stdout and stderr. If the value of ``response_format`` is ``json``
@@ -584,6 +598,10 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
     :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
     :param artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+                                 value is set to 'True' it will raise 'AnsibleRunnerException' exception,
+                                 if set to 'False' it log a debug message and continue execution. Default value is 'False'
+
     :type list_files: bool
     :type plugin_type: str
     :type response_format: str
@@ -616,6 +634,7 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :type finished_callback: function
     :type status_handler: function
     :type artifacts_handler: function
+    :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
               ``pexpect`` uses same output descriptor for stdout and stderr. If the vaue of ``response_format`` is ``json``
@@ -698,6 +717,9 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
     :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
     :param artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+                                 value is set to 'True' it will raise 'AnsibleRunnerException' exception,
+                                 if set to 'False' it log a debug message and continue execution. Default value is 'False'
     :type action: str
     :type inventories: list
     :type response_format: str
@@ -734,6 +756,7 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :type finished_callback: function
     :type status_handler: function
     :type artifacts_handler: function
+    :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is
               empty as ``pexpect`` uses same output descriptor for stdout and stderr. If the vaue of ``response_format`` is ``json``
@@ -808,6 +831,9 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
     :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
     :param artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+                                 value is set to 'True' it will raise 'AnsibleRunnerException' exception,
+                                 if set to 'False' it log a debug message and continue execution. Default value is 'False'
     :type action: str
     :type config_file: str
     :type only_changed: bool
@@ -838,6 +864,7 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :type finished_callback: function
     :type status_handler: function
     :type artifacts_handler: function
+    :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is
               empty as ``pexpect`` uses same output descriptor for stdout and stderr.

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -72,8 +72,10 @@ class Runner(object):
                     event_data.update(partial_event_data)
                     if self.remove_partials:
                         os.remove(partial_filename)
-                except IOError:
-                    debug("Failed to open ansible stdout callback plugin partial data file {}".format(partial_filename))
+                except IOError as e:
+                    msg = "Failed to open ansible stdout callback plugin partial data" \
+                          " file {} with error {}".format(partial_filename, str(e))
+                    raise AnsibleRunnerException(msg)
 
                 # prefer 'created' from partial data, but verbose events set time here
                 if 'created' not in event_data:

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -75,7 +75,9 @@ class Runner(object):
                 except IOError as e:
                     msg = "Failed to open ansible stdout callback plugin partial data" \
                           " file {} with error {}".format(partial_filename, str(e))
-                    raise AnsibleRunnerException(msg)
+                    debug(msg)
+                    if self.config.check_job_event_data:
+                        raise AnsibleRunnerException(msg)
 
                 # prefer 'created' from partial data, but verbose events set time here
                 if 'created' not in event_data:

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -11,7 +11,7 @@ import six
 import sys
 
 from ansible_runner import Runner
-from ansible_runner.exceptions import CallbackError
+from ansible_runner.exceptions import CallbackError, AnsibleRunnerException
 from ansible_runner.config.runner import RunnerConfig
 
 HERE, FILENAME = os.path.split(__file__)
@@ -101,6 +101,18 @@ def test_env_vars(rc, value):
     assert exitcode == 0
     with codecs.open(os.path.join(rc.artifact_dir, 'stdout'), 'r', encoding='utf-8') as f:
         assert value in f.read()
+
+
+def test_event_callback_data_check(rc):
+    rc.ident = "testident"
+    rc.check_job_event_data = True
+    runner = Runner(config=rc, remove_partials=False)
+    runner.event_handler = mock.Mock()
+
+    with pytest.raises(AnsibleRunnerException) as exc:
+        runner.event_callback(dict(uuid="testuuid", counter=0))
+    
+    assert "Failed to open ansible stdout callback plugin partial data" in str(exc)
 
 
 def test_event_callback_interface_has_ident(rc):


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-runner/issues/718

*  Raise execption if user does not have permissions to read
   the partial event data file instead of silently ignoring it.