### PR TITLE
Work around kernel bug that forces fuse-overlayfs in podman

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -196,8 +196,8 @@ class BaseConfig(object):
 
             if self.process_isolation_executable == 'podman':
                 # A kernel bug in RHEL < 8.5 causes podman to use the fuse-overlayfs driver. This results in errors when
-                # trying to set extended file attributes. Setting this environment variables
-                # allows modules to take advantage of a fallback to work around this bug when failures are encountered.
+                # trying to set extended file attributes. Setting this environment variable allows modules to take advantage
+                # of a fallback to work around this bug when failures are encountered.
                 #
                 # See the following for more information:
                 #    https://github.com/ansible/ansible/pull/73282

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -194,15 +194,16 @@ class BaseConfig(object):
             # Special flags to convey info to entrypoint or process in container
             self.env['LAUNCHED_BY_RUNNER'] = '1'
 
-            # A kernel bug in RHEL < 8.5 causes podman to use the fuse-overlayfs driver. This results in errors when
-            # trying to set extended file attributes. Setting this environment variables
-            # allows modules to take advantage of a fallback to work around this bug when failures are encountered.
-            #
-            # See the following for more information:
-            #    https://github.com/ansible/ansible/pull/73282
-            #    https://github.com/ansible/ansible/issues/73310
-            #    https://issues.redhat.com/browse/AAP-476
-            self.env['ANSIBLE_UNSAFE_WRITES'] = '1'
+            if self.process_isolation_executable == 'podman':
+                # A kernel bug in RHEL < 8.5 causes podman to use the fuse-overlayfs driver. This results in errors when
+                # trying to set extended file attributes. Setting this environment variables
+                # allows modules to take advantage of a fallback to work around this bug when failures are encountered.
+                #
+                # See the following for more information:
+                #    https://github.com/ansible/ansible/pull/73282
+                #    https://github.com/ansible/ansible/issues/73310
+                #    https://issues.redhat.com/browse/AAP-476
+                self.env['ANSIBLE_UNSAFE_WRITES'] = '1'
 
             artifact_dir = os.path.join("/runner/artifacts", "{}".format(self.ident))
             self.env['AWX_ISOLATED_DATA_DIR'] = artifact_dir

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -194,7 +194,7 @@ class BaseConfig(object):
             # Special flags to convey info to entrypoint or process in container
             self.env['LAUNCHED_BY_RUNNER'] = '1'
 
-            # A bug in the fuse-overlayfs driver in RHEL < 5.8 causes errors when trying to set extended file attributes.
+            # A bug in the fuse-overlayfs driver in RHEL < 8.5 causes errors when trying to set extended file attributes.
             # Setting this environment variablesallows modules to take advantage of a fallback to work around
             # this bug only when failures are encountered.
             #

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -193,6 +193,17 @@ class BaseConfig(object):
             self.env = {}
             # Special flags to convey info to entrypoint or process in container
             self.env['LAUNCHED_BY_RUNNER'] = '1'
+
+            # A bug in the fuse-overlayfs driver in RHEL < 5.8 causes errors when trying to set extended file attributes.
+            # Setting this environment variablesallows modules to take advantage of a fallback to work around
+            # this bug only when failures are encountered.
+            #
+            # See the following for more information:
+            #    https://github.com/ansible/ansible/pull/73282
+            #    https://github.com/ansible/ansible/issues/73310
+            #    https://issues.redhat.com/browse/AAP-476
+            self.env['ANSIBLE_UNSAFE_WRITES'] = '1'
+
             artifact_dir = os.path.join("/runner/artifacts", "{}".format(self.ident))
             self.env['AWX_ISOLATED_DATA_DIR'] = artifact_dir
             if self.fact_cache_type == 'jsonfile':

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -194,9 +194,9 @@ class BaseConfig(object):
             # Special flags to convey info to entrypoint or process in container
             self.env['LAUNCHED_BY_RUNNER'] = '1'
 
-            # A bug in the fuse-overlayfs driver in RHEL < 8.5 causes errors when trying to set extended file attributes.
-            # Setting this environment variablesallows modules to take advantage of a fallback to work around
-            # this bug only when failures are encountered.
+            # A kernel bug in RHEL < 8.5 causes podman to use the fuse-overlayfs driver. This results in errors when
+            # trying to set extended file attributes. Setting this environment variables
+            # allows modules to take advantage of a fallback to work around this bug when failures are encountered.
             #
             # See the following for more information:
             #    https://github.com/ansible/ansible/pull/73282

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -283,9 +283,9 @@ def test_containerization_settings(tmpdir, container_runtime):
         rc.command = ['ansible-playbook'] + rc.cmdline_args
         rc.process_isolation = True
         rc.runner_mode = 'pexpect'
-        rc.process_isolation_executable=container_runtime
+        rc.process_isolation_executable = container_runtime
         rc.container_image = 'my_container'
-        rc.container_volume_mounts=['/host1:/container1', 'host2:/container2']
+        rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
         mock_containerized.return_value = True
         rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
         rc._prepare_env()
@@ -330,9 +330,9 @@ def test_containerization_unsafe_write_setting(tmpdir, container_runtime, expect
         rc.command = ['ansible-playbook'] + rc.cmdline_args
         rc.process_isolation = True
         rc.runner_mode = 'pexpect'
-        rc.process_isolation_executable=container_runtime
+        rc.process_isolation_executable = container_runtime
         rc.container_image = 'my_container'
-        rc.container_volume_mounts=['/host1:/container1', 'host2:/container2']
+        rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
         mock_containerized.return_value = True
         rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
         rc._prepare_env()


### PR DESCRIPTION
In the current version of RHEL there is a bug in the fuser-overlayfs driver that prevents extended attributes from being set. This PR uses the mechanism [provided](https://github.com/ansible/ansible/pull/73282) in `anisble-core` to work around this issue.