### PR TITLE
Add python37-devel for tox testing

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -6,6 +6,8 @@
         - ansible-runner-build-container-image-stable-2.9
         - ansible-runner-build-container-image-stable-2.10
         - ansible-runner-build-container-image-stable-2.11
+        - ansible-tox-py36
+        - ansible-tox-py37
     gate:
       jobs: *id001
     post:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -10,19 +10,3 @@
         - ansible-tox-py37
     gate:
       jobs: *id001
-    post:
-      jobs: &id002
-        - ansible-runner-upload-container-image:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.9:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.10:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.11:
-            vars:
-              upload_container_image_promote: false
-    periodic:
-      jobs: *id002

--- a/bindep.txt
+++ b/bindep.txt
@@ -4,6 +4,7 @@ git
 openssh-clients
 rsync
 sshpass [epel]
+python37-devel [test platform:fedora]
 
 # ansible
 python38-cffi [platform:centos-8]

--- a/bindep.txt
+++ b/bindep.txt
@@ -4,7 +4,7 @@ git
 openssh-clients
 rsync
 sshpass [epel]
-python37-devel [test platform:fedora]
+python3.7 [test platform:fedora]
 
 # ansible
 python38-cffi [platform:centos-8]


### PR DESCRIPTION
The `ansible-tox-py37` job was changed from using a `centos` node to using a `fedora-latest` node. In AWS, some of these nodes will not have Python 3.7, and some will, causing random test failures. This makes sure that it is installed before running the tests.

And because the `py36` and `py37` jobs were removed from our project def in `project-config`, we re-add them here in-repo.