### PR TITLE
Fix unit tests to run consistently in CI and locally

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,10 @@
 markers =
     serial: tests that cannot be reliably ran with pytest multiprocessing
     timeout: used with pytest-timeout
+addopts =
+    -r a
+    --color yes
+    --showlocals
+    --verbose
+    --numprocesses auto
+    --durations 10

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -10,14 +10,14 @@ from ansible_runner.config.runner import RunnerConfig
 
 
 @pytest.fixture(scope='function')
-def rc(tmpdir):
-    rc = RunnerConfig(str(tmpdir))
+def rc(tmp_path):
+    rc = RunnerConfig(str(tmp_path))
     rc.suppress_ansible_output = True
     rc.expect_passwords = {
         pexpect.TIMEOUT: None,
         pexpect.EOF: None
     }
-    rc.cwd = str(tmpdir)
+    rc.cwd = str(tmp_path)
     rc.env = {}
     rc.job_timeout = 10
     rc.idle_timeout = 0

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -15,8 +15,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 @pytest.fixture()
-def executor(tmpdir, request, is_pre_ansible28):
-    private_data_dir = six.text_type(tmpdir.mkdir('foo'))
+def executor(tmp_path, request, is_pre_ansible28):
+    private_data_dir = six.text_type(tmp_path.mkdir('foo'))
 
     playbooks = request.node.callspec.params.get('playbook')
     playbook = list(playbooks.values())[0]
@@ -323,7 +323,7 @@ def test_module_level_no_log(executor, playbook, skipif_pre_ansible28):
     assert 'SENSITIVE' not in json.dumps(list(executor.events))
 
 
-def test_output_when_given_invalid_playbook(tmpdir):
+def test_output_when_given_invalid_playbook(tmp_path):
     # As shown in the following issue:
     #
     #   https://github.com/ansible/ansible-runner/issues/29
@@ -334,7 +334,7 @@ def test_output_when_given_invalid_playbook(tmpdir):
     #   https://github.com/ansible/ansible-runner/pull/34
     #
     # But no test validated it.  This does that.
-    private_data_dir = str(tmpdir)
+    private_data_dir = str(tmp_path)
     executor = init_runner(
         private_data_dir=private_data_dir,
         inventory="localhost ansible_connection=local",
@@ -348,7 +348,7 @@ def test_output_when_given_invalid_playbook(tmpdir):
     assert "could not be found" in stdout
 
 
-def test_output_when_given_non_playbook_script(tmpdir):
+def test_output_when_given_non_playbook_script(tmp_path):
     # As shown in the following pull request:
     #
     #   https://github.com/ansible/ansible-runner/pull/256
@@ -360,7 +360,7 @@ def test_output_when_given_non_playbook_script(tmpdir):
     # this is a retro-active test based on the sample repo provided in the PR:
     #
     #   https://github.com/AlanCoding/ansible-runner-examples/tree/master/non_playbook/sleep_with_writes
-    private_data_dir = str(tmpdir)
+    private_data_dir = str(tmp_path)
     with open(os.path.join(private_data_dir, "args"), 'w') as args_file:
         args_file.write("bash sleep_and_write.sh\n")
     with open(os.path.join(private_data_dir, "sleep_and_write.sh"), 'w') as script_file:

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -16,7 +16,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 @pytest.fixture()
 def executor(tmp_path, request, is_pre_ansible28):
-    private_data_dir = six.text_type(tmp_path.mkdir('foo'))
+    private_data_dir = tmp_path / 'foo'
+    private_data_dir.mkdir()
 
     playbooks = request.node.callspec.params.get('playbook')
     playbook = list(playbooks.values())[0]

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -7,9 +7,7 @@ import codecs
 import multiprocessing
 import shutil
 import yaml
-import tempfile
 import time
-from contextlib import contextmanager
 import pytest
 
 
@@ -28,51 +26,20 @@ def iterate_timeout(max_seconds, purpose, interval=2):
     raise Exception("Timeout waiting for %s" % purpose)
 
 
-def ensure_directory(directory):
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-
-def ensure_removed(path):
-    if os.path.exists(path):
-        if os.path.isfile(path):
-            os.unlink(path)
-        elif os.path.isdir(path):
-            shutil.rmtree(path)
-
-
-@contextmanager
-def temp_directory(files=None):
-    temp_dir = tempfile.mkdtemp()
-    print(temp_dir)
-    try:
-        yield temp_dir
-        shutil.rmtree(temp_dir)
-    except BaseException:
-        if files is not None:
-            for file in files:
-                if os.path.exists(file):
-                    with open(file) as f:
-                        print(f.read())
-        raise
-
-
-def test_temp_directory():
-
+def test_temp_directory(tmp_path):
     context = dict()
 
     def will_fail():
-        with temp_directory() as temp_dir:
-            context['saved_temp_dir'] = temp_dir
-            assert False
+        context['saved_temp_dir'] = str(tmp_path)
+        assert False
 
     def will_pass():
-        with temp_directory() as temp_dir:
-            context['saved_temp_dir'] = temp_dir
-            assert True
+        context['saved_temp_dir'] = str(tmp_path)
+        assert True
 
     with pytest.raises(AssertionError):
         will_fail()
+
     assert os.path.exists(context['saved_temp_dir'])
     shutil.rmtree(context['saved_temp_dir'])
 
@@ -113,11 +80,10 @@ def test_module_run_debug():
             shutil.rmtree('./ping')
 
 
-def test_module_run_clean():
-    with temp_directory() as temp_dir:
-        rc = main(['run', '-m', 'ping',
-                   '--hosts', 'localhost',
-                   temp_dir])
+def test_module_run_clean(tmp_path):
+    rc = main(['run', '-m', 'ping',
+               '--hosts', 'localhost',
+               str(tmp_path)])
     assert rc == 0
 
 
@@ -129,54 +95,46 @@ def test_role_run(skipif_pre_ansible28, clear_integration_artifacts):
     assert rc == 0
 
 
-def test_role_run_abs():
-    with temp_directory() as temp_dir:
-        rc = main(['run', '-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', os.path.join(HERE, 'project/roles'),
-                   temp_dir])
+def test_role_run_abs(tmp_path):
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               str(tmp_path)])
     assert rc == 0
 
 
-def test_role_logfile(skipif_pre_ansible28, clear_integration_artifacts):
+def test_role_logfile(skipif_pre_ansible28, clear_integration_artifacts, tmp_path):
+    log_file = tmp_path / 'test_role_logfile'
     rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/project/roles',
-               '--logfile', 'test_role_logfile',
+               '--logfile', str(log_file),
                'test/integration'])
-    assert os.path.exists('test_role_logfile'), rc
+    assert log_file.exists()
     assert rc == 0
 
 
-def test_role_logfile_abs():
-    try:
-        with temp_directory() as temp_dir:
-            rc = main(['run', '-r', 'benthomasson.hello_role',
-                       '--hosts', 'localhost',
-                       '--roles-path', os.path.join(HERE, 'project/roles'),
-                       '--logfile', 'new_logfile',
-                       temp_dir])
-        assert os.path.exists('new_logfile')
-        assert rc == 0
-    finally:
-        ensure_removed("new_logfile")
+def test_role_logfile_abs(tmp_path):
+    log_file = tmp_path / 'new_logfile'
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               '--logfile', str(log_file),
+               str(tmp_path)])
+    assert log_file.exists()
+    assert rc == 0
 
 
-def test_role_bad_project_dir():
-
-    with open("bad_project_dir", 'w') as f:
+def test_role_bad_project_dir(tmp_path):
+    with open(tmp_path / "bad_project_dir", 'w') as f:
         f.write('not a directory')
 
-    try:
-        with pytest.raises(OSError):
-            main(['run', '-r', 'benthomasson.hello_role',
-                  '--hosts', 'localhost',
-                  '--roles-path', os.path.join(HERE, 'project/roles'),
-                  '--logfile', 'new_logfile',
-                  'bad_project_dir'])
-    finally:
-        os.unlink('bad_project_dir')
-        ensure_removed("new_logfile")
+    with pytest.raises(OSError):
+        main(['run', '-r', 'benthomasson.hello_role',
+              '--hosts', 'localhost',
+              '--roles-path', os.path.join(HERE, 'project/roles'),
+              '--logfile', tmp_path.joinpath('new_logfile').as_posix(),
+              tmp_path.joinpath('bad_project_dir').as_posix()])
 
 
 def test_role_run_clean(skipif_pre_ansible28, clear_integration_artifacts):
@@ -188,36 +146,33 @@ def test_role_run_clean(skipif_pre_ansible28, clear_integration_artifacts):
     assert rc == 0
 
 
-def test_role_run_cmd_line_abs():
-    with temp_directory() as temp_dir:
-        rc = main(['run', '-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', os.path.join(HERE, 'project/roles'),
-                   temp_dir])
+def test_role_run_cmd_line_abs(tmp_path):
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               str(tmp_path)])
     assert rc == 0
 
 
-def test_role_run_artifacts_dir(skipif_pre_ansible28, clear_integration_artifacts):
+def test_role_run_artifacts_dir(skipif_pre_ansible28, clear_integration_artifacts, tmp_path):
     rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/roles',
-               '--artifact-dir', 'otherartifacts',
+               '--artifact-dir', tmp_path.joinpath('otherartifacts').as_posix(),
                "test/integration"])
     assert rc == 0
 
 
-def test_role_run_artifacts_dir_abs(skipif_pre_ansible28):
-    try:
-        with temp_directory() as temp_dir:
-            rc = main(['run', '-r', 'benthomasson.hello_role',
-                       '--hosts', 'localhost',
-                       '--roles-path', os.path.join(HERE, 'project/roles'),
-                       '--artifact-dir', 'otherartifacts',
-                       temp_dir])
-        assert os.path.exists(os.path.join('.', 'otherartifacts'))
-        assert rc == 0
-    finally:
-        shutil.rmtree(os.path.join('.', 'otherartifacts'))
+def test_role_run_artifacts_dir_abs(skipif_pre_ansible28, tmp_path):
+    artifacts_dir = tmp_path / 'otherartifacts'
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               '--artifact-dir', artifacts_dir.as_posix(),
+               str(tmp_path)])
+
+    assert artifacts_dir.exists()
+    assert rc == 0
 
 
 @pytest.mark.parametrize('envvars', [
@@ -228,108 +183,111 @@ def test_role_run_artifacts_dir_abs(skipif_pre_ansible28):
     }],
     ids=['regular-text', 'utf-8-text']
 )
-def test_role_run_env_vars(envvars):
+def test_role_run_env_vars(envvars, tmp_path):
+    env_path = tmp_path / 'env'
+    env_path.mkdir()
 
-    with temp_directory() as temp_dir:
-        ensure_directory(os.path.join(temp_dir, 'env'))
-        with codecs.open(os.path.join(temp_dir, 'env/envvars'), 'w', encoding='utf-8') as f:
-            f.write(yaml.dump(envvars))
+    with codecs.open(env_path / 'envvars', 'w', encoding='utf-8') as f:
+        f.write(yaml.dump(envvars))
 
-        rc = main(['run', '-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', os.path.join(HERE, 'project/roles'),
-                   temp_dir])
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               str(tmp_path)])
+
     assert rc == 0
 
 
-def test_role_run_args():
-
-    with temp_directory() as temp_dir:
-        rc = main(['run', '-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', os.path.join(HERE, 'project/roles'),
-                   '--role-vars', 'msg=hi',
-                   temp_dir])
+def test_role_run_args(tmp_path):
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               '--role-vars', 'msg=hi',
+               str(tmp_path)])
     assert rc == 0
 
 
-def test_role_run_inventory(is_pre_ansible28):
+def test_role_run_inventory(is_pre_ansible28, tmp_path):
+    src_inv = 'inventory/localhost_preansible28' if is_pre_ansible28 else 'inventory/localhost'
 
-    inv = 'inventory/localhost_preansible28' if is_pre_ansible28 else 'inventory/localhost'
-    with temp_directory() as temp_dir:
-        ensure_directory(os.path.join(temp_dir, 'inventory'))
-        shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir, 'inventory/localhost'))
+    inventory_dir = tmp_path / 'inventory'
+    inventory_dir.mkdir()
 
-        rc = main(['run', '-r', 'benthomasson.hello_role',
-                   '--hosts', 'localhost',
-                   '--roles-path', os.path.join(HERE, 'project/roles'),
-                   '--inventory', os.path.join(temp_dir, 'inventory/localhost'),
-                   temp_dir])
+    inventory = inventory_dir / 'localhost'
+
+    shutil.copy(os.path.join(HERE, src_inv), inventory)
+
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               '--inventory', str(inventory),
+               str(tmp_path)])
+
     assert rc == 0
 
 
-def test_role_run_inventory_missing(is_pre_ansible28):
+def test_role_run_inventory_missing(is_pre_ansible28, tmp_path):
+    src_inv = 'inventory/localhost_preansible28' if is_pre_ansible28 else 'inventory/localhost'
+    inventory_dir = tmp_path / 'inventory'
+    inventory_dir.mkdir()
 
-    inv = 'inventory/localhost_preansible28' if is_pre_ansible28 else 'inventory/localhost'
-    with temp_directory() as temp_dir:
-        ensure_directory(os.path.join(temp_dir, 'inventory'))
-        shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir, 'inventory/localhost'))
+    inventory = inventory_dir / 'localhost'
 
-        with pytest.raises(AnsibleRunnerException):
-            main(['run', '-r', 'benthomasson.hello_role',
-                  '--hosts', 'localhost',
-                  '--roles-path', os.path.join(HERE, 'project/roles'),
-                  '--inventory', 'does_not_exist',
-                  temp_dir])
+    shutil.copy(os.path.join(HERE, src_inv), inventory)
 
-
-def test_role_start():
-
-    with temp_directory() as temp_dir:
-        p = multiprocessing.Process(target=main,
-                                    args=[['start', '-r', 'benthomasson.hello_role',
-                                           '--hosts', 'localhost',
-                                           '--roles-path', os.path.join(HERE, 'project/roles'),
-                                           temp_dir]])
-        p.start()
-        p.join()
+    with pytest.raises(AnsibleRunnerException):
+        main(['run', '-r', 'benthomasson.hello_role',
+              '--hosts', 'localhost',
+              '--roles-path', os.path.join(HERE, 'project/roles'),
+              '--inventory', 'does_not_exist',
+              str(tmp_path)])
 
 
-def test_playbook_start(skipif_pre_ansible28):
+def test_role_start(tmp_path):
+    p = multiprocessing.Process(target=main,
+                                args=[['start', '-r', 'benthomasson.hello_role',
+                                       '--hosts', 'localhost',
+                                       '--roles-path', os.path.join(HERE, 'project/roles'),
+                                       str(tmp_path)]])
+    p.start()
+    p.join()
 
-    inv = 'inventory/localhost'
-    with temp_directory() as temp_dir:
-        project_dir = os.path.join(temp_dir, 'project')
-        ensure_directory(project_dir)
-        shutil.copy(os.path.join(HERE, 'project/hello.yml'), project_dir)
-        ensure_directory(os.path.join(temp_dir, 'inventory'))
-        shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir, 'inventory/localhost'))
 
-        # privateip: removed --hosts command line option from test beause it is
-        # not a supported combination of cli options
-        p = multiprocessing.Process(target=main,
-                                    args=[['start', '-p', 'hello.yml',
-                                           '--inventory', os.path.join(HERE, 'inventory/localhost'),
-                                           # '--hosts', 'localhost',
-                                           temp_dir]])
-        p.start()
+def test_playbook_start(skipif_pre_ansible28, tmp_path):
+    project_dir = tmp_path / 'project'
+    project_dir.mkdir()
 
-        pid_path = os.path.join(temp_dir, 'pid')
-        for _ in iterate_timeout(30, "pid file creation"):
-            if os.path.exists(pid_path):
-                break
+    shutil.copy(os.path.join(HERE, 'project/hello.yml'), project_dir)
 
-        rc = main(['is-alive', temp_dir])
-        assert rc == 0
-        rc = main(['stop', temp_dir])
-        assert rc == 0
+    inventory_dir = tmp_path / 'inventory'
+    inventory_dir.mkdir()
+    inventory = inventory_dir / 'localhost'
 
-        for _ in iterate_timeout(30, "background process to stop"):
-            rc = main(['is-alive', temp_dir])
-            if rc == 1:
-                break
+    shutil.copy(os.path.join(HERE, 'inventory/localhost'), inventory)
 
-        ensure_removed(pid_path)
+    # privateip: removed --hosts command line option from test beause it is
+    # not a supported combination of cli options
+    p = multiprocessing.Process(target=main,
+                                args=[['start', '-p', 'hello.yml',
+                                       '--inventory', os.path.join(HERE, 'inventory/localhost'),
+                                       # '--hosts', 'localhost',
+                                       str(tmp_path)]])
+    p.start()
 
-        rc = main(['stop', temp_dir])
-        assert rc == 1
+    pid_path = tmp_path / 'pid'
+    for _ in iterate_timeout(30, "pid file creation"):
+        if pid_path.exists():
+            break
+
+    rc = main(['is-alive', str(tmp_path)])
+    assert rc == 0
+    rc = main(['stop', str(tmp_path)])
+    assert rc == 0
+
+    for _ in iterate_timeout(30, "background process to stop"):
+        rc = main(['is-alive', str(tmp_path)])
+        if rc == 1:
+            break
+
+    rc = main(['stop', str(tmp_path)])
+    assert rc == 1

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -135,6 +135,9 @@ def test_role_run_abs():
     assert rc == 0
 
 
+# FIXME: This test interferes with test_role_logfile_abs. Marking it as serial so it is executed
+#        in a separate test run.
+@pytest.mark.serial
 def test_role_logfile(skipif_pre_ansible28, clear_integration_artifacts, tmp_path):
     logfile = tmp_path.joinpath('test_role_logfile')
     rc = main(['run', '-r', 'benthomasson.hello_role',

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -99,25 +99,22 @@ def test_module_run():
             shutil.rmtree('./ping')
 
 
-def test_module_run_debug():
-    try:
-        rc = main(['run', '-m', 'ping',
-                   '--hosts', 'localhost',
-                   '--debug',
-                   'ping'])
-        assert os.path.exists('./ping')
-        assert os.path.exists('./ping/artifacts')
-        assert rc == 0
-    finally:
-        if os.path.exists('./ping'):
-            shutil.rmtree('./ping')
+def test_module_run_debug(tmp_path):
+    output = tmp_path / 'ping'
+    rc = main(['run', '-m', 'ping',
+               '--hosts', 'localhost',
+               '--debug',
+               str(output)])
+
+    assert output.exists()
+    assert output.joinpath('artifacts').exists()
+    assert rc == 0
 
 
-def test_module_run_clean():
-    with temp_directory() as temp_dir:
-        rc = main(['run', '-m', 'ping',
-                   '--hosts', 'localhost',
-                   temp_dir])
+def test_module_run_clean(tmp_path):
+    rc = main(['run', '-m', 'ping',
+               '--hosts', 'localhost',
+               str(tmp_path)])
     assert rc == 0
 
 
@@ -138,28 +135,26 @@ def test_role_run_abs():
     assert rc == 0
 
 
-def test_role_logfile(skipif_pre_ansible28, clear_integration_artifacts):
+def test_role_logfile(skipif_pre_ansible28, clear_integration_artifacts, tmp_path):
+    logfile = tmp_path.joinpath('test_role_logfile')
     rc = main(['run', '-r', 'benthomasson.hello_role',
                '--hosts', 'localhost',
                '--roles-path', 'test/integration/project/roles',
-               '--logfile', 'test_role_logfile',
+               '--logfile', str(logfile),
                'test/integration'])
-    assert os.path.exists('test_role_logfile'), rc
+    assert logfile.exists()
     assert rc == 0
 
 
-def test_role_logfile_abs():
-    try:
-        with temp_directory() as temp_dir:
-            rc = main(['run', '-r', 'benthomasson.hello_role',
-                       '--hosts', 'localhost',
-                       '--roles-path', os.path.join(HERE, 'project/roles'),
-                       '--logfile', 'new_logfile',
-                       temp_dir])
-        assert os.path.exists('new_logfile')
-        assert rc == 0
-    finally:
-        ensure_removed("new_logfile")
+def test_role_logfile_abs(tmp_path):
+    rc = main(['run', '-r', 'benthomasson.hello_role',
+               '--hosts', 'localhost',
+               '--roles-path', os.path.join(HERE, 'project/roles'),
+               '--logfile', tmp_path.joinpath('new_logfile').as_posix(),
+               str(tmp_path)])
+
+    assert tmp_path.joinpath('new_logfile').exists()
+    assert rc == 0
 
 
 def test_role_bad_project_dir():

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -53,10 +53,10 @@ class TestStreamingUsage:
             assert '"ansible_facts"' in stdout
 
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
-    def test_remote_job_interface(self, tmpdir, test_data_dir, job_type):
+    def test_remote_job_interface(self, tmp_path, test_data_dir, job_type):
         transmit_dir = os.path.join(test_data_dir, 'debug')
-        worker_dir = str(tmpdir.mkdir('for_worker'))
-        process_dir = str(tmpdir.mkdir('for_process'))
+        worker_dir = str(tmp_path.mkdir('for_worker'))
+        process_dir = str(tmp_path.mkdir('for_process'))
         job_kwargs = self.get_job_kwargs(job_type)
 
         outgoing_buffer = tempfile.NamedTemporaryFile()
@@ -93,14 +93,14 @@ class TestStreamingUsage:
         self.check_artifacts(process_dir, job_type)
 
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
-    def test_remote_job_by_sockets(self, tmpdir, test_data_dir, container_runtime_installed, job_type):
+    def test_remote_job_by_sockets(self, tmp_path, test_data_dir, container_runtime_installed, job_type):
         """This test case is intended to be close to how the AWX use case works
         the process interacts with receptorctl with sockets
         sockets are used here, but worker is manually called instead of invoked by receptor
         """
         transmit_dir = os.path.join(test_data_dir, 'debug')
-        worker_dir = str(tmpdir.mkdir('for_worker'))
-        process_dir = str(tmpdir.mkdir('for_process'))
+        worker_dir = str(tmp_path.mkdir('for_worker'))
+        process_dir = str(tmp_path.mkdir('for_process'))
         job_kwargs = self.get_job_kwargs(job_type)
 
         def transmit_method(transmit_sockfile_write):
@@ -207,8 +207,8 @@ def test_missing_private_dir_transmit(tmpdir):
     assert "private_data_dir path is either invalid or does not exist" in str(excinfo.value)
 
 
-def test_garbage_private_dir_worker(tmpdir):
-    worker_dir = str(tmpdir.mkdir('for_worker'))
+def test_garbage_private_dir_worker(tmp_path):
+    worker_dir = str(tmp_path.mkdir('for_worker'))
     incoming_buffer = io.BytesIO(
         b'{"kwargs": {"playbook": "debug.yml"}}\n{"zipfile": 5}\n\x01\x02\x03\x04\x05{"eof": true}\n')
     outgoing_buffer = io.BytesIO()
@@ -224,8 +224,8 @@ def test_garbage_private_dir_worker(tmpdir):
     assert b'"status": "error"' in sent
 
 
-def test_unparsable_private_dir_worker(tmpdir):
-    worker_dir = str(tmpdir.mkdir('for_worker'))
+def test_unparsable_private_dir_worker(tmp_path):
+    worker_dir = str(tmp_path.mkdir('for_worker'))
     incoming_buffer = io.BytesIO(b'')
     outgoing_buffer = io.BytesIO()
 
@@ -240,8 +240,8 @@ def test_unparsable_private_dir_worker(tmpdir):
     assert b'"status": "error"' in sent
 
 
-def test_unparsable_private_dir_processor(tmpdir):
-    process_dir = str(tmpdir.mkdir('for_process'))
+def test_unparsable_private_dir_processor(tmp_path):
+    process_dir = str(tmp_path.mkdir('for_process'))
     incoming_buffer = io.BytesIO(b'')
 
     processor = run(

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -55,8 +55,12 @@ class TestStreamingUsage:
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
     def test_remote_job_interface(self, tmp_path, test_data_dir, job_type):
         transmit_dir = os.path.join(test_data_dir, 'debug')
-        worker_dir = str(tmp_path.mkdir('for_worker'))
-        process_dir = str(tmp_path.mkdir('for_process'))
+        worker_dir = tmp_path / 'for_worker'
+        worker_dir.mkdir()
+
+        process_dir = tmp_path / 'for_process'
+        process_dir.mkdir()
+
         job_kwargs = self.get_job_kwargs(job_type)
 
         outgoing_buffer = tempfile.NamedTemporaryFile()
@@ -90,7 +94,7 @@ class TestStreamingUsage:
         processor = Processor(_input=incoming_buffer, private_data_dir=process_dir)
         processor.run()
 
-        self.check_artifacts(process_dir, job_type)
+        self.check_artifacts(str(process_dir), job_type)
 
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
     def test_remote_job_by_sockets(self, tmp_path, test_data_dir, container_runtime_installed, job_type):
@@ -99,8 +103,12 @@ class TestStreamingUsage:
         sockets are used here, but worker is manually called instead of invoked by receptor
         """
         transmit_dir = os.path.join(test_data_dir, 'debug')
-        worker_dir = str(tmp_path.mkdir('for_worker'))
-        process_dir = str(tmp_path.mkdir('for_process'))
+        worker_dir = tmp_path / 'for_worker'
+        worker_dir.mkdir()
+
+        process_dir = tmp_path / 'for_process'
+        process_dir.mkdir()
+
         job_kwargs = self.get_job_kwargs(job_type)
 
         def transmit_method(transmit_sockfile_write):
@@ -155,7 +163,7 @@ class TestStreamingUsage:
 
         assert set(os.listdir(worker_dir)) == {'artifacts', 'inventory', 'project', 'env'}
 
-        self.check_artifacts(process_dir, job_type)
+        self.check_artifacts(str(process_dir), job_type)
 
 
 @pytest.fixture(scope='session')
@@ -208,7 +216,8 @@ def test_missing_private_dir_transmit(tmpdir):
 
 
 def test_garbage_private_dir_worker(tmp_path):
-    worker_dir = str(tmp_path.mkdir('for_worker'))
+    worker_dir = tmp_path / 'for_worker'
+    worker_dir.mkdir()
     incoming_buffer = io.BytesIO(
         b'{"kwargs": {"playbook": "debug.yml"}}\n{"zipfile": 5}\n\x01\x02\x03\x04\x05{"eof": true}\n')
     outgoing_buffer = io.BytesIO()
@@ -225,7 +234,8 @@ def test_garbage_private_dir_worker(tmp_path):
 
 
 def test_unparsable_private_dir_worker(tmp_path):
-    worker_dir = str(tmp_path.mkdir('for_worker'))
+    worker_dir = tmp_path / 'for_worker'
+    worker_dir.mkdir()
     incoming_buffer = io.BytesIO(b'')
     outgoing_buffer = io.BytesIO()
 
@@ -241,7 +251,8 @@ def test_unparsable_private_dir_worker(tmp_path):
 
 
 def test_unparsable_private_dir_processor(tmp_path):
-    process_dir = str(tmp_path.mkdir('for_process'))
+    process_dir = tmp_path / 'for_process'
+    process_dir.mkdir()
     incoming_buffer = io.BytesIO(b'')
 
     processor = run(

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-mock
 pytest-xdist
 mock
 flake8

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -299,7 +299,7 @@ def test_containerization_settings(tmp_path, container_runtime, mocker):
     if container_runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
-        extra_container_args = ['--user={os.getuid()}']
+        extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
         container_runtime,
@@ -328,11 +328,7 @@ def test_containerization_settings(tmp_path, container_runtime, mocker):
         'my_container', 'ansible-playbook', 'main.yaml', '-i', '/tmp/inventory',
     ])
 
-    for index, element in enumerate(expected_command_start):
-        if '--user=' in element:
-            assert '--user=' in rc.command[index]
-        else:
-            assert rc.command[index] == element
+    assert expected_command_start == rc.command
 
 
 @pytest.mark.parametrize(

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -55,12 +55,12 @@ def test_prepare_config_invalid_action():
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_config_command_with_containerization(tmpdir, container_runtime, mocker):
-    mocker.patch.dict('os.environ', {'HOME': str(tmpdir)}, clear=True)
-    os.mkdir(os.path.join(tmpdir, '.ssh'))
+def test_prepare_config_command_with_containerization(tmp_path, container_runtime, mocker):
+    mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
+    tmp_path.joinpath('.ssh').mkdir()
 
     kwargs = {
-        'private_data_dir': tmpdir,
+        'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
         'process_isolation_executable': container_runtime

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -55,7 +55,10 @@ def test_prepare_config_invalid_action():
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_config_command_with_containerization(tmpdir, container_runtime):
+def test_prepare_config_command_with_containerization(tmpdir, container_runtime, mocker):
+    mocker.patch.dict('os.environ', {'HOME': str(tmpdir)}, clear=True)
+    os.mkdir(os.path.join(tmpdir, '.ssh'))
+
     kwargs = {
         'private_data_dir': tmpdir,
         'process_isolation': True,
@@ -73,17 +76,36 @@ def test_prepare_config_command_with_containerization(tmpdir, container_runtime)
     else:
         extra_container_args = ['--user={os.getuid()}']
 
-    expected_command_start = [container_runtime, 'run', '--rm', '--interactive', '--workdir', '/runner/project'] + \
-                             ['-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
-    if container_runtime == 'podman':
-        expected_command_start += ['--group-add=root', '--ipc=host']
+    expected_command_start = [
+        container_runtime,
+        'run',
+        '--rm',
+        '--interactive',
+        '--workdir',
+        '/runner/project',
+        '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
+    ]
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
-        ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
-        extra_container_args + \
-        ['--name', 'ansible_runner_foo'] + \
-        ['my_container', 'ansible-config', 'list', '-c', '/tmp/ansible.cfg']
+    if container_runtime == 'podman':
+        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+
+    expected_command_start.extend([
+        '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
+        '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
+        '--env-file', '{}/env.list'.format(rc.artifact_dir),
+    ])
+
+    expected_command_start.extend(extra_container_args)
+
+    expected_command_start.extend([
+        '--name',
+        'ansible_runner_foo',
+        'my_container',
+        'ansible-config',
+        'list',
+        '-c',
+        '/tmp/ansible.cfg',
+    ])
 
     for index, element in enumerate(expected_command_start):
         if '--user=' in element:

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -74,7 +74,7 @@ def test_prepare_config_command_with_containerization(tmp_path, container_runtim
     if container_runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
-        extra_container_args = ['--user={os.getuid()}']
+        extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
         container_runtime,
@@ -107,8 +107,4 @@ def test_prepare_config_command_with_containerization(tmp_path, container_runtim
         '/tmp/ansible.cfg',
     ])
 
-    for index, element in enumerate(expected_command_start):
-        if '--user=' in element:
-            assert '--user=' in rc.command[index]
-        else:
-            assert rc.command[index] == element
+    assert expected_command_start == rc.command

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -64,12 +64,12 @@ def test_prepare_run_command_generic():
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_run_command_with_containerization(tmpdir, container_runtime, mocker):
-    mocker.patch.dict('os.environ', {'HOME': str(tmpdir)}, clear=True)
-    os.mkdir(os.path.join(tmpdir, '.ssh'))
+def test_prepare_run_command_with_containerization(tmp_path, container_runtime, mocker):
+    mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
+    tmp_path.joinpath('.ssh').mkdir()
 
     kwargs = {
-        'private_data_dir': tmpdir,
+        'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
         'process_isolation_executable': container_runtime

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -64,7 +64,10 @@ def test_prepare_run_command_generic():
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_run_command_with_containerization(tmpdir, container_runtime):
+def test_prepare_run_command_with_containerization(tmpdir, container_runtime, mocker):
+    mocker.patch.dict('os.environ', {'HOME': str(tmpdir)}, clear=True)
+    os.mkdir(os.path.join(tmpdir, '.ssh'))
+
     kwargs = {
         'private_data_dir': tmpdir,
         'process_isolation': True,
@@ -85,18 +88,37 @@ def test_prepare_run_command_with_containerization(tmpdir, container_runtime):
     else:
         extra_container_args = ['--user={os.getuid()}']
 
-    expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
-                             ['-v', '{}/:{}/'.format(cwd, cwd), '-v', '{}/.ssh/:/home/runner/.ssh/'.format(os.environ['HOME'])]
+    expected_command_start = [
+        container_runtime,
+        'run',
+        '--rm',
+        '--tty',
+        '--interactive',
+        '--workdir',
+        '/runner/project',
+        '-v', '{}/:{}/'.format(cwd, cwd),
+        '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
+    ]
 
     if container_runtime == 'podman':
-        expected_command_start += ['--group-add=root', '--ipc=host']
+        expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
-    expected_command_start += ['-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir)] + \
-        ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
-        ['--env-file', '{}/env.list'.format(rc.artifact_dir)] + \
-        extra_container_args + \
-        ['--name', 'ansible_runner_foo'] + \
-        ['my_container'] + [executable_cmd] + cmdline_args
+    expected_command_start.extend([
+        '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
+        '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
+        '--env-file', '{}/env.list'.format(rc.artifact_dir),
+    ])
+
+    expected_command_start.extend(extra_container_args)
+
+    expected_command_start.extend([
+        '--name',
+        'ansible_runner_foo',
+        'my_container',
+        executable_cmd,
+    ])
+
+    expected_command_start.extend(cmdline_args)
 
     for index, element in enumerate(expected_command_start):
         if '--user=' in element:

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -86,7 +86,7 @@ def test_prepare_run_command_with_containerization(tmp_path, container_runtime, 
     if container_runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
-        extra_container_args = ['--user={os.getuid()}']
+        extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
         container_runtime,
@@ -120,8 +120,4 @@ def test_prepare_run_command_with_containerization(tmp_path, container_runtime, 
 
     expected_command_start.extend(cmdline_args)
 
-    for index, element in enumerate(expected_command_start):
-        if '--user=' in element:
-            assert '--user=' in rc.command[index]
-        else:
-            assert rc.command[index] == element
+    assert expected_command_start == rc.command

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -84,7 +84,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_r
     if container_runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
-        extra_container_args = ['--user={os.getuid()}']
+        extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
         container_runtime,
@@ -118,11 +118,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_r
         'file',
     ])
 
-    for index, element in enumerate(expected_command_start):
-        if '--user=' in element:
-            assert '--user=' in rc.command[index]
-        else:
-            assert rc.command[index] == element
+    assert expected_command_start == rc.command
 
 
 def test_prepare_plugin_list_command():
@@ -137,7 +133,7 @@ def test_prepare_plugin_list_command():
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
 def test_prepare_plugin_list_command_with_containerization(tmp_path, container_runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
-    os.mkdir(os.path.join(tmp_path, '.ssh'))
+    tmp_path.joinpath('.ssh').mkdir()
 
     kwargs = {
         'private_data_dir': tmp_path,
@@ -155,7 +151,7 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, container_r
     if container_runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
-        extra_container_args = ['--user={os.getuid()}']
+        extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
         container_runtime,

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -61,12 +61,12 @@ def test_prepare_plugin_docs_command():
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_plugin_docs_command_with_containerization(tmpdir, container_runtime, mocker):
-    mocker.patch.dict('os.environ', {'HOME': str(tmpdir)}, clear=True)
-    os.mkdir(os.path.join(tmpdir, '.ssh'))
+def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_runtime, mocker):
+    mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
+    tmp_path.joinpath('.ssh').mkdir()
 
     kwargs = {
-        'private_data_dir': tmpdir,
+        'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
         'process_isolation_executable': container_runtime
@@ -135,12 +135,12 @@ def test_prepare_plugin_list_command():
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_plugin_list_command_with_containerization(tmpdir, container_runtime, mocker):
-    mocker.patch.dict('os.environ', {'HOME': str(tmpdir)}, clear=True)
-    os.mkdir(os.path.join(tmpdir, '.ssh'))
+def test_prepare_plugin_list_command_with_containerization(tmp_path, container_runtime, mocker):
+    mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
+    os.mkdir(os.path.join(tmp_path, '.ssh'))
 
     kwargs = {
-        'private_data_dir': tmpdir,
+        'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
         'process_isolation_executable': container_runtime

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -87,12 +87,12 @@ def test_prepare_inventory_invalid_graph_response_format():
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_inventory_command_with_containerization(tmpdir, container_runtime, mocker):
-    mocker.patch.dict('os.environ', {'HOME': str(tmpdir)}, clear=True)
-    os.mkdir(os.path.join(tmpdir, '.ssh'))
+def test_prepare_inventory_command_with_containerization(tmp_path, container_runtime, mocker):
+    mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
+    tmp_path.joinpath('.ssh').mkdir()
 
     kwargs = {
-        'private_data_dir': tmpdir,
+        'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
         'process_isolation_executable': container_runtime

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -109,7 +109,7 @@ def test_prepare_inventory_command_with_containerization(tmp_path, container_run
     if container_runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
-        extra_container_args = ['--user={os.getuid()}']
+        extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
         container_runtime,
@@ -150,8 +150,4 @@ def test_prepare_inventory_command_with_containerization(tmp_path, container_run
 
     assert len(expected_command_start) == len(rc.command)
 
-    for index, element in enumerate(expected_command_start):
-        if '--user=' in element:
-            assert '--user=' in rc.command[index]
-        else:
-            assert rc.command[index] == element
+    assert expected_command_start == rc.command

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -635,8 +635,8 @@ def test_profiling_plugin_settings_with_custom_intervals(mock_mkdir):
 
 @patch('os.path.isdir', return_value=True)
 @patch('os.path.exists', return_value=True)
-def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmpdir):
-    rc = RunnerConfig(str(tmpdir))
+def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmp_path):
+    rc = RunnerConfig(str(tmp_path))
     rc.container_volume_mounts = ['/tmp/project_path:/tmp/project_path:Z']
     rc.container_name = 'foo'
     rc.env = {}
@@ -654,9 +654,9 @@ def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmpdir):
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
 @patch('os.path.isdir', return_value=True)
 @patch('os.path.exists', return_value=True)
-def test_containerization_settings(mock_isdir, mock_exists, tmpdir, container_runtime):
+def test_containerization_settings(mock_isdir, mock_exists, tmp_path, container_runtime):
     with patch('ansible_runner.runner_config.RunnerConfig.containerized', new_callable=PropertyMock) as mock_containerized:
-        rc = RunnerConfig(tmpdir)
+        rc = RunnerConfig(tmp_path)
         rc.ident = 'foo'
         rc.playbook = 'main.yaml'
         rc.command = 'ansible-playbook'

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -600,10 +600,11 @@ def test_profiling_plugin_settings(mock_mkdir):
         '--sticky',
         '-g',
         'cpuacct,memory,pids:ansible-runner/{}'.format(rc.ident),
-        'ansible-playbook'
+        'ansible-playbook',
+        'main.yaml',
     ]
-    for index, element in enumerate(expected_command_start):
-        assert rc.command[index] == element
+
+    assert expected_command_start == rc.command
     assert 'main.yaml' in rc.command
     assert rc.env['ANSIBLE_CALLBACK_WHITELIST'] == 'cgroup_perf_recap'
     assert rc.env['CGROUP_CONTROL_GROUP'] == 'ansible-runner/{}'.format(rc.ident)
@@ -671,7 +672,7 @@ def test_containerization_settings(mock_isdir, mock_exists, tmp_path, container_
     if container_runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
-        extra_container_args = ['--user={os.getuid()}']
+        extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [container_runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
         ['-v', '{}/:/runner/:Z'.format(rc.private_data_dir)] + \
@@ -681,8 +682,4 @@ def test_containerization_settings(mock_isdir, mock_exists, tmp_path, container_
         ['--name', 'ansible_runner_foo'] + \
         ['my_container', 'ansible-playbook', '-i', '/runner/inventory/hosts', 'main.yaml']
 
-    for index, element in enumerate(expected_command_start):
-        if '--user' in element:
-            assert '--user=' in rc.command[index]
-        else:
-            assert rc.command[index] == element
+    assert expected_command_start == rc.command

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -18,14 +18,14 @@ HERE, FILENAME = os.path.split(__file__)
 
 
 @pytest.fixture(scope='function')
-def rc(request, tmpdir):
-    rc = RunnerConfig(str(tmpdir))
+def rc(request, tmp_path):
+    rc = RunnerConfig(str(tmp_path))
     rc.suppress_ansible_output = True
     rc.expect_passwords = {
         pexpect.TIMEOUT: None,
         pexpect.EOF: None
     }
-    rc.cwd = str(tmpdir)
+    rc.cwd = str(tmp_path)
     rc.env = {}
     rc.job_timeout = .5
     rc.idle_timeout = 0

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -235,6 +235,8 @@ def test_sanitize_container_name(container_name, expected_name):
     ('filedoesnotexist.txt', [])
 ], ids=['global', 'local', 'directory', 'recursive', 'bad'])
 def test_transmit_symlink(tmpdir, symlink_dest, check_content):
+    if not os.path.exists(symlink_dest):
+        pytest.skip(f"File does not exists {symlink_dest}")
     # prepare the input private_data_dir directory to zip
     pdd = tmpdir.mkdir('symlink_zip_test')
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import tempfile
 import io
@@ -253,11 +254,10 @@ def test_transmit_symlink(tmp_path, symlink_dest, check_content):
 
     old_symlink_path = pdd / 'my_link'
     old_symlink_path.symlink_to(symlink_dest)
-    # os.symlink(symlink_dest, old_symlink_path)
 
     # SANITY - set expectations for the symlink
     assert old_symlink_path.is_symlink()
-    old_symlink_path.readlink() == symlink_dest
+    assert os.readlink(old_symlink_path) == str(symlink_dest)
 
     # zip and stream the data into the in-memory buffer outgoing_buffer
     outgoing_buffer = io.BytesIO()
@@ -280,7 +280,7 @@ def test_transmit_symlink(tmp_path, symlink_dest, check_content):
         # Assure the new symlink is still the same type of symlink
         new_symlink_path = dest_dir / 'my_link'
         assert new_symlink_path.is_symlink()
-        new_symlink_path.readlink() == symlink_dest
+        assert os.readlink(new_symlink_path) == str(symlink_dest)
 
     for fname in check_content:
         abs_path = dest_dir / fname

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@ envlist = linters, ansible{27, 28, 29, -base}
 skipsdist = True
 
 [testenv]
+description = Run tests with {basepython}
 deps = ansible27: ansible<2.8
        ansible28: ansible<2.9
        ansible29: ansible<2.10
        ansible-base: ansible-base
        py{,3,38}: ansible-core
-       -rrequirements.txt
-       -rtest/requirements.txt
+       -r {toxinidir}/requirements.txt
+       -r {toxinidir}/test/requirements.txt
 passenv = HOME
 usedevelop = True
 commands=
@@ -17,6 +18,7 @@ commands=
     pytest -n 0 -m serial {posargs:test}
 
 [testenv:linters]
+description = Run code linters
 basepython = python3
 commands=
     flake8 --version
@@ -25,6 +27,7 @@ commands=
     yamllint -s .
 
 [testenv:docs]
+description = Build documentation
 deps = -r{toxinidir}/docs/requirements.txt
 commands =
     sphinx-build -E -W -d docs/build/doctrees -b html docs docs/build/html

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ deps = ansible27: ansible<2.8
 passenv = HOME
 usedevelop = True
 commands=
-    py.test -v -n 4 -m "not serial" {posargs:test}
-    py.test -v -m serial {posargs:test}
+    pytest -m "not serial" {posargs:test}
+    pytest -n 0 -m serial {posargs:test}
 
 [testenv:linters]
 basepython = python3


### PR DESCRIPTION
- use pytest-mock and `tmp_path` fixtures
- mock test environment variables to prevent inconsistent test results
- reformat test fixtures so they are easier to read

This will resolve the test failures in #805.