### PR TITLE
Small change to properly test containers

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -195,13 +195,14 @@
     name: ansible-runner-upload-container-image-stable-2.9
     parent: ansible-runner-container-image-base
 
+# =============================================================================
 - job:
     name: ansible-runner-integration
     parent: ansible-buildset-registry-consumer
     requires:
       - ansible-runner-container-image
     dependencies:
-      - ansible-buildset-registry
+      - ansible-runner-build-container-image
     vars:
       container_command: docker
 


### PR DESCRIPTION
We should depend on the container build job, not buildset registry. This
way, we pull down the proper pre-merged container for testing changes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>