### PR TITLE
Add stable-2.12 container builds

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -58,47 +58,48 @@
 # =============================================================================
 
 - job:
-    name: ansible-runner-build-container-image-stable-2.10
+    name: ansible-runner-build-container-image-stable-2.12
     parent: ansible-build-container-image
     provides:
-      - ansible-runner-stable-2.10-container-image
+      - ansible-runner-stable-2.12-container-image
     requires:
       - python-base-container-image
       - python-builder-container-image
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars: &ansible_runner_image_vars_stable_2_10
-      container_images: &container_images_stable_2_10
+        override-checkout: stable-2.12
+    vars: &ansible_runner_image_vars_stable_2_12
+      container_images: &container_images_stable_2_12
         - context: .
-          build_args:
-            - ANSIBLE_BRANCH=stable-2.10
+          # NOTE(pabelanger): Once stable-2.12 exists uncomment.
+          # build_args:
+          #   - ANSIBLE_BRANCH=stable-2.12
           registry: quay.io
           repository: quay.io/ansible/ansible-runner
           siblings:
             - github.com/ansible/ansible
-          tags: ['stable-2.10-devel']
-      docker_images: *container_images_stable_2_10
+          tags: ['stable-2.12-devel']
+      docker_images: *container_images_stable_2_12
 
 - job:
-    name: ansible-runner-build-container-image-stable-2.10
+    name: ansible-runner-build-container-image-stable-2.12
     parent: ansible-runner-container-image-base
 
 - job:
-    name: ansible-runner-upload-container-image-stable-2.10
+    name: ansible-runner-upload-container-image-stable-2.12
     parent: ansible-upload-container-image
     provides:
-      - ansible-runner-stable-2.10-container-image
+      - ansible-runner-stable-2.12-container-image
     requires:
       - python-base-container-image
       - python-builder-container-image
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars: *ansible_runner_image_vars_stable_2_10
+        override-checkout: stable-2.12
+    vars: *ansible_runner_image_vars_stable_2_12
 
 - job:
-    name: ansible-runner-upload-container-image-stable-2.10
+    name: ansible-runner-upload-container-image-stable-2.12
     parent: ansible-runner-container-image-base
 
 # =============================================================================
@@ -148,6 +149,53 @@
 - job:
     name: ansible-runner-upload-container-image-stable-2.11
     parent: ansible-runner-container-image-base
+
+# =============================================================================
+
+- job:
+    name: ansible-runner-build-container-image-stable-2.10
+    parent: ansible-build-container-image
+    provides:
+      - ansible-runner-stable-2.10-container-image
+    requires:
+      - python-base-container-image
+      - python-builder-container-image
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.10
+    vars: &ansible_runner_image_vars_stable_2_10
+      container_images: &container_images_stable_2_10
+        - context: .
+          build_args:
+            - ANSIBLE_BRANCH=stable-2.10
+          registry: quay.io
+          repository: quay.io/ansible/ansible-runner
+          siblings:
+            - github.com/ansible/ansible
+          tags: ['stable-2.10-devel']
+      docker_images: *container_images_stable_2_10
+
+- job:
+    name: ansible-runner-build-container-image-stable-2.10
+    parent: ansible-runner-container-image-base
+
+- job:
+    name: ansible-runner-upload-container-image-stable-2.10
+    parent: ansible-upload-container-image
+    provides:
+      - ansible-runner-stable-2.10-container-image
+    requires:
+      - python-base-container-image
+      - python-builder-container-image
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.10
+    vars: *ansible_runner_image_vars_stable_2_10
+
+- job:
+    name: ansible-runner-upload-container-image-stable-2.10
+    parent: ansible-runner-container-image-base
+
 
 # =============================================================================
 

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,6 +7,7 @@
         - ansible-runner-build-container-image-stable-2.9
         - ansible-runner-build-container-image-stable-2.10
         - ansible-runner-build-container-image-stable-2.11
+        - ansible-runner-build-container-image-stable-2.12
         - ansible-runner-integration
         - ansible-tox-docs:
             vars:
@@ -26,6 +27,9 @@
             vars:
               upload_container_image_promote: false
         - ansible-runner-upload-container-image-stable-2.11:
+            vars:
+              upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.12:
             vars:
               upload_container_image_promote: false
     periodic:

--- a/tools/requirements-stable-2.12.txt
+++ b/tools/requirements-stable-2.12.txt
@@ -1,0 +1,11 @@
+ansible-core
+ncclient
+paramiko
+pyOpenSSL<20.0.0  # Transient dependency for credssp support.
+pypsrp[kerberos,credssp]
+pywinrm[kerberos,credssp]
+toml
+pexpect>=4.5
+python-daemon
+pyyaml
+six

--- a/tools/upper-constraints-stable-2.11.txt
+++ b/tools/upper-constraints-stable-2.11.txt
@@ -1,1 +1,1 @@
-ansible-core
+ansible-core<2.12

--- a/tools/upper-constraints-stable-2.12.txt
+++ b/tools/upper-constraints-stable-2.12.txt
@@ -1,0 +1,1 @@
+ansible-core


### PR DESCRIPTION
While ansible/ansible hasn't create stable-2.12 branch we can start to
prepare our stable-2.12 testing of execution environments.

This adds all the required jobs but still points to the devel branch.
Once the branch has been created, we can update the zuul job to point to
the correct branch.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>