### PR TITLE
Rework bindep.txt files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \
       echo "Installing requirements.txt" ; \
       cp /tmp/src/tools/requirements.txt /tmp/src/requirements.txt ; \
     fi \
-    && cp /tmp/src/tools/build-requirements.txt /tmp/src/build-requirements.txt
+    && cp /tmp/src/tools/build-requirements.txt /tmp/src/build-requirements.txt \
+    && cp /tmp/src/tools/bindep.txt /tmp/src/bindep.txt
 
 # NOTE(pabelanger): For downstream builds, we compile everything from source
 # over using existing wheels. Do this upstream too so we can better catch

--- a/bindep.txt
+++ b/bindep.txt
@@ -1,29 +1,2 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
-git
-openssh-clients [!platform:ubuntu-bionic]
-openssh-client [platform:ubuntu-bionic]
-rsync
-sshpass [epel]
-
-# ansible
-python38-cffi [platform:centos-8]
-python38-cryptography [platform:centos-8]
-python38-jinja2 [platform:centos-8]
-python38-pycparser [platform:centos-8]
-python38-six [platform:centos-8]
-python38-yaml [platform:centos-8]
-
-# ncclient
-python38-lxml [platform:centos-8 platform:rhel-8]
-
-# paramiko
-findutils [compile platform:centos-8 platform:rhel-8]
-gcc [compile platform:centos-8 platform:rhel-8]
-make [compile platform:centos-8 platform:rhel-8]
-python38-devel [compile platform:centos-8 platform:rhel-8]
-
-# pypsrp
-krb5-devel [compile platform:centos-8 platform:rhel-8]
-krb5-workstation [platform:centos-8 platform:rhel-8]
-python38-requests [platform:centos-8 platform:rhel-8]

--- a/tools/bindep.txt
+++ b/tools/bindep.txt
@@ -1,0 +1,29 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+git
+openssh-clients [!platform:ubuntu-bionic]
+openssh-client [platform:ubuntu-bionic]
+rsync
+sshpass [epel]
+
+# ansible
+python38-cffi [platform:centos-8]
+python38-cryptography [platform:centos-8]
+python38-jinja2 [platform:centos-8]
+python38-pycparser [platform:centos-8]
+python38-six [platform:centos-8]
+python38-yaml [platform:centos-8]
+
+# ncclient
+python38-lxml [platform:centos-8 platform:rhel-8]
+
+# paramiko
+findutils [compile platform:centos-8 platform:rhel-8]
+gcc [compile platform:centos-8 platform:rhel-8]
+make [compile platform:centos-8 platform:rhel-8]
+python38-devel [compile platform:centos-8 platform:rhel-8]
+
+# pypsrp
+krb5-devel [compile platform:centos-8 platform:rhel-8]
+krb5-workstation [platform:centos-8 platform:rhel-8]
+python38-requests [platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
When we run CI jobs, we are actually install packages for our
containers.  Given both use bindep.txt files, we need to be a little
more dynamic.

This pattern is already used for requirements.txt files and should
result in some faster CI run times.

Depends-On: https://github.com/ansible/ansible-runner/pull/796
Signed-off-by: Paul Belanger <pabelanger@redhat.com>