### PR TITLE
[containerization] Ensure volume mounts are unique directories with trailing slash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ test/integration/containerized/priv_data/artifacts/
 .coverage
 *,cover
 .venv
+/venv
 .env
 /test/data/debug/
 /test/data/printenv/env/

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -133,9 +133,9 @@ def test_role_logfile(skipif_pre_ansible28, clear_integration_artifacts):
     rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/project/roles',
-               '--logfile', 'new_logfile',
+               '--logfile', 'test_role_logfile',
                'test/integration'])
-    assert os.path.exists('new_logfile')
+    assert os.path.exists('test_role_logfile'), rc
     assert rc == 0
 
 

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -261,7 +261,7 @@ def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, mock_makedirs
     for i, entry in enumerate(new_args):
         if entry == '-v':
             mount = new_args[i + 1]
-            if mount.endswith('project_path:Z'):
+            if mount.endswith('project_path/:Z'):
                 break
     else:
         raise Exception('Could not find expected mount, args: {}'.format(new_args))
@@ -295,8 +295,8 @@ def test_containerization_settings(tmpdir, container_runtime):
     if container_runtime == 'podman':
         expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner:Z'.format(rc.private_data_dir)] + \
+    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
+        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -70,8 +70,8 @@ def test_prepare_config_command_with_containerization(tmpdir, container_runtime)
     if container_runtime == 'podman':
         expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner:Z'.format(rc.private_data_dir)] + \
+    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
+        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -78,13 +78,13 @@ def test_prepare_run_command_with_containerization(tmpdir, container_runtime):
         extra_container_args = ['--user={os.getuid()}']
 
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
-                             ['-v', '{}/:{}'.format(cwd, cwd), '-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
+                             ['-v', '{}/:{}/'.format(cwd, cwd), '-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
 
     if container_runtime == 'podman':
         expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner:Z'.format(rc.private_data_dir)] + \
+    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
+        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \

--- a/test/unit/config/test_container_volmount_generation.py
+++ b/test/unit/config/test_container_volmount_generation.py
@@ -1,0 +1,225 @@
+""" Ensure the generation of container volume mounts is handled
+predictably and consistently """
+
+import os
+import pytest
+
+from unittest.mock import patch
+
+from typing import NamedTuple
+
+from ansible_runner.config._base import BaseConfig
+from ansible_runner.exceptions import ConfigurationError
+
+
+class Variation(NamedTuple):
+    """one piece of the path"""
+
+    comment: str
+    path: str
+
+
+dir_variations = (
+    Variation(comment="dir no slash", path="/somedir_0"),
+    Variation(comment="dir with slash", path="/somedir_1/"),
+    Variation(comment="nested dir no slash", path="/somedir/otherdir_0"),
+    Variation(comment="nested dir with slash", path="/somedir/otherdir_1/"),
+    Variation(comment="path with dot", path="/somedir/foo.bar"),
+    Variation(comment="path with var no slash", path="$HOME/somedir_0"),
+    Variation(comment="path with var slash", path="$HOME/somedir_1"),
+    Variation(comment="path with ~ no slash", path="~/somedir_2"),
+    Variation(comment="path with ~ slash", path="~/somedir_3"),
+)
+
+labels = (None, "", "Z", "ro,Z", ":z")
+not_safe = ("/", "/home", "/usr")
+
+
+def id_for_dst(value):
+    """generate a test id for dest"""
+    return f"dst->{value.comment}"
+
+
+def id_for_isdir(value):
+    """generate a test id for dest"""
+    return f"isdir->{value}"
+
+
+def id_for_label(value):
+    """generate a test id for labels"""
+    return f"labels->{value}"
+
+
+def id_for_src(value):
+    """generate a test id for src"""
+    return f"src->{value.comment}"
+
+
+def resolve_path(path):
+    """Fully resolve a path"""
+    return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+
+
+def generate_volmount_args(src_str, dst_str, labels):
+    """Generate a podman style volmount string"""
+    vol_mount_str = f"{src_str}:{dst_str}"
+    if labels:
+        if not labels.startswith(":"):
+            vol_mount_str += ":"
+        vol_mount_str += labels
+    return ["-v", vol_mount_str]
+
+
+@patch("os.path.exists", return_value=True)
+@pytest.mark.parametrize("not_safe", not_safe)
+def test_check_not_safe_to_mount_dir(_mock_ope, not_safe):
+    """Ensure unsafe directories are not mounted"""
+    with pytest.raises(ConfigurationError):
+        BaseConfig()._update_volume_mount_paths(
+            args_list=[], src_mount_path=not_safe, dst_mount_path=None
+        )
+
+
+@patch("os.path.exists", return_value=True)
+@pytest.mark.parametrize("not_safe", not_safe)
+def test_check_not_safe_to_mount_file(_mock_ope, not_safe):
+    """Ensure unsafe directories for a given file are not mounted"""
+    file_path = os.path.join(not_safe, "file.txt")
+    with pytest.raises(ConfigurationError):
+        BaseConfig()._update_volume_mount_paths(
+            args_list=[], src_mount_path=file_path, dst_mount_path=None
+        )
+
+
+@patch("os.path.exists", return_value=True)
+@patch("os.path.isdir", return_value=True)
+@pytest.mark.parametrize("path", dir_variations, ids=id_for_src)
+def test_duplicate_detection_dst(_mock_ope, _mock_isdir, path):
+    """Ensure no duplicate volumne mount entries are created"""
+    base_config = BaseConfig()
+
+    def generate(args_list):
+        for entry in dir_variations:
+            for label in labels:
+                base_config._update_volume_mount_paths(
+                    args_list=first_pass,
+                    src_mount_path=path.path,
+                    dst_mount_path=entry.path,
+                    labels=label,
+                )
+
+    first_pass = []
+    generate(first_pass)
+    second_pass = first_pass[:]
+    generate(second_pass)
+    assert first_pass == second_pass
+
+
+@patch("os.path.exists", return_value=True)
+@patch("os.path.isdir", return_value=True)
+@pytest.mark.parametrize("labels", labels, ids=id_for_label)
+@pytest.mark.parametrize("path", dir_variations, ids=id_for_src)
+def test_no_dst_all_dirs(_mock_ope, _mock_isdir, path, labels):
+    """Ensure dst == src when not provided"""
+    src_str = os.path.join(resolve_path(path.path), "")
+    dst_str = src_str
+    expected = generate_volmount_args(src_str=src_str, dst_str=dst_str, labels=labels)
+
+    result = []
+    BaseConfig()._update_volume_mount_paths(
+        args_list=result, src_mount_path=path.path, dst_mount_path=None, labels=labels
+    )
+
+    explanation = (
+        f"provided: {path.path}:{None}",
+        f"got: {result}",
+        f"expected {expected}",
+    )
+    assert result == expected, explanation
+    assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
+
+
+
+@patch("os.path.exists", return_value=True)
+@patch("os.path.isdir", return_value=True)
+@pytest.mark.parametrize("labels", labels, ids=id_for_label)
+@pytest.mark.parametrize("dst", dir_variations, ids=id_for_dst)
+@pytest.mark.parametrize("src", dir_variations, ids=id_for_src)
+def test_src_dst_all_dirs(_mock_ope, _mock_isdir, src, dst, labels):
+    """Ensure src and dest end with trailing slash"""
+    src_str = os.path.join(resolve_path(src.path), "")
+    dst_str = os.path.join(resolve_path(dst.path), "")
+    expected = generate_volmount_args(src_str=src_str, dst_str=dst_str, labels=labels)
+
+    result = []
+    BaseConfig()._update_volume_mount_paths(
+        args_list=result, src_mount_path=src.path, dst_mount_path=dst.path, labels=labels
+    )
+
+    explanation = (
+        f"provided: {src.path}:{dst.path}",
+        f"got: {result}",
+        f"expected {expected}",
+    )
+    assert result == expected, explanation
+    assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
+
+
+
+@patch("os.path.exists", return_value=True)
+@pytest.mark.parametrize("labels", labels, ids=id_for_label)
+@pytest.mark.parametrize("path", dir_variations, ids=id_for_src)
+def test_src_dst_all_files(_mock_ope, path, labels):
+    """Ensure file paths are tranformed correctly into dir paths"""
+    src_str = os.path.join(resolve_path(path.path), "")
+    dst_str = src_str
+    expected = generate_volmount_args(src_str=src_str, dst_str=dst_str, labels=labels)
+
+    result = []
+    src_file = os.path.join(path.path, "", "file.txt")
+    dest_file = src_file
+
+    base_config = BaseConfig()
+    with patch("os.path.isdir", return_value=False):
+        base_config._update_volume_mount_paths(
+            args_list=result, src_mount_path=src_file, dst_mount_path=dest_file, labels=labels
+        )
+
+    explanation = (
+        f"provided: {src_file}:{dest_file}",
+        f"got: {result}",
+        f"expected {expected}",
+    )
+    assert result == expected, explanation
+    assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
+
+
+
+@patch("os.path.exists", return_value=True)
+@patch("os.path.isdir", return_value=True)
+@pytest.mark.parametrize("relative", (".", "..", "../.."))
+@pytest.mark.parametrize("labels", labels, ids=id_for_label)
+@pytest.mark.parametrize("dst", dir_variations, ids=id_for_dst)
+@pytest.mark.parametrize("src", dir_variations, ids=id_for_src)
+def test_src_dst_all_relative_dirs(_mock_ope, _mock_isdir, src, dst, labels, relative):
+    """Ensure src is resolved and dest mapped to workdir when relative"""
+    relative_src = f"{relative}{src.path}"
+    relative_dst = f"{relative}{dst.path}"
+    workdir = "/workdir"
+    src_str = os.path.join(resolve_path(relative_src), "")
+    dst_str = os.path.join(resolve_path(os.path.join(workdir, relative_dst)), "")
+    expected = generate_volmount_args(src_str=src_str, dst_str=dst_str, labels=labels)
+
+    result = []
+    BaseConfig(container_workdir=workdir)._update_volume_mount_paths(
+        args_list=result, src_mount_path=relative_src, dst_mount_path=relative_dst, labels=labels
+    )
+
+    explanation = (
+        f"provided: {relative_src}:{relative_dst}",
+        f"got: {result}",
+        f"expected {expected}",
+    )
+    assert result == expected, explanation
+    assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
+

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -80,8 +80,8 @@ def test_prepare_plugin_docs_command_with_containerization(tmpdir, container_run
     if container_runtime == 'podman':
         expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner:Z'.format(rc.private_data_dir)] + \
+    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
+        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \
@@ -128,8 +128,8 @@ def test_prepare_plugin_list_command_with_containerization(tmpdir, container_run
     if container_runtime == 'podman':
         expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner:Z'.format(rc.private_data_dir)] + \
+    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
+        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -105,8 +105,8 @@ def test_prepare_inventory_command_with_containerization(tmpdir, container_runti
     if container_runtime == 'podman':
         expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner:Z'.format(rc.private_data_dir)] + \
+    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
+        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo', 'my_container'] + \

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -637,7 +637,7 @@ def test_profiling_plugin_settings_with_custom_intervals(mock_mkdir):
 @patch('os.path.exists', return_value=True)
 def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmpdir):
     rc = RunnerConfig(str(tmpdir))
-    rc.container_volume_mounts = ['project_path:project_path:Z']
+    rc.container_volume_mounts = ['/tmp/project_path:/tmp/project_path:Z']
     rc.container_name = 'foo'
     rc.env = {}
     new_args = rc.wrap_args_for_containerization(['ansible-playbook', 'foo.yml'], 0, None)
@@ -645,7 +645,7 @@ def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmpdir):
     for i, entry in enumerate(new_args):
         if entry == '-v':
             mount = new_args[i + 1]
-            if mount.endswith(':project_path:Z'):
+            if mount.endswith(':/tmp/project_path/:Z'):
                 break
     else:
         raise Exception('Could not find expected mount, args: {}'.format(new_args))
@@ -663,7 +663,7 @@ def test_containerization_settings(mock_isdir, mock_exists, tmpdir, container_ru
         rc.process_isolation = True
         rc.process_isolation_executable=container_runtime
         rc.container_image = 'my_container'
-        rc.container_volume_mounts=['/host1:/container1', 'host2:/container2']
+        rc.container_volume_mounts=['/host1:/container1', '/host2:/container2']
         mock_containerized.return_value = True
         rc.prepare()
 
@@ -674,8 +674,8 @@ def test_containerization_settings(mock_isdir, mock_exists, tmpdir, container_ru
         extra_container_args = ['--user={os.getuid()}']
 
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
-        ['-v', '{}/:/runner:Z'.format(rc.private_data_dir)] + \
-        ['-v', '/host1/:/container1', '-v', 'host2/:/container2'] + \
+        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
+        ['-v', '/host1/:/container1/', '-v', '/host2/:/container2/'] + \
         ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \


### PR DESCRIPTION
Fixes #727
Fixes https://github.com/ansible/ansible-navigator/issues/471

- Clear up logic, ensure src and dest are always directories with a trailing slash
- Ensure abs, expand user and vars for each
- Remove unused func for trailing slash adding as it is within the only func using it
- Add sufficient unit test to cover all scenarios
- 1 var rename for consistency with src
- Fix safe path mount to cover with and without trailing slash
- change log file to unique to avoid suspected race condition