### PR TITLE
PEP8 and setuptools cleanup

### DIFF
--- a/ansible_runner/__init__.py
+++ b/ansible_runner/__init__.py
@@ -14,4 +14,3 @@ plugins = {
     for entry_point
     in pkg_resources.iter_entry_points('ansible_runner.plugins')
 }
-

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -750,7 +750,6 @@ def main(sys_args=None):
         print_common_usage()
         parser.exit(status=0)
 
-
     args = parser.parse_args(sys_args)
 
     vargs = vars(args)

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -79,7 +79,7 @@ class BaseConfig(object):
         self.private_data_dir = private_data_dir
         self.rotate_artifacts = rotate_artifacts
         self.quiet = quiet
-        self.json_mode=json_mode
+        self.json_mode = json_mode
         self.passwords = passwords
         self.settings = settings
         self.timeout = timeout
@@ -169,7 +169,7 @@ class BaseConfig(object):
             self.pexpect_timeout = self.settings.get('pexpect_timeout', 5)
             self.pexpect_use_poll = self.settings.get('pexpect_use_poll', True)
             self.idle_timeout = self.settings.get('idle_timeout', None)
- 
+
             if self.timeout:
                 self.job_timeout = int(self.timeout)
             else:
@@ -207,7 +207,7 @@ class BaseConfig(object):
         try:
             envvars = self.loader.load_file('env/envvars', Mapping)
             if envvars:
-                self.env.update({str(k):str(v) for k, v in envvars.items()})
+                self.env.update({str(k): str(v) for k, v in envvars.items()})
         except ConfigurationError:
             debug("Not loading environment vars")
             # Still need to pass default environment to pexpect
@@ -242,7 +242,7 @@ class BaseConfig(object):
             self.env['PYTHONPATH'] = ':'.join([python_path, callback_dir])
             if python_path and not python_path.endswith(':'):
                 python_path += ':'
-            self.env['ANSIBLE_CALLBACK_PLUGINS'] = ':'.join(filter(None,(self.env.get('ANSIBLE_CALLBACK_PLUGINS'), callback_dir)))
+            self.env['ANSIBLE_CALLBACK_PLUGINS'] = ':'.join(filter(None, (self.env.get('ANSIBLE_CALLBACK_PLUGINS'), callback_dir)))
 
         if 'AD_HOC_COMMAND_ID' in self.env:
             self.env['ANSIBLE_STDOUT_CALLBACK'] = 'minimal'
@@ -260,7 +260,7 @@ class BaseConfig(object):
                 self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = self.fact_cache
 
         debug('env:')
-        for k,v in sorted(self.env.items()):
+        for k, v in sorted(self.env.items()):
             debug(f' {k}: {v}')
 
     def _handle_command_wrap(self, execution_mode, cmdline_args):
@@ -314,7 +314,7 @@ class BaseConfig(object):
                     break
 
         return _playbook
-    
+
     def _update_volume_mount_paths(
         self, args_list, src_mount_path, dst_mount_path=None, labels=None
     ):
@@ -360,7 +360,6 @@ class BaseConfig(object):
             if not labels.startswith(":"):
                 volume_mount_path += ":"
             volume_mount_path += labels
-
 
         # check if mount path already added in args list
         if volume_mount_path not in args_list:
@@ -473,14 +472,14 @@ class BaseConfig(object):
             # Mount the entire private_data_dir
             # custom show paths inside private_data_dir do not make sense
             self._update_volume_mount_paths(new_args, "{}".format(self.private_data_dir), dst_mount_path="/runner", labels=":Z")
-    
+
         if self.container_volume_mounts:
             for mapping in self.container_volume_mounts:
                 volume_mounts = mapping.split(':', 2)
                 self._ensure_path_safe_to_mount(volume_mounts[0])
                 labels = None
                 if len(volume_mounts) == 3:
-                    labels = ":%s" %volume_mounts[2]
+                    labels = ":%s" % volume_mounts[2]
                 self._update_volume_mount_paths(new_args, volume_mounts[0], dst_mount_path=volume_mounts[1], labels=labels)
 
         # Reference the file with list of keys to pass into container

--- a/ansible_runner/config/ansible_cfg.py
+++ b/ansible_runner/config/ansible_cfg.py
@@ -59,7 +59,6 @@ class AnsibleCfgConfig(BaseConfig):
 
     _supported_actions = ('list', 'dump', 'view')
 
-
     def prepare_ansible_config_command(self, action, config_file=None, only_changed=None):
 
         if action not in AnsibleCfgConfig._supported_actions:

--- a/ansible_runner/config/runner.py
+++ b/ansible_runner/config/runner.py
@@ -110,7 +110,6 @@ class RunnerConfig(BaseConfig):
         self.omit_event_data = omit_event_data
         self.only_failed_event_data = only_failed_event_data
 
-
     @property
     def sandboxed(self):
         return self.process_isolation and self.process_isolation_executable not in self._CONTAINER_ENGINES
@@ -156,7 +155,7 @@ class RunnerConfig(BaseConfig):
         self._handle_command_wrap()
 
         debug('env:')
-        for k,v in sorted(self.env.items()):
+        for k, v in sorted(self.env.items()):
             debug(f' {k}: {v}')
         if hasattr(self, 'command') and isinstance(self.command, list):
             debug(f"command: {' '.join(self.command)}")
@@ -399,7 +398,7 @@ class RunnerConfig(BaseConfig):
                 logger.debug('read-only path not found: {0}'.format(path))
                 continue
             path = os.path.realpath(path)
-            new_args.extend(['--ro-bind', '{0}'.format(path),  '{0}'.format(path)])
+            new_args.extend(['--ro-bind', '{0}'.format(path), '{0}'.format(path)])
 
         show_paths.extend(self.process_isolation_show_paths or [])
         for path in sorted(set(show_paths)):

--- a/ansible_runner/loader.py
+++ b/ansible_runner/loader.py
@@ -129,7 +129,6 @@ class ArtifactLoader(object):
         '''
         return os.path.isfile(self.abspath(path))
 
-
     def load_file(self, path, objtype=None, encoding='utf-8'):
         '''
         Load the file specified by path

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -214,7 +214,6 @@ class Runner(object):
             else:
                 logger.info("Created cgroup '{}'".format(cgroup_path))
 
-
         self.status_callback('running')
         self.last_stdout_update = time.time()
 
@@ -255,7 +254,7 @@ class Runner(object):
                 if subprocess_timeout is not None:
                     kwargs.update({'timeout': subprocess_timeout})
 
-                proc_out = run_subprocess( " ".join(command), **kwargs)
+                proc_out = run_subprocess(" ".join(command), **kwargs)
 
                 stdout_response = proc_out.stdout
                 stderr_response = proc_out.stderr
@@ -338,8 +337,8 @@ class Runner(object):
                         self.canceled = self.cancel_callback()
                     except Exception as e:
                         # TODO: logger.exception('Could not check cancel callback - cancelling immediately')
-                        #if isinstance(extra_update_fields, dict):
-                        #    extra_update_fields['job_explanation'] = "System error during job execution, check system logs"
+                        # if isinstance(extra_update_fields, dict):
+                        #     extra_update_fields['job_explanation'] = "System error during job execution, check system logs"
                         raise CallbackError("Exception in Cancel Callback: {}".format(e))
                 if self.config.job_timeout and not self.canceled and (time.time() - job_start) > self.config.job_timeout:
                     self.timed_out = True
@@ -507,15 +506,14 @@ class Runner(object):
         if not last_event:
             return None
         last_event = last_event[0]['event_data']
-        return dict(skipped=last_event.get('skipped',{}),
-                    ok=last_event.get('ok',{}),
-                    dark=last_event.get('dark',{}),
-                    failures=last_event.get('failures',{}),
+        return dict(skipped=last_event.get('skipped', {}),
+                    ok=last_event.get('ok', {}),
+                    dark=last_event.get('dark', {}),
+                    failures=last_event.get('failures', {}),
                     ignored=last_event.get('ignored', {}),
                     rescued=last_event.get('rescued', {}),
-                    processed=last_event.get('processed',{}),
-                    changed=last_event.get('changed',{}))
-
+                    processed=last_event.get('processed', {}),
+                    changed=last_event.get('changed', {}))
 
     def host_events(self, host):
         '''
@@ -560,7 +558,6 @@ class Runner(object):
             os.remove(pidfile)
         except (TypeError, OSError):
             pass
-
 
     def get_fact_cache(self, host):
         '''

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -212,7 +212,7 @@ def dump_artifacts(kwargs):
             kwargs.pop(key)
 
 
-def collect_new_events(event_path,old_events):
+def collect_new_events(event_path, old_events):
     '''
     Collect new events for the 'events' generator property
     '''
@@ -220,7 +220,7 @@ def collect_new_events(event_path,old_events):
     dir_events_actual = []
     for each_file in dir_events:
         if re.match("^[0-9]+-.+json$", each_file):
-            if '-partial' not in each_file and each_file not in old_events.keys() :
+            if '-partial' not in each_file and each_file not in old_events.keys():
                 dir_events_actual.append(each_file)
     dir_events_actual.sort(key=lambda filenm: int(filenm.split("-", 1)[0]))
     for event_file in dir_events_actual:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = ansible-runner
 author = Ansible, Inc.
-author_email = info@ansible.com
+author-email = info@ansible.com
 summary = "Consistent Ansible Python API and CLI with container and process isolation runtime capabilities"
-home_page = https://ansible-runner.readthedocs.io
-description_file = README.md
-description_content_type = text/markdown
+home-page = https://ansible-runner.readthedocs.io
+description-file = README.md
+description-content-type = text/markdown
 license_file = LICENSE.md
 
 [entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,12 @@ data-files =
     share/ansible-runner/utils = utils/*
 
 [pep8]
+# W503 - Line break occurred before a binary operator
+ignore=W503
 exclude=.tox,venv
 
 [flake8]
+# W503 - Line break occurred before a binary operator
+ignore=W503
 max-line-length=160
 exclude=.tox,venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,23 +19,8 @@ data-files =
     share/ansible-runner/utils = utils/*
 
 [pep8]
-# E201 - Whitespace after '('
-# E203 - Whitespace before ":"
-# E221 - Multiple spaces after operator
-# E225 - Missing whitespace around operator
-# E231 - Missing whitespace after ','
-# E241 - Multiple spaces after ','
-# E251 - Unexpected spaces around keyword / parameter equals
-# E261 - At least two spaces before inline comment
-# E302 - Expected 2 blank lines found 0
-# E303 - Too many blank lines
-# W291 - Trailing whitespace
-# W391 - Blank line at end of file
-# W293 - Blank line contains whitespace
-ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,W291,W391,W293
 exclude=.tox,venv
 
 [flake8]
 max-line-length=160
-ignore=E201,E203,E221,E225,E231,E241,E251,E261,E265,E303,W291,W391,W293,E731,F405
 exclude=.tox,venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = ansible-runner
 author = Ansible, Inc.
-author-email = info@ansible.com
+author_email = info@ansible.com
 summary = "Consistent Ansible Python API and CLI with container and process isolation runtime capabilities"
-home-page = https://ansible-runner.readthedocs.io
-description-file = README.md
-description-content-type = text/markdown
+home_page = https://ansible-runner.readthedocs.io
+description_file = README.md
+description_content_type = text/markdown
 license_file = LICENSE.md
 
 [entry_points]

--- a/test/integration/callback/other_callback.py
+++ b/test/integration/callback/other_callback.py
@@ -11,4 +11,3 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_ok(self, result):
         pass
-

--- a/test/integration/containerized/conftest.py
+++ b/test/integration/containerized/conftest.py
@@ -45,7 +45,7 @@ class CompletedProcessProxy(object):
 def cli(request):
     def run(args, *a, **kw):
         if not kw.pop('bare', None):
-            args = ['ansible-runner',] + args
+            args = ['ansible-runner'] + args
         kw['encoding'] = 'utf-8'
         if 'check' not in kw:
             # By default we want to fail if a command fails to run. Tests that

--- a/test/integration/containerized/test_cli_containerized.py
+++ b/test/integration/containerized/test_cli_containerized.py
@@ -14,13 +14,13 @@ def skip_if_no_podman(container_runtime_installed):
 
 @pytest.mark.serial
 def test_module_run(cli, skip_if_no_podman):
-    r = cli(['run', '-m', 'ping','--hosts', 'localhost', os.path.join(HERE, 'priv_data')])
+    r = cli(['run', '-m', 'ping', '--hosts', 'localhost', os.path.join(HERE, 'priv_data')])
     assert '"ping": "pong"' in r.stdout
 
 
 @pytest.mark.serial
 def test_playbook_run(cli, skip_if_no_podman):
-    r = cli(['run', os.path.join(HERE,'priv_data'), '-p', 'test-container.yml'])
+    r = cli(['run', os.path.join(HERE, 'priv_data'), '-p', 'test-container.yml'])
     assert 'PLAY RECAP *******' in r.stdout
     assert 'failed=0' in r.stdout
 
@@ -36,7 +36,7 @@ def test_adhoc_localhost_setup(cli, skip_if_no_podman, container_runtime_install
     r = cli(
         [
             'adhoc',
-            '--private-data-dir', os.path.join(HERE,'priv_data'),
+            '--private-data-dir', os.path.join(HERE, 'priv_data'),
             '--container-runtime', container_runtime_installed,
             'localhost', '-m', 'setup'
         ]
@@ -51,7 +51,7 @@ def test_playbook_with_private_data_dir(cli, skip_if_no_podman, container_runtim
     r = cli(
         [
             'playbook',
-            '--private-data-dir', os.path.join(HERE,'priv_data'),
+            '--private-data-dir', os.path.join(HERE, 'priv_data'),
             '--container-runtime', container_runtime_installed,
             os.path.join(HERE, 'priv_data/project/test-container.yml')
         ]

--- a/test/integration/test___main__.py
+++ b/test/integration/test___main__.py
@@ -69,7 +69,7 @@ def test_cmdline_role_defaults():
     """Run a role directly with all command line defaults
     """
     private_data_dir = tempfile.mkdtemp()
-    options = ['-r' , 'test']
+    options = ['-r', 'test']
 
     playbook = [{'hosts': 'all', 'gather_facts': True, 'roles': [{'role': 'test'}]}]
 
@@ -86,7 +86,7 @@ def test_cmdline_role_skip_facts():
     """Run a role directly and set --role-skip-facts option
     """
     private_data_dir = tempfile.mkdtemp()
-    options = ['-r' , 'test', '--role-skip-facts']
+    options = ['-r', 'test', '--role-skip-facts']
 
     playbook = [{'hosts': 'all', 'gather_facts': False, 'roles': [{'role': 'test'}]}]
 
@@ -103,7 +103,7 @@ def test_cmdline_role_inventory():
     """Run a role directly and set --inventory option
     """
     private_data_dir = tempfile.mkdtemp()
-    options = ['-r' , 'test', '--inventory hosts']
+    options = ['-r', 'test', '--inventory hosts']
 
     playbook = [{'hosts': 'all', 'gather_facts': False, 'roles': [{'role': 'test'}]}]
 
@@ -121,7 +121,7 @@ def test_cmdline_role_vars():
     """Run a role directly and set --role-vars option
     """
     private_data_dir = tempfile.mkdtemp()
-    options = ['-r' , 'test', '--role-vars "foo=bar"']
+    options = ['-r', 'test', '--role-vars "foo=bar"']
 
     playbook = [{
         'hosts': 'all',
@@ -145,7 +145,7 @@ def test_cmdline_roles_path():
     """Run a role directly and set --roles-path option
     """
     private_data_dir = tempfile.mkdtemp()
-    options = ['-r' , 'test', '--roles-path /tmp/roles']
+    options = ['-r', 'test', '--roles-path /tmp/roles']
 
     playbook = [{'hosts': 'all', 'gather_facts': False, 'roles': [{'role': 'test'}]}]
 
@@ -242,7 +242,7 @@ def test_cmdline_cmdline_override(is_pre_ansible28):
 
         # privateip: removed --hosts command line option from test beause it is
         # not a supported combination of cli options
-        #cmdline('run', private_data_dir, '-p', playbook, '--hosts', 'all', '--cmdline', '-e foo=bar')
+        # cmdline('run', private_data_dir, '-p', playbook, '--hosts', 'all', '--cmdline', '-e foo=bar')
         cmdline('run', private_data_dir, '-p', playbook, '--cmdline', '-e foo=bar')
         assert main() == 0
     finally:

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -33,7 +33,6 @@ def executor(tmpdir, request, is_pre_ansible28):
     else:
         inventory = 'localhost ansible_connection=local'
 
-
     r = init_runner(
         private_data_dir=private_data_dir,
         inventory=inventory,
@@ -81,7 +80,6 @@ def test_callback_plugin_receives_events(executor, event, playbook, envvars):
     executor.run()
     assert len(list(executor.events))
     assert event in [task['event'] for task in executor.events]
-
 
 
 @pytest.mark.parametrize('playbook', [

--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -60,7 +60,7 @@ def test_basic_events(containerized, container_runtime_available, is_pre_ansible
 
 @pytest.mark.parametrize('containerized', [True, False])
 def test_async_events(containerized, container_runtime_available, is_pre_ansible28):
-    test_basic_events(containerized, container_runtime_available, is_pre_ansible28, is_run_async=True,g_facts=True)
+    test_basic_events(containerized, container_runtime_available, is_pre_ansible28, is_run_async=True, g_facts=True)
 
 
 def test_basic_serializeable(is_pre_ansible28):

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -51,7 +51,6 @@ def test_temp_directory():
 
     context = dict()
 
-
     def will_fail():
         with temp_directory() as temp_dir:
             context['saved_temp_dir'] = temp_dir
@@ -276,7 +275,6 @@ def test_role_run_inventory_missing(is_pre_ansible28):
 
 def test_role_start():
 
-
     with temp_directory() as temp_dir:
         p = multiprocessing.Process(target=main,
                                     args=[['start', '-r', 'benthomasson.hello_role',
@@ -295,17 +293,16 @@ def test_playbook_start(skipif_pre_ansible28):
         ensure_directory(project_dir)
         shutil.copy(os.path.join(HERE, 'project/hello.yml'), project_dir)
         ensure_directory(os.path.join(temp_dir, 'inventory'))
-        shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir,'inventory/localhost'))
+        shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir, 'inventory/localhost'))
 
         # privateip: removed --hosts command line option from test beause it is
         # not a supported combination of cli options
         p = multiprocessing.Process(target=main,
                                     args=[['start', '-p', 'hello.yml',
                                            '--inventory', os.path.join(HERE, 'inventory/localhost'),
-                                           #'--hosts', 'localhost',
+                                           # '--hosts', 'localhost',
                                            temp_dir]])
         p.start()
-
 
         time.sleep(5)
 

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -33,7 +33,7 @@ def test_run_command(rc):
     assert exitcode == 0
     with open(os.path.join(rc.artifact_dir, 'command')) as f:
         data = json.load(f)
-        assert data.get('command') == ['sleep','1']
+        assert data.get('command') == ['sleep', '1']
         assert 'cwd' in data
         assert isinstance(data.get('env'), dict)
 
@@ -58,7 +58,7 @@ def test_run_command_with_unicode(rc):
 
 def test_run_command_finished_callback(rc):
     finished_callback = MagicMock()
-    rc.command = ['sleep','1']
+    rc.command = ['sleep', '1']
     runner = Runner(config=rc, finished_callback=finished_callback)
     status, exitcode = runner.run()
     assert status == 'successful'
@@ -69,7 +69,7 @@ def test_run_command_finished_callback(rc):
 def test_run_command_explosive_finished_callback(rc):
     def boom(*args):
         raise Exception('boom')
-    rc.command = ['sleep','1']
+    rc.command = ['sleep', '1']
     runner = Runner(config=rc, finished_callback=boom)
     with pytest.raises(Exception):
         runner.run()
@@ -78,7 +78,7 @@ def test_run_command_explosive_finished_callback(rc):
 def test_run_command_explosive_cancel_callback(rc):
     def boom(*args):
         raise Exception('boom')
-    rc.command = ['sleep','1']
+    rc.command = ['sleep', '1']
     runner = Runner(config=rc, cancel_callback=boom)
     with pytest.raises(Exception):
         runner.run()
@@ -87,7 +87,7 @@ def test_run_command_explosive_cancel_callback(rc):
 def test_run_command_cancel_callback(rc):
     def cancel(*args):
         return True
-    rc.command = ['sleep','1']
+    rc.command = ['sleep', '1']
     runner = Runner(config=rc, cancel_callback=cancel)
     status, exitcode = runner.run()
     assert status == 'canceled'
@@ -148,7 +148,7 @@ def test_run_command_long_running_children(rc):
 
 
 def test_run_command_events_missing(rc):
-    rc.command = ['sleep','1']
+    rc.command = ['sleep', '1']
     runner = Runner(config=rc)
     status, exitcode = runner.run()
     assert status == 'successful'
@@ -157,7 +157,7 @@ def test_run_command_events_missing(rc):
 
 
 def test_run_command_stdout_missing(rc):
-    rc.command = ['sleep','1']
+    rc.command = ['sleep', '1']
     runner = Runner(config=rc)
     status, exitcode = runner.run()
     assert status == 'successful'
@@ -168,7 +168,7 @@ def test_run_command_stdout_missing(rc):
 
 
 def test_run_command_no_stats(rc):
-    rc.command = ['sleep','1']
+    rc.command = ['sleep', '1']
     runner = Runner(config=rc)
     status, exitcode = runner.run()
     assert status == 'successful'
@@ -276,4 +276,3 @@ def test_set_extra_vars(rc):
     status, exitcode = runner.run()
     with open(os.path.join(rc.artifact_dir, 'stdout')) as f:
         assert 'hello there' in f.read()
-

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -35,7 +35,7 @@ class TestStreamingUsage:
 
     def check_artifacts(self, process_dir, job_type):
 
-        assert set(os.listdir(process_dir)) == {'artifacts',}
+        assert set(os.listdir(process_dir)) == {'artifacts', }
 
         events_dir = os.path.join(process_dir, 'artifacts', 'job_events')
         events = []
@@ -91,7 +91,6 @@ class TestStreamingUsage:
         processor.run()
 
         self.check_artifacts(process_dir, job_type)
-
 
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
     def test_remote_job_by_sockets(self, tmpdir, test_data_dir, container_runtime_installed, job_type):

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -163,7 +163,7 @@ def test_prepare_env_sshkey():
 
 def test_prepare_env_defaults():
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc = BaseConfig(private_data_dir='/tmp', host_cwd='/tmp/project')
         rc._prepare_env()
         assert rc.idle_timeout is None
@@ -283,9 +283,9 @@ def test_containerization_settings(tmpdir, container_runtime):
         rc.command = ['ansible-playbook'] + rc.cmdline_args
         rc.process_isolation = True
         rc.runner_mode = 'pexpect'
-        rc.process_isolation_executable=container_runtime
+        rc.process_isolation_executable = container_runtime
         rc.container_image = 'my_container'
-        rc.container_volume_mounts=['/host1:/container1', 'host2:/container2']
+        rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
         mock_containerized.return_value = True
         rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
         rc._prepare_env()
@@ -300,7 +300,7 @@ def test_containerization_settings(tmpdir, container_runtime):
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--ipc=host']
+        expected_command_start += ['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -76,7 +76,7 @@ def test_prepare_config_command_with_containerization(tmpdir, container_runtime)
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--ipc=host']
+        expected_command_start += ['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -89,7 +89,7 @@ def test_prepare_run_command_with_containerization(tmpdir, container_runtime):
                              ['-v', '{}/:{}/'.format(cwd, cwd), '-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
 
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--ipc=host']
+        expected_command_start += ['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_container_volmount_generation.py
+++ b/test/unit/config/test_container_volmount_generation.py
@@ -141,7 +141,6 @@ def test_no_dst_all_dirs(_mock_ope, _mock_isdir, path, labels):
     assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
 
 
-
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @pytest.mark.parametrize("labels", labels, ids=id_for_label)
@@ -165,7 +164,6 @@ def test_src_dst_all_dirs(_mock_ope, _mock_isdir, src, dst, labels):
     )
     assert result == expected, explanation
     assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
-
 
 
 @pytest.mark.parametrize("labels", labels, ids=id_for_label)
@@ -196,7 +194,6 @@ def test_src_dst_all_files(path, labels):
     assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
 
 
-
 @patch("os.path.exists", return_value=True)
 @patch("os.path.isdir", return_value=True)
 @pytest.mark.parametrize("relative", (".", "..", "../.."))
@@ -224,4 +221,3 @@ def test_src_dst_all_relative_dirs(_mock_ope, _mock_isdir, src, dst, labels, rel
     )
     assert result == expected, explanation
     assert all(part.endswith('/') for part in result[1].split(':')[0:1]), explanation
-

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -86,7 +86,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmpdir, container_run
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--ipc=host']
+        expected_command_start += ['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
@@ -134,7 +134,7 @@ def test_prepare_plugin_list_command_with_containerization(tmpdir, container_run
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--ipc=host']
+        expected_command_start += ['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -111,7 +111,7 @@ def test_prepare_inventory_command_with_containerization(tmpdir, container_runti
     expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
                              ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
     if container_runtime == 'podman':
-        expected_command_start +=['--group-add=root', '--ipc=host']
+        expected_command_start += ['--group-add=root', '--ipc=host']
 
     expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -180,7 +180,7 @@ def test_prepare_env_sshkey(mock_makedirs, open_fifo_write_mock):
 @patch('os.makedirs', return_value=True)
 def test_prepare_env_defaults(mock_makedirs):
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc = RunnerConfig('/')
         rc.prepare_env()
         assert rc.idle_timeout is None
@@ -192,7 +192,7 @@ def test_prepare_env_defaults(mock_makedirs):
 @patch('os.makedirs', return_value=True)
 def test_prepare_env_directory_isolation(mock_makedirs):
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc = RunnerConfig('/')
         rc.directory_isolation_path = '/tmp/foo'
         rc.prepare_env()
@@ -221,7 +221,7 @@ def test_prepare_inventory(path_exists, mock_makedirs):
 def test_generate_ansible_command(mock_makedirs):
     rc = RunnerConfig(private_data_dir='/', playbook='main.yaml')
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc.prepare_inventory()
     rc.extra_vars = None
 
@@ -292,9 +292,9 @@ def test_generate_ansible_command(mock_makedirs):
 
 @patch('os.makedirs', return_value=True)
 def test_generate_ansible_command_with_api_extravars(mock_makedirs):
-    rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo":"bar"})
+    rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo": "bar"})
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc.prepare_inventory()
 
     cmd = rc.generate_ansible_command()
@@ -303,9 +303,9 @@ def test_generate_ansible_command_with_api_extravars(mock_makedirs):
 
 @patch('os.makedirs', return_value=True)
 def test_generate_ansible_command_with_dict_extravars(mock_makedirs):
-    rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo":"test \n hello"})
+    rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo": "test \n hello"})
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc.prepare_inventory()
 
     cmd = rc.generate_ansible_command()
@@ -467,7 +467,7 @@ def test_process_isolation_executable_not_found(mock_subprocess, mock_sys, mock_
     # Mock subprocess.Popen indicates if
     # process isolation executable is present
     mock_proc = Mock()
-    mock_proc.returncode=(0 if executable_present else 1)
+    mock_proc.returncode = (0 if executable_present else 1)
     mock_subprocess.Popen.return_value = mock_proc
 
     kwargs = {'process_isolation': True,
@@ -488,7 +488,7 @@ def test_bwrap_process_isolation_defaults(mock_makedirs):
     rc.process_isolation = True
     rc.process_isolation_executable = 'bwrap'
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc.prepare()
 
     assert rc.command == [
@@ -552,7 +552,7 @@ def test_process_isolation_settings(mock_isdir, mock_exists, mock_makedirs):
     rc.process_isolation_path = '/tmp'
 
     with patch('os.path.exists') as path_exists:
-        path_exists.return_value=True
+        path_exists.return_value = True
         rc.prepare()
     print(rc.command)
     assert rc.command[0:8] == [
@@ -661,9 +661,9 @@ def test_containerization_settings(mock_isdir, mock_exists, tmpdir, container_ru
         rc.playbook = 'main.yaml'
         rc.command = 'ansible-playbook'
         rc.process_isolation = True
-        rc.process_isolation_executable=container_runtime
+        rc.process_isolation_executable = container_runtime
         rc.container_image = 'my_container'
-        rc.container_volume_mounts=['/host1:/container1', '/host2:/container2']
+        rc.container_volume_mounts = ['/host1:/container1', '/host2:/container2']
         mock_containerized.return_value = True
         rc.prepare()
 

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -117,7 +117,7 @@ def test_get_contents_ok(loader):
         handler.write(b"test string")
         handler.seek(0)
 
-        mock_open.return_value.__enter__.return_value  = handler
+        mock_open.return_value.__enter__.return_value = handler
 
         res = loader.get_contents('/tmp')
         assert res == b'test string'

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -111,7 +111,7 @@ def test_event_callback_data_check(rc):
 
     with pytest.raises(AnsibleRunnerException) as exc:
         runner.event_callback(dict(uuid="testuuid", counter=0))
-    
+
     assert "Failed to open ansible stdout callback plugin partial data" in str(exc)
 
 


### PR DESCRIPTION
All the PEP8 rules that were ignored have to do with whitespace formatting which help keep the code readable. Fix all the rule violations and remove the ignored rules.