### PR TITLE
If private_data_dir not passed default to temp location

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -21,6 +21,7 @@ import os
 import pexpect
 import re
 
+from tempfile import gettempdir
 from uuid import uuid4
 try:
     from collections.abc import Mapping
@@ -87,7 +88,7 @@ class BaseConfig(object):
         if private_data_dir:
             self.private_data_dir = os.path.abspath(private_data_dir)
         else:
-            self.private_data_dir = os.path.abspath(os.path.expanduser('~/.ansible-runner'))
+            self.private_data_dir = os.path.join(gettempdir(), ".ansible-runner")
 
         if artifact_dir is None:
             artifact_dir = os.path.join(self.private_data_dir, 'artifacts')

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -8,6 +8,8 @@ import six
 from pexpect import TIMEOUT, EOF
 
 import pytest
+
+from tempfile import gettempdir
 from unittest.mock import (Mock, patch, PropertyMock)
 
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
@@ -45,7 +47,7 @@ def test_base_config_init_defaults():
 def test_base_config_with_artifact_dir():
     rc = BaseConfig(artifact_dir='/tmp/this-is-some-dir')
     assert rc.artifact_dir == os.path.join('/tmp/this-is-some-dir', rc.ident)
-    assert rc.private_data_dir == os.path.abspath(os.path.expanduser('~/.ansible-runner'))
+    assert rc.private_data_dir == os.path.join(gettempdir(), ".ansible-runner")
 
 
 def test_base_config_init_with_ident():

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -3,6 +3,8 @@
 import os
 import pytest
 
+from tempfile import gettempdir
+
 from ansible_runner.config.ansible_cfg import AnsibleCfgConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
@@ -11,7 +13,7 @@ from ansible_runner.utils import get_executable_path
 
 def test_ansible_cfg_init_defaults():
     rc = AnsibleCfgConfig()
-    assert rc.private_data_dir == os.path.abspath(os.path.expanduser('~/.ansible-runner'))
+    assert rc.private_data_dir == os.path.join(gettempdir(), ".ansible-runner")
     assert rc.execution_mode == BaseExecutionMode.ANSIBLE_COMMANDS
 
 

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -3,6 +3,8 @@
 import os
 import pytest
 
+from tempfile import gettempdir
+
 from ansible_runner.config.command import CommandConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
@@ -10,7 +12,7 @@ from ansible_runner.exceptions import ConfigurationError
 
 def test_ansible_config_defaults():
     rc = CommandConfig()
-    assert rc.private_data_dir == os.path.abspath(os.path.expanduser('~/.ansible-runner'))
+    assert rc.private_data_dir == os.path.join(gettempdir(), ".ansible-runner")
     assert rc.execution_mode == BaseExecutionMode.NONE
     assert rc.runner_mode is None
 

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -3,6 +3,8 @@
 import os
 import pytest
 
+from tempfile import gettempdir
+
 from ansible_runner.config.doc import DocConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
@@ -11,7 +13,7 @@ from ansible_runner.utils import get_executable_path
 
 def test_ansible_doc_defaults():
     rc = DocConfig()
-    assert rc.private_data_dir == os.path.abspath(os.path.expanduser('~/.ansible-runner'))
+    assert rc.private_data_dir == os.path.join(gettempdir(), ".ansible-runner")
     assert rc.execution_mode == BaseExecutionMode.ANSIBLE_COMMANDS
     assert rc.runner_mode == 'subprocess'
 

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -3,6 +3,8 @@
 import os
 import pytest
 
+from tempfile import gettempdir
+
 from ansible_runner.config.inventory import InventoryConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
@@ -11,7 +13,7 @@ from ansible_runner.utils import get_executable_path
 
 def test_ansible_inventory_init_defaults():
     rc = InventoryConfig()
-    assert rc.private_data_dir == os.path.abspath(os.path.expanduser('~/.ansible-runner'))
+    assert rc.private_data_dir == os.path.join(gettempdir(), ".ansible-runner")
     assert rc.execution_mode == BaseExecutionMode.ANSIBLE_COMMANDS
 
 


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-runner/issues/699

*  Use temp location for `private_data_dir` if not passed
   in the interface API.