### PR TITLE
Add utils/* to data-files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ console_scripts =
 [files]
 packages =
     ansible_runner
+data-files =
+    share/ansible-runner/utils = utils/*
 
 [pep8]
 # E201 - Whitespace after '('


### PR DESCRIPTION
This allows for downstream to properly package these files in RPMs.
Which will be used by containers downstream.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>