### PR TITLE
Allow Users to Obtain Execution Node CPU and Memory Capacities

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -34,6 +34,7 @@ import tempfile
 import atexit
 
 from contextlib import contextmanager
+from pathlib import Path
 from uuid import uuid4
 
 from yaml import safe_load
@@ -41,7 +42,7 @@ from yaml import safe_load
 from ansible_runner import run
 from ansible_runner import output
 from ansible_runner.utils import dump_artifact, Bunch
-from ansible_runner.utils.capacity import get_cpu_capacity, get_mem_capacity
+from ansible_runner.utils.capacity import get_cpu_count, get_mem_info
 from ansible_runner.runner import Runner
 from ansible_runner.exceptions import AnsibleRunnerException
 
@@ -629,17 +630,18 @@ def main(sys_args=None):
         'worker',
         help="Execute work streamed from a controlling instance"
     )
-    info = worker_subparser.add_subparsers(
-        dest='worker_info',
-        help="Show the execution node's Ansible Runner version along with its memory and CPU capacities"
-    )
-    info.add_parser('capacity')
     worker_subparser.add_argument(
         "--private-data-dir",
         help="base directory containing the ansible-runner metadata "
              "(project, inventory, env, etc)",
     )
 
+    worker_subparser.add_argument(
+        "--worker-info",
+        dest="worker_info",
+        action="store_true",
+        help="show the execution node's Ansible Runner version along with its memory and CPU capacities"
+    )
     process_subparser = subparser.add_parser(
         'process',
         help="Receive the output of remote ansible-runner work and distribute the results"
@@ -763,12 +765,15 @@ def main(sys_args=None):
 
     if vargs.get('command') in ('worker', 'process'):
         if vargs.get('worker_info'):
-            cpu = get_cpu_capacity()
-            mem = get_mem_capacity()
+            cpu = get_cpu_count()
+            mem = get_mem_info()
             if cpu or mem > 0:
-                print("\nExecution Node Info\n"
-                      "-------------------\n"
-                      f"Ansible-Runner Version: {VERSION}\nCPU Capacity: {cpu}\nMemory Capacity: {mem}\n")
+                base = Path('worker_info')
+                info_file = str(uuid4().hex)
+                jsonpath = base / info_file
+                base.mkdir(exist_ok=True)
+                info = [VERSION, cpu, mem]
+                jsonpath.write_text(json.dumps(info))
                 parser.exit(0)
             else:
                 sys.tracebacklimit = 0

--- a/ansible_runner/utils/capacity.py
+++ b/ansible_runner/utils/capacity.py
@@ -2,16 +2,13 @@ import multiprocessing
 import resource
 
 
-def get_cpu_capacity():
+def get_cpu_count():
     # `multiprocessing` info: https://docs.python.org/3/library/multiprocessing.html
-    forkcpu = 4
-    cpu_capacity = multiprocessing.cpu_count() * forkcpu
+    cpu_capacity = multiprocessing.cpu_count()
     return cpu_capacity
 
 
-def get_mem_capacity():
+def get_mem_info():
     # `resource` info: https://docs.python.org/3/library/resource.html
-    byte_denom = 1024
-    mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss 
-    mem_capacity = mem / byte_denom
+    mem_capacity = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
     return mem_capacity

--- a/ansible_runner/utils/capacity.py
+++ b/ansible_runner/utils/capacity.py
@@ -1,5 +1,5 @@
 import multiprocessing
-import resource
+import re
 
 
 def get_cpu_count():
@@ -9,6 +9,13 @@ def get_cpu_count():
 
 
 def get_mem_info():
-    # `resource` info: https://docs.python.org/3/library/resource.html
-    mem_capacity = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    return mem_capacity
+    try:
+        with open('/proc/meminfo') as f:
+            mem = f.read()
+        matched = re.search(r'^MemTotal:\s+(\d+)', mem)
+        if matched:
+            mem_capacity = int(matched.groups()[0])
+        return mem_capacity
+    except FileNotFoundError:
+        error = "The /proc/meminfo file could not found, memory capacity undiscoverable."
+        return error

--- a/ansible_runner/utils/capacity.py
+++ b/ansible_runner/utils/capacity.py
@@ -1,0 +1,17 @@
+import multiprocessing
+import resource
+
+
+def get_cpu_capacity():
+    # `multiprocessing` info: https://docs.python.org/3/library/multiprocessing.html
+    forkcpu = 4
+    cpu_capacity = multiprocessing.cpu_count() * forkcpu
+    return cpu_capacity
+
+
+def get_mem_capacity():
+    # `resource` info: https://docs.python.org/3/library/resource.html
+    byte_denom = 1024
+    mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss 
+    mem_capacity = mem / byte_denom
+    return mem_capacity


### PR DESCRIPTION
Connecting AWX Issue https://github.com/ansible/awx/issues/10693

* * *

The CPU/memory capacity checks implemented in this PR are based off of the `get_cpu_capacity` and `get_mem_capacity` functions found in `awx/main/utils/common.py`:
https://github.com/ansible/awx/blob/devel/awx/main/utils/common.py#L702-L749

Since [`psutil` was removed from Ansible Runner](https://github.com/ansible/ansible-runner/pull/555) last year, `multiprocessing` and `resource` were utilized in order to surface the relevant information. 

Now, the command `ansible-runner worker capacity` can be run, with the resulting output as shown below:

![Screenshot from 2021-07-28 21-39-50](https://user-images.githubusercontent.com/28930622/127507042-445b12d5-0680-44d7-9556-ac1a58933474.png)
