### PR TITLE
Add a Patchback config

### DIFF
--- a/.github/patchback.yml
+++ b/.github/patchback.yml
@@ -1,0 +1,5 @@
+---
+backport_branch_prefix: patchback/backports/
+backport_label_prefix: backport-
+target_branch_prefix: release_
+...


### PR DESCRIPTION
Seeing how y'all are working on improving the backporting experience, I thought I'd suggest a bot of my own that auto-creates backport PRs (requested by applying labels). This simplifies backporting of the clean patches dramatically with a single click (merging of the backport PRs is still manual because such things should be checked by a human, of course).

To activate the integration fully, install https://github.com/apps/patchback into this repo and create a label called `backport-2.0`. That's it! After that, any time you want a PR backported just add this label (before or after merging it) and wait for the magic to happen.

P.S. This is used by https://github.com/ansible/ansible-hub-ui (@himdel seems pretty satisfied with how it works), the whole Ansible Collections org (ask @felixfontein about the experience!), and a few of my other orgs.

Demos:
* https://github.com/ansible/ansible-hub-ui/pull/735#issuecomment-893561996 — on the original PR, a comment is created with a link to the backport
* https://github.com/ansible/ansible-hub-ui/pull/749 — this is created on success
* https://github.com/ansible/ansible-hub-ui/pull/702#issuecomment-888104962 — on conflicts, it tells people how to manually perform the process