### PR TITLE
Migrate container jobs to centos-8-stream nodeset

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -8,6 +8,7 @@
     timeout: 5400
     vars:
       zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-runner'].src_dir }}"
+    nodeset: centos-8-stream
 
 # =============================================================================
 

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -2,6 +2,7 @@
 - project:
     check:
       jobs: &id001
+        - ansible-buildset-registry
         - ansible-runner-build-container-image
         - ansible-runner-build-container-image-stable-2.9
         - ansible-runner-build-container-image-stable-2.10
@@ -14,6 +15,7 @@
       jobs: *id001
     post:
       jobs: &id002
+        - ansible-buildset-registry
         - ansible-runner-upload-container-image:
             vars:
               upload_container_image_promote: false


### PR DESCRIPTION
This should result in faster builds, and closer testing to RHEL.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1050
Depends-On: https://github.com/ansible/ansible-runner/pull/797
Signed-off-by: Paul Belanger <pabelanger@redhat.com>