### PR TITLE
apply cmdline option

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -877,6 +877,7 @@ def main(sys_args=None):
                                    resource_profiling_memory_poll_interval=vargs.get('resource_profiling_memory_poll_interval'),
                                    resource_profiling_pid_poll_interval=vargs.get('resource_profiling_pid_poll_interval'),
                                    resource_profiling_results_dir=vargs.get('resource_profiling_results_dir'),
+                                   cmdline=vargs.get('cmdline'),
                                    limit=vargs.get('limit'),
                                    streamer=streamer
                                    )


### PR DESCRIPTION
The command line `--cmdline` option (not `env/cmdline` file) seemed to be ignored, so I fixed it to apply.