### PR TITLE
Tune tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = linters, ansible{27, 28, 29, -base}
+skipsdist = True
 
 [testenv]
 deps = ansible27: ansible<2.8
@@ -10,6 +11,7 @@ deps = ansible27: ansible<2.8
        -rrequirements.txt
        -rtest/requirements.txt
 passenv = HOME
+usedevelop = True
 commands=
     py.test -v -n 4 -m "not serial" {posargs:test}
     py.test -v -m serial {posargs:test}


### PR DESCRIPTION
We can tune tox to help speed up job runs.

  https://tox.readthedocs.io/en/latest/example/general.html#avoiding-expensive-sdist

Signed-off-by: Paul Belanger <pabelanger@redhat.com>