### PR TITLE
fix(make): removed unused arg and fixing tools/req/branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ NAME = ansible-runner
 IMAGE_NAME ?= quay.io/ansible/ansible-runner
 IMAGE_NAME_STRIPPED := $(word 1,$(subst :, ,$(IMAGE_NAME)))
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
-ANSIBLE_BRANCH ?= ""
+ANSIBLE_BRANCH ?=
 ANSIBLE_VERSIONS ?= stable-2.9 stable-2.10 stable-2.11
 PIP_NAME = ansible_runner
 VERSION := $(shell python setup.py --version)
@@ -97,9 +97,9 @@ image: sdist
 		-t $(IMAGE_NAME) -f Dockerfile .
 	$(CONTAINER_ENGINE) tag $(IMAGE_NAME) $(IMAGE_NAME_STRIPPED):$(GIT_BRANCH)
 
-image_matrix:
+image_matrix: image
 	for version in $(ANSIBLE_VERSIONS) ; do \
-		ANSIBLE_BRANCH=$$version GIT_BRANCH=$$version.$(GIT_BRANCH) make image ; \
+		ANSIBLE_BRANCH=$$version GIT_BRANCH=$$version-$(GIT_BRANCH) make image ; \
 	done
 	$(CONTAINER_ENGINE) tag $(IMAGE_NAME) $(IMAGE_NAME_STRIPPED):$(GIT_BRANCH)
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ NAME = ansible-runner
 IMAGE_NAME ?= quay.io/ansible/ansible-runner
 IMAGE_NAME_STRIPPED := $(word 1,$(subst :, ,$(IMAGE_NAME)))
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
-ANSIBLE_BRANCH ?= devel
-ANSIBLE_VERSIONS ?= stable-2.9 stable-2.10 devel
+ANSIBLE_BRANCH ?= ""
+ANSIBLE_VERSIONS ?= stable-2.9 stable-2.10 stable-2.11
 PIP_NAME = ansible_runner
 VERSION := $(shell python setup.py --version)
 ifeq ($(OFFICIAL),yes)
@@ -93,7 +93,7 @@ docs:
 
 image: sdist
 	$(CONTAINER_ENGINE) build --rm=true \
-		--build-arg RUNNER_VERSION=$(VERSION) \
+		--build-arg ANSIBLE_BRANCH=$(ANSIBLE_BRANCH) \
 		-t $(IMAGE_NAME) -f Dockerfile .
 	$(CONTAINER_ENGINE) tag $(IMAGE_NAME) $(IMAGE_NAME_STRIPPED):$(GIT_BRANCH)
 


### PR DESCRIPTION
Hi,
a simple fix for Makefile to build docker images using their defaults and the right --build-arg` values.


- fixing `make image_matrix`

removing devel from `ANSIBLE_VERSIONS` defaults; https://github.com/ansible/ansible-runner/tree/devel/tools doesn't contain "devel" requirements files so `make image_matrix` fails with default values.

- fixing `make image`

`RUNNER_VERSION` is not a Dokerfile ARG  replaced with `ANSIBLE_BRANCH`

`ANSIBLE_BRANCH` default value is "" to fit Dokerfile tools/requirement condition