### PR TITLE
Update run_command() examples in docs

### DIFF
--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -203,7 +203,7 @@ Usage examples
 .. code-block:: python
 
   # run ansible/generic commands in interactive mode within container
-  out, err = ansible_runner.run_command(
+  out, err, rc = ansible_runner.run_command(
       executable_cmd='ansible-playbook',
       cmdline_args=['gather.yaml', '-i', 'inventory', '-vvvv', '-k'],
       input_fd=sys.stdin,
@@ -213,19 +213,21 @@ Usage examples
       process_isolation=True,
       container_image='network-ee'
   )
+  print("rc: {}".format(rc))
   print("out: {}".format(out))
   print("err: {}".format(err))
 
 .. code-block:: python
 
   # run ansible/generic commands in interactive mode locally  
-  out, err = ansible_runner.run_command(
+  out, err, rc = ansible_runner.run_command(
       executable_cmd='ansible-playbook',
       cmdline_args=['gather.yaml', '-i', 'inventory', '-vvvv', '-k'],
       input_fd=sys.stdin,
       output_fd=sys.stdout,
       error_fd=sys.stderr,
   )
+  print("rc: {}".format(rc))
   print("out: {}".format(out))
   print("err: {}".format(err))
 


### PR DESCRIPTION
The tuple returned from `run_command()` returns 3 items (response, error string and return code), not two, as used in the examples in the Python interface doc.