### PR TITLE
Do not rely on length of sys.argv

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -414,11 +414,9 @@ logger = logging.getLogger('ansible-runner')
 
 class AnsibleRunnerArgumentParser(argparse.ArgumentParser):
     def error(self, message):
-        # If no sub command was provided, print common usage and exit cleanly.
-        if 'required: command' in message:
-            self.print_usage()
+        # If no sub command was provided, print common usage then exit
+        if 'required: command' in message.lower():
             print_common_usage()
-            self.exit(0, message)
 
         super(AnsibleRunnerArgumentParser, self).error(message)
 
@@ -755,15 +753,7 @@ def main(sys_args=None):
     add_args_to_parser(isalive_container_group, DEFAULT_CLI_ARGS['container_group'])
     add_args_to_parser(transmit_container_group, DEFAULT_CLI_ARGS['container_group'])
 
-    try:
-        args = parser.parse_args(sys_args)
-    except SystemExit:
-        # If sys_args is None, assume this is interactive and use the behavior in the custom error() method.
-        if sys_args is None:
-            raise
-
-        # Otherwise, assume a call to main() passed in invalid arguments
-        parser.exit(2)
+    args = parser.parse_args(sys_args)
 
     vargs = vars(args)
 

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -81,17 +81,22 @@ def test_temp_directory():
 
 
 @pytest.mark.parametrize(
-    ('command', 'exit_code'),
+    ('command', 'expected'),
     (
-        (None, 0),
-        ([], 2),
-        (['run'], 2)
+        (None, {'out': 'These are common Ansible Runner commands', 'err': ''}),
+        ([], {'out': 'These are common Ansible Runner commands', 'err': ''}),
+        (['run'], {'out': '', 'err': 'the following arguments are required'}),
     )
 )
-def test_help(command, exit_code):
+def test_help(command, capsys, expected):
     with pytest.raises(SystemExit) as exc:
         main(command)
-    assert exc.value.code == exit_code, f'Should raise SystemExit with return code {exit_code}'
+
+    stdout, stderr = capsys.readouterr()
+
+    assert exc.value.code == 2, 'Should raise SystemExit with return code 2'
+    assert expected['out'] in stdout
+    assert expected['err'] in stderr
 
 
 def test_module_run():

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -80,10 +80,18 @@ def test_temp_directory():
     assert not os.path.exists(context['saved_temp_dir'])
 
 
-def test_help():
+@pytest.mark.parametrize(
+    ('command', 'exit_code'),
+    (
+        (None, 0),
+        ([], 2),
+        (['run'], 2)
+    )
+)
+def test_help(command, exit_code):
     with pytest.raises(SystemExit) as exc:
-        main([])
-    assert exc.value.code == 2, 'Should raise SystemExit with return code 2'
+        main(command)
+    assert exc.value.code == exit_code, f'Should raise SystemExit with return code {exit_code}'
 
 
 def test_module_run():

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -88,7 +88,10 @@ def test_temp_directory():
         (['run'], {'out': '', 'err': 'the following arguments are required'}),
     )
 )
-def test_help(command, capsys, expected):
+def test_help(command, expected, capsys, monkeypatch):
+    # Ensure that sys.argv of the test command does not affect the test environment.
+    monkeypatch.setattr('sys.argv', command or [])
+
     with pytest.raises(SystemExit) as exc:
         main(command)
 


### PR DESCRIPTION
From the current behavior, it seems the goal is to print a common usage message and exit 0 if no sub command was given. Under other circumstances, such as an invalid or missing parameter, exit with 2 and print the normal usage message.

In order to preserve this behavior and make the tests run consistently whether or not they are run in multiple process, a custom error method was created that inspects the error message and exits 0 with the common usage message if no command was given. This is a bit fragile, but inside that method we do not have easy access to arguments passed to the main() function (they could be inferred by inspecting private attributes, but this is probably unwise).

This requires catching the SystemExit in the main() function and deciding there based on sys_args how to handle it.

This fix preservers the existing behavior whil making the tests pass consistently. However, it would be much simpler to rely on the default behavior of argparse and exit 2 in both cases. This would remove the need for a custom error method and exception handling. It would be a change in behavior, though.

Related to #815.