### PR TITLE
New feature: support the choice to store or not passwords into file

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -159,6 +159,7 @@ def run(**kwargs):
                      be read from ``env/settings`` in ``private_data_dir``.
     :param ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
+    :param store_passwords: Disable the file ``env/passwords`` creation which store passwords provided by a dictionary with ``passwords`` argument
     :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param forks: Control Ansible parallel concurrency
     :param verbosity: Control how verbose the output of ansible-playbook is
@@ -217,6 +218,7 @@ def run(**kwargs):
     :type rotate_artifacts: int
     :type timeout: int
     :type cmdline: str
+    :type store_passwords: bool
     :type limit: str
     :type forks: int
     :type quiet: bool

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -198,11 +198,12 @@ def dump_artifacts(kwargs):
                 kwargs['inventory'] = dump_artifact(obj, path, 'hosts')
 
     for key in ('envvars', 'extravars', 'passwords', 'settings'):
-        obj = kwargs.get(key)
-        if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
-            path = os.path.join(private_data_dir, 'env')
-            dump_artifact(json.dumps(obj), path, key)
-            kwargs.pop(key)
+        if key == 'passwords' and kwargs.get('store_passwords', True) or key != 'passwords':
+            obj = kwargs.get(key)
+            if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
+                path = os.path.join(private_data_dir, 'env')
+                print(dump_artifact(json.dumps(obj), path, key))
+                kwargs.pop(key)
 
     for key in ('ssh_key', 'cmdline'):
         obj = kwargs.get(key)


### PR DESCRIPTION
Hi

When we provide passwords with `passwords` dictionnary into `run()` function, `ansible-runner` create the `env/passwords` file with the `passwords` as content.
This new feature aim to disable the storage, because password is a sensitive information.

How to provide dictionnary password (feature already exists) : 
```
passwords = {"SSH password:": "PASS"}
r = ansible_runner.run(private_data_dir='/', playbook='get_facts.yaml', inventory="myhosts", passwords=passwords)
```

How to disable the storage : 
```
passwords = {"SSH password:": "PASS"}
r = ansible_runner.run(private_data_dir='/', playbook='get_facts.yaml', inventory="myhosts", passwords=passwords, store_passwords=False)
```
