### PR TITLE
Add python37-devel for tox testing

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -4,6 +4,7 @@ git
 openssh-clients
 rsync
 sshpass [epel]
+python37-devel [test platform:fedora]
 
 # ansible
 python38-cffi [platform:centos-8]


### PR DESCRIPTION
Until AWS nodes are build via diskimage-builder, we'll have to try and
install python37 ourself for testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>