### PR TITLE
Add py38 job

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -6,6 +6,7 @@
         - ansible-runner-build-container-image-stable-2.9
         - ansible-runner-build-container-image-stable-2.10
         - ansible-runner-build-container-image-stable-2.11
+        - ansible-tox-py38
         - ansible-tox-docs:
             vars:
               sphinx_build_dir: docs/build

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,7 +1,8 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 git
-openssh-clients
+openssh-clients [!platform:ubuntu-bionic]
+openssh-client [platform:ubuntu-bionic]
 rsync
 sshpass [epel]
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps = ansible27: ansible<2.8
        ansible-base: ansible-base
        py36: ansible-core
        py37: ansible-core
+       py38: ansible-core
        -rrequirements.txt
        -rtest/requirements.txt
 passenv = HOME
@@ -30,6 +31,12 @@ commands=
     py.test -v test -m serial
 
 [testenv:py37]
+passenv = HOME
+commands=
+    py.test -v -n 4 -m "not serial" test
+    py.test -v test -m serial
+
+[testenv:py38]
 passenv = HOME
 commands=
     py.test -v -n 4 -m "not serial" test


### PR DESCRIPTION
Python 3.8 is going to be our minimum. Add a tox py38 section and Zuul job. py36 and py37 will be removed from `tox.ini` after altering the project in `project-config`.