### PR TITLE
Fix date in changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@
 Changelog
 ---------
 
-2.0.0a3 (2020-05-20)
+2.0.0a3 (2021-05-20)
 ++++++++++++++++++++
 - Updated streaming module to fail jobs when a project contains an invalid symlink in the source files
 


### PR DESCRIPTION
I'm going to assume since the RPM changelog lists this as 2021 that this was a typo. Some projects can be out of sync like this (release a 2.x version and continue to update 1.x) so this date kind of threw me.