### PR TITLE
Remove usage of --userns=keep-id.

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -444,7 +444,6 @@ class BaseConfig(object):
             if 'podman' in self.process_isolation_executable:
                 # container namespace stuff
                 new_args.extend(["--group-add=root"])
-                new_args.extend(["--userns=keep-id"])
                 new_args.extend(["--ipc=host"])
 
             self._ensure_path_safe_to_mount(self.private_data_dir)

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -300,7 +300,7 @@ def test_containerization_settings(tmpdir, container_runtime):
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
+        expected_command_start +=['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -76,7 +76,7 @@ def test_prepare_config_command_with_containerization(tmpdir, container_runtime)
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
+        expected_command_start +=['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -89,7 +89,7 @@ def test_prepare_run_command_with_containerization(tmpdir, container_runtime):
                              ['-v', '{}/:{}/'.format(cwd, cwd), '-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
 
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
+        expected_command_start +=['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -86,7 +86,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmpdir, container_run
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
+        expected_command_start +=['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
@@ -134,7 +134,7 @@ def test_prepare_plugin_list_command_with_containerization(tmpdir, container_run
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
+        expected_command_start +=['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -111,7 +111,7 @@ def test_prepare_inventory_command_with_containerization(tmpdir, container_runti
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--userns=keep-id', '--ipc=host']
+        expected_command_start +=['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \


### PR DESCRIPTION
When using an EE that has `USER root`, this was causing files created in the container to be owned by the mapped UID on the host. Not what we want!