### PR TITLE
Update linter configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,4 @@ data-files =
 # W503 - Line break occurred before a binary operator
 ignore=W503
 max-line-length=160
-exclude=.tox,venv
+extend-exclude=venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,3 @@ data-files =
 # W503 - Line break occurred before a binary operator
 ignore=W503
 max-line-length=160
-extend-exclude=venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,6 @@ packages =
 data-files =
     share/ansible-runner/utils = utils/*
 
-[pep8]
-# W503 - Line break occurred before a binary operator
-ignore=W503
-exclude=.tox,venv
-
 [flake8]
 # W503 - Line break occurred before a binary operator
 ignore=W503


### PR DESCRIPTION
- remove section for `autopep8` since we don't use it
- Change `flake8` settings to exclude excludes since the default list of excluded files is good