### PR TITLE
Make some assertions more consistent with other tests

### DIFF
--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -184,8 +184,4 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, container_r
         '-M', '/test/module'
     ])
 
-    for index, element in enumerate(expected_command_start):
-        if '--user=' in element:
-            assert '--user=' in rc.command[index]
-        else:
-            assert rc.command[index] == element
+    assert expected_command_start == rc.command

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -148,6 +148,4 @@ def test_prepare_inventory_command_with_containerization(tmp_path, container_run
         '--export',
     ])
 
-    assert len(expected_command_start) == len(rc.command)
-
     assert expected_command_start == rc.command


### PR DESCRIPTION
With this, if you do

```
grep -r "assert expected_command_start == rc.command" test | wc -l
```

you find 8 occurrences of the same assertion. All of these tests have a _very high_ level of similarity, to the point that they could probably use some code consolidation.

I've been bitten, myself, by these assertions because they don't give as much info as you would want. Running with `-v` gives you really helpful information for `assert list_a == list_b`, and doing this extra stuff just makes it worse. We shouldn't need the `--user` exception (not that it should be done this way if we needed it), as evidenced by the other tests which also got rid of this.

Ping @samdoran, I can't use the github thing to request a reviewer anymore.