### PR TITLE
Remove unused tox test environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,7 @@ deps = ansible27: ansible<2.8
        ansible28: ansible<2.9
        ansible29: ansible<2.10
        ansible-base: ansible-base
-       py36: ansible-core
-       py37: ansible-core
+       py3: ansible-core
        py38: ansible-core
        -rrequirements.txt
        -rtest/requirements.txt
@@ -23,24 +22,6 @@ commands=
     flake8 docs ansible_runner test
     yamllint --version
     yamllint -s .
-
-[testenv:py36]
-passenv = HOME
-commands=
-    py.test -v -n 4 -m "not serial" test
-    py.test -v test -m serial
-
-[testenv:py37]
-passenv = HOME
-commands=
-    py.test -v -n 4 -m "not serial" test
-    py.test -v test -m serial
-
-[testenv:py38]
-passenv = HOME
-commands=
-    py.test -v -n 4 -m "not serial" test
-    py.test -v test -m serial
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,13 @@ deps = ansible27: ansible<2.8
        ansible28: ansible<2.9
        ansible29: ansible<2.10
        ansible-base: ansible-base
-       py3: ansible-core
-       py38: ansible-core
+       py{,3,38}: ansible-core
        -rrequirements.txt
        -rtest/requirements.txt
 passenv = HOME
 commands=
-    py.test -v -n 4 -m "not serial" test
-    py.test -v test -m serial
+    py.test -v -n 4 -m "not serial" {posargs:test}
+    py.test -v -m serial {posargs:test}
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
The `testenv:py*` entries are not necessary (especially since we no longer run the `py36` and `py37` jobs). We just need the `py38` factor conditional dependency for the Zuul tests.

To make testing locally easier and not require a specific python version, a developer may use `py` or `py3` as the tox target. E.g., `tox -e py3` will run the tests with whichever Python 3 version you may have installed.

Also, we now use `{posargs}` so we can specify a specific test to run. Example:

`tox -e py3 -- test/integration/test_interface.py::test_env_accuracy`