### PR TITLE
Delete broken --keep-files, add new flag just for worker command

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -35,7 +35,6 @@ from ansible_runner.output import debug
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.utils import (
-    register_for_cleanup,
     open_fifo_write,
     args2cmdline,
     sanitize_container_name,
@@ -95,8 +94,6 @@ class BaseConfig(object):
             os.makedirs(self.private_data_dir, exist_ok=True, mode=0o700)
         else:
             self.private_data_dir = tempfile.mkdtemp(prefix=".ansible-runner-")
-
-            register_for_cleanup(self.private_data_dir)
 
         if artifact_dir is None:
             artifact_dir = os.path.join(self.private_data_dir, 'artifacts')

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -35,6 +35,7 @@ from ansible_runner.output import debug
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.utils import (
+    register_for_cleanup,
     open_fifo_write,
     args2cmdline,
     sanitize_container_name,
@@ -94,6 +95,8 @@ class BaseConfig(object):
             os.makedirs(self.private_data_dir, exist_ok=True, mode=0o700)
         else:
             self.private_data_dir = tempfile.mkdtemp(prefix=".ansible-runner-")
+
+            register_for_cleanup(self.private_data_dir)
 
         if artifact_dir is None:
             artifact_dir = os.path.join(self.private_data_dir, 'artifacts')

--- a/ansible_runner/config/runner.py
+++ b/ansible_runner/config/runner.py
@@ -31,6 +31,7 @@ from ansible_runner import output
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.output import debug
+from ansible_runner.utils import register_for_cleanup
 
 
 logger = logging.getLogger('ansible-runner')
@@ -355,6 +356,9 @@ class RunnerConfig(BaseConfig):
         '''
         path = tempfile.mkdtemp(prefix='ansible_runner_pi_', dir=self.process_isolation_path)
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+        register_for_cleanup(path)
+
         return path
 
     def wrap_args_with_cgexec(self, args):

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -15,6 +15,7 @@ import ansible_runner
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.loader import ArtifactLoader
 import ansible_runner.plugins
+from ansible_runner.utils import register_for_cleanup
 from ansible_runner.utils.streaming import stream_dir, unstream_dir
 
 
@@ -74,6 +75,7 @@ class Worker(object):
         private_data_dir = kwargs.get('private_data_dir')
         if private_data_dir is None:
             private_data_dir = tempfile.mkdtemp()
+            register_for_cleanup(private_data_dir)
         self.private_data_dir = private_data_dir
 
         self.status = "unstarted"

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -14,6 +14,7 @@ import threading
 import pipes
 import uuid
 import codecs
+import atexit
 
 from distutils.spawn import find_executable
 from ansible_runner.exceptions import ConfigurationError
@@ -24,6 +25,21 @@ except ImportError:
     from collections import Iterable, Mapping
 from io import StringIO
 from six import string_types, PY2, PY3, text_type, binary_type
+
+
+def _cleanup_folder(folder):
+    try:
+        shutil.rmtree(folder)
+    except FileNotFoundError:
+        pass
+
+
+def register_for_cleanup(folder):
+    '''
+    Provide the path to a folder to make sure it is deleted when execution finishes.
+    The folder need not exist at the time when this is called.
+    '''
+    atexit.register(_cleanup_folder, folder)
 
 
 class Bunch(object):

--- a/docs/remote_jobs.rst
+++ b/docs/remote_jobs.rst
@@ -27,6 +27,7 @@ This command optionally accepts the `--private-data-dir` option.
 If provided, it will extract the contents sent from `ansible-runner transmit` into that directory.
 If no `--private-data-dir` is given, then it will extract the contents to a temporary directory,
 which will be deleted at the end of execution.
+You can use the `--delete` flag to assure that files are deleted from a location specified by `--private-data-dir` as well.
 
 The `ansible-runner process` command accepts the result stream from the worker, and fires all the normal callbacks
 and does job event processing.  In the command above, this results in printing the playbook output and saving

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,6 +25,6 @@ def skipif_pre_ansible28(is_pre_ansible28):
         pytest.skip("Valid only on Ansible 2.8+")
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def test_data_dir():
     return os.path.join(os.path.dirname(__file__), 'data')

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,5 +1,8 @@
 import os
 import shutil
+import subprocess
+import json
+import yaml
 
 import pytest
 import pexpect
@@ -71,3 +74,56 @@ def clear_integration_artifacts(request):
             shutil.rmtree(path)
 
     request.addfinalizer(rm_integration_artifacts)
+
+
+class CompletedProcessProxy(object):
+
+    def __init__(self, result):
+        self.result = result
+
+    def __getattr__(self, attr):
+        return getattr(self.result, attr)
+
+    @property
+    def json(self):
+        try:
+            response_json = json.loads(self.stdout)
+        except json.JSONDecodeError:
+            pytest.fail(
+                f"Unable to convert the response to a valid json - stdout: {self.stdout}, stderr: {self.stderr}"
+            )
+        return response_json
+
+    @property
+    def yaml(self):
+        return yaml.safe_load(self.stdout)
+
+
+@pytest.fixture(scope='function')
+def cli(request):
+    def run(args, *a, **kw):
+        if not kw.pop('bare', None):
+            args = ['ansible-runner'] + args
+        kw['encoding'] = 'utf-8'
+        if 'check' not in kw:
+            # By default we want to fail if a command fails to run. Tests that
+            # want to skip this can pass check=False when calling this fixture
+            kw['check'] = True
+        if 'stdout' not in kw:
+            kw['stdout'] = subprocess.PIPE
+        if 'stderr' not in kw:
+            kw['stderr'] = subprocess.PIPE
+
+        kw.setdefault('env', os.environ.copy()).update({
+            'LANG': 'en_US.UTF-8'
+        })
+
+        try:
+            ret = CompletedProcessProxy(subprocess.run(' '.join(args), shell=True, *a, **kw))
+        except subprocess.CalledProcessError as err:
+            pytest.fail(
+                f"Running {err.cmd} resulted in a non-zero return code: {err.returncode} - stdout: {err.stdout}, stderr: {err.stderr}"
+            )
+
+        return ret
+    return run

--- a/test/integration/containerized/conftest.py
+++ b/test/integration/containerized/conftest.py
@@ -1,8 +1,3 @@
-import json
-import os
-import subprocess
-import yaml
-
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -16,56 +11,3 @@ def tmp_file_maker():
             tempf.write(bytes(text, 'UTF-8'))
         return tempf.name
     return tmp_file
-
-
-class CompletedProcessProxy(object):
-
-    def __init__(self, result):
-        self.result = result
-
-    def __getattr__(self, attr):
-        return getattr(self.result, attr)
-
-    @property
-    def json(self):
-        try:
-            response_json = json.loads(self.stdout)
-        except json.JSONDecodeError:
-            pytest.fail(
-                f"Unable to convert the response to a valid json - stdout: {self.stdout}, stderr: {self.stderr}"
-            )
-        return response_json
-
-    @property
-    def yaml(self):
-        return yaml.safe_load(self.stdout)
-
-
-@pytest.fixture(scope='function')
-def cli(request):
-    def run(args, *a, **kw):
-        if not kw.pop('bare', None):
-            args = ['ansible-runner'] + args
-        kw['encoding'] = 'utf-8'
-        if 'check' not in kw:
-            # By default we want to fail if a command fails to run. Tests that
-            # want to skip this can pass check=False when calling this fixture
-            kw['check'] = True
-        if 'stdout' not in kw:
-            kw['stdout'] = subprocess.PIPE
-        if 'stderr' not in kw:
-            kw['stderr'] = subprocess.PIPE
-
-        kw.setdefault('env', os.environ.copy()).update({
-            'LANG': 'en_US.UTF-8'
-        })
-
-        try:
-            ret = CompletedProcessProxy(subprocess.run(' '.join(args), shell=True, *a, **kw))
-        except subprocess.CalledProcessError as err:
-            pytest.fail(
-                f"Running {err.cmd} resulted in a non-zero return code: {err.returncode} - stdout: {err.stdout}, stderr: {err.stderr}"
-            )
-
-        return ret
-    return run

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -158,6 +158,40 @@ class TestStreamingUsage:
         self.check_artifacts(process_dir, job_type)
 
 
+@pytest.fixture(scope='session')
+def transmit_stream(test_data_dir):
+    outgoing_buffer = tempfile.NamedTemporaryFile()
+    transmit_dir = os.path.join(test_data_dir, 'debug')
+    transmitter = Transmitter(_output=outgoing_buffer, private_data_dir=transmit_dir, playbook='debug.yml')
+    status, rc = transmitter.run()
+    assert rc in (None, 0)
+    assert status == 'unstarted'
+    return outgoing_buffer
+
+
+@pytest.mark.parametrize('delete', [False, True])
+def test_worker_preserve_or_delete_dir(tmp_path, cli, transmit_stream, delete):
+    worker_dir = str(tmp_path / 'for_worker')
+    os.mkdir(worker_dir)
+
+    test_file_path = os.path.join(worker_dir, 'test_file.txt')
+    with open(os.path.join(worker_dir, 'test_file.txt'), 'w') as f:
+        f.write('foobar')
+
+    with open(transmit_stream.name, 'r') as f:
+        worker_args = ['worker', '--private-data-dir', worker_dir]
+        if delete is True:
+            worker_args.append('--delete')
+        r = cli(worker_args, stdin=f)
+
+    assert '{"eof": true}' in r.stdout
+    for test_path in (test_file_path, os.path.join(worker_dir, 'project', 'debug.yml')):
+        if delete:
+            assert not os.path.exists(test_path)
+        else:
+            assert os.path.exists(test_path)
+
+
 def test_missing_private_dir_transmit(tmpdir):
     outgoing_buffer = io.BytesIO()
 


### PR DESCRIPTION
Connect https://github.com/ansible/awx/issues/10687

This would fulfill our requirement of deleting the private data dir after the worker command finishes. Background: the worker command streams and unzips it into the target dir (either specified or a new temporary file). So deleting the directory is just deleting what the command, itself, wrote.

I'm still debating a few specific implementation details, but this has developed enough that any questions would be helpful. I may be asking myself the same questions...