### PR TITLE
Use mocker fixture

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ addopts =
     --verbose
     --numprocesses auto
     --durations 10
+    --durations-min 1

--- a/test/integration/test___main__.py
+++ b/test/integration/test___main__.py
@@ -52,7 +52,7 @@ def run_role(options, mocker, private_data_dir, expected_rc=0):
     args.extend(options)
     mock_run = mocker.patch('ansible_runner.interface.run')
     with pytest.raises(SystemExit) as exc:
-        main()
+        main(args)
 
     assert exc.type == SystemExit
     assert exc.value.code == expected_rc

--- a/test/integration/test___main__.py
+++ b/test/integration/test___main__.py
@@ -53,8 +53,9 @@ def run_role(options, mocker, private_data_dir, expected_rc=0):
     mock_run = mocker.patch('ansible_runner.interface.run')
     with pytest.raises(SystemExit) as exc:
         main()
-        assert exc.type == SystemExit
-        assert exc.value.code == expected_rc
+
+    assert exc.type == SystemExit
+    assert exc.value.code == expected_rc
 
     return mock_run
 

--- a/test/integration/test___main__.py
+++ b/test/integration/test___main__.py
@@ -47,20 +47,23 @@ def test_main_bad_private_data_dir():
         os.remove(tmpfile)
 
 
-def run_role(options, mocker, private_data_dir, expected_rc=0):
-    args = ['run', private_data_dir]
-    args.extend(options)
-    mock_run = mocker.patch('ansible_runner.interface.run')
-    with pytest.raises(SystemExit) as exc:
-        main(args)
+@pytest.fixture
+def run_role(mocker):
+    def _run_role(options, private_data_dir, expected_rc=0):
+        args = ['run', private_data_dir]
+        args.extend(options)
+        with mocker.patch('ansible_runner.interface.run') as mock_run:
+            with pytest.raises(SystemExit) as exc:
+                main(args)
 
-    assert exc.type == SystemExit
-    assert exc.value.code == expected_rc
+            assert exc.value.code == expected_rc
 
-    return mock_run
+        return mock_run
+
+    return _run_role
 
 
-def test_cmdline_role_defaults(mocker):
+def test_cmdline_role_defaults(run_role):
     """Run a role directly with all command line defaults
     """
     private_data_dir = tempfile.mkdtemp()
@@ -73,11 +76,11 @@ def test_cmdline_role_defaults(mocker):
         'playbook': playbook
     }
 
-    result = run_role(options, mocker, private_data_dir)
+    result = run_role(options, private_data_dir)
     result.called_with_args([run_options])
 
 
-def test_cmdline_role_skip_facts(mocker):
+def test_cmdline_role_skip_facts(run_role):
     """Run a role directly and set --role-skip-facts option
     """
     private_data_dir = tempfile.mkdtemp()
@@ -90,11 +93,11 @@ def test_cmdline_role_skip_facts(mocker):
         'playbook': playbook
     }
 
-    result = run_role(options, mocker, private_data_dir)
+    result = run_role(options, private_data_dir)
     result.called_with_args([run_options])
 
 
-def test_cmdline_role_inventory(mocker):
+def test_cmdline_role_inventory(run_role):
     """Run a role directly and set --inventory option
     """
     private_data_dir = tempfile.mkdtemp()
@@ -108,11 +111,11 @@ def test_cmdline_role_inventory(mocker):
         'inventory': 'hosts'
     }
 
-    result = run_role(options, mocker, private_data_dir)
+    result = run_role(options, private_data_dir)
     result.called_with_args([run_options])
 
 
-def test_cmdline_role_vars(mocker):
+def test_cmdline_role_vars(run_role):
     """Run a role directly and set --role-vars option
     """
     private_data_dir = tempfile.mkdtemp()
@@ -132,11 +135,11 @@ def test_cmdline_role_vars(mocker):
         'playbook': playbook
     }
 
-    result = run_role(options, mocker, private_data_dir)
+    result = run_role(options, private_data_dir)
     result.called_with_args([run_options])
 
 
-def test_cmdline_roles_path(mocker):
+def test_cmdline_roles_path(run_role):
     """Run a role directly and set --roles-path option
     """
     private_data_dir = tempfile.mkdtemp()
@@ -150,7 +153,7 @@ def test_cmdline_roles_path(mocker):
         'envvars': {'ANSIBLE_ROLES_PATH': '/tmp/roles'}
     }
 
-    result = run_role(options, mocker, private_data_dir)
+    result = run_role(options, private_data_dir)
     result.called_with_args([run_options])
 
 

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -6,10 +6,7 @@ import re
 import pytest
 import six
 import sys
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from unittest.mock import MagicMock
+
 from ansible_runner import Runner
 
 from ansible_runner.exceptions import AnsibleRunnerException
@@ -56,8 +53,8 @@ def test_run_command_with_unicode(rc):
         assert u"䉪ቒ칸" in data.get('env')
 
 
-def test_run_command_finished_callback(rc):
-    finished_callback = MagicMock()
+def test_run_command_finished_callback(rc, mocker):
+    finished_callback = mocker.MagicMock()
     rc.command = ['sleep', '1']
     runner = Runner(config=rc, finished_callback=finished_callback)
     status, exitcode = runner.run()
@@ -191,9 +188,9 @@ def test_run_command_ansible(rc):
     assert stdout.read() != ""
 
 
-def test_run_command_ansible_event_handler(rc):
-    event_handler = MagicMock()
-    status_handler = MagicMock()
+def test_run_command_ansible_event_handler(rc, mocker):
+    event_handler = mocker.MagicMock()
+    status_handler = mocker.MagicMock()
     rc.module = "debug"
     rc.host_pattern = "localhost"
     rc.prepare()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-mock
+pytest-timeout
 pytest-xdist
 flake8
 yamllint

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,5 @@
 pytest
 pytest-mock
 pytest-xdist
-mock
 flake8
 yamllint

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -9,7 +9,6 @@ import six
 from pexpect import TIMEOUT, EOF
 
 import pytest
-from unittest.mock import (Mock, patch, PropertyMock)
 
 from ansible_runner.config.runner import RunnerConfig, ExecutionMode
 from ansible_runner.interface import init_runner
@@ -30,8 +29,9 @@ def load_file_side_effect(path, value=None, *args, **kwargs):
     raise ConfigurationError
 
 
-@patch('os.makedirs', return_value=True)
-def test_runner_config_init_defaults(mock_makedirs):
+def test_runner_config_init_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
     assert rc.private_data_dir == '/'
     assert rc.ident is not None
@@ -44,14 +44,16 @@ def test_runner_config_init_defaults(mock_makedirs):
     assert isinstance(rc.loader, ArtifactLoader)
 
 
-@patch('os.makedirs', return_value=True)
-def test_runner_config_with_artifact_dir(mock_makedirs):
+def test_runner_config_with_artifact_dir(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/', artifact_dir='/this-is-some-dir')
     assert rc.artifact_dir == os.path.join('/this-is-some-dir', rc.ident)
 
 
-@patch('os.makedirs', return_value=True)
-def test_runner_config_init_with_ident(mock_makedirs):
+def test_runner_config_init_with_ident(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/', ident='test')
     assert rc.private_data_dir == '/'
     assert rc.ident == 'test'
@@ -64,47 +66,53 @@ def test_runner_config_init_with_ident(mock_makedirs):
     assert isinstance(rc.loader, ArtifactLoader)
 
 
-@patch('os.makedirs', return_value=True)
-def test_runner_config_project_dir(mock_makedirs):
+def test_runner_config_project_dir(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/', project_dir='/another/path')
     assert rc.project_dir == '/another/path'
     rc = RunnerConfig('/')
     assert rc.project_dir == '/project'
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_environment_vars_only_strings(mock_makedirs):
+def test_prepare_environment_vars_only_strings(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig(private_data_dir="/", envvars=dict(D='D'))
 
     value = dict(A=1, B=True, C="foo")
     envvar_side_effect = partial(load_file_side_effect, 'env/envvars', value)
 
-    with patch.object(rc.loader, 'load_file', side_effect=envvar_side_effect):
-        rc.prepare_env()
-        assert 'A' in rc.env
-        assert isinstance(rc.env['A'], six.string_types)
-        assert 'B' in rc.env
-        assert isinstance(rc.env['B'], six.string_types)
-        assert 'C' in rc.env
-        assert isinstance(rc.env['C'], six.string_types)
-        assert 'D' in rc.env
-        assert rc.env['D'] == 'D'
+    mocker.patch.object(rc.loader, 'load_file', side_effect=envvar_side_effect)
+
+    rc.prepare_env()
+    assert 'A' in rc.env
+    assert isinstance(rc.env['A'], six.string_types)
+    assert 'B' in rc.env
+    assert isinstance(rc.env['B'], six.string_types)
+    assert 'C' in rc.env
+    assert isinstance(rc.env['C'], six.string_types)
+    assert 'D' in rc.env
+    assert rc.env['D'] == 'D'
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_ad_hoc_command(mock_makedirs):
+def test_prepare_env_ad_hoc_command(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig(private_data_dir="/")
 
     value = {'AD_HOC_COMMAND_ID': 'teststring'}
     envvar_side_effect = partial(load_file_side_effect, 'env/envvars', value)
 
-    with patch.object(rc.loader, 'load_file', side_effect=envvar_side_effect):
-        rc.prepare_env()
-        assert rc.cwd == '/'
+    mocker.patch.object(rc.loader, 'load_file', side_effect=envvar_side_effect)
+
+    rc.prepare_env()
+    assert rc.cwd == '/'
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_environment_pexpect_defaults(mock_makedirs):
+def test_prepare_environment_pexpect_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig(private_data_dir="/")
     rc.prepare_env()
 
@@ -115,93 +123,104 @@ def test_prepare_environment_pexpect_defaults(mock_makedirs):
     assert rc.expect_passwords[EOF] is None
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_passwords(mock_makedirs):
+def test_prepare_env_passwords(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig(private_data_dir='/')
 
     value = {'^SSH [pP]assword.*$': 'secret'}
     password_side_effect = partial(load_file_side_effect, 'env/passwords', value)
 
-    with patch.object(rc.loader, 'load_file', side_effect=password_side_effect):
-        rc.prepare_env()
-        rc.expect_passwords.pop(TIMEOUT)
-        rc.expect_passwords.pop(EOF)
-        assert len(rc.expect_passwords) == 1
-        assert isinstance(list(rc.expect_passwords.keys())[0], Pattern)
-        assert 'secret' in rc.expect_passwords.values()
+    mocker.patch.object(rc.loader, 'load_file', side_effect=password_side_effect)
+
+    rc.prepare_env()
+    rc.expect_passwords.pop(TIMEOUT)
+    rc.expect_passwords.pop(EOF)
+    assert len(rc.expect_passwords) == 1
+    assert isinstance(list(rc.expect_passwords.keys())[0], Pattern)
+    assert 'secret' in rc.expect_passwords.values()
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_extra_vars_defaults(mock_makedirs):
+def test_prepare_env_extra_vars_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
     rc.prepare_env()
     assert rc.extra_vars is None
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_settings_defaults(mock_makedirs):
+def test_prepare_env_settings_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
     rc.prepare_env()
     assert rc.settings == {}
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_settings(mock_makedirs):
+def test_prepare_env_settings(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
 
     value = {'test': 'string'}
     settings_side_effect = partial(load_file_side_effect, 'env/settings', value)
 
-    with patch.object(rc.loader, 'load_file', side_effect=settings_side_effect):
-        rc.prepare_env()
-        assert rc.settings == value
+    mocker.patch.object(rc.loader, 'load_file', side_effect=settings_side_effect)
+
+    rc.prepare_env()
+    assert rc.settings == value
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_sshkey_defaults(mock_makedirs):
+def test_prepare_env_sshkey_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
     rc.prepare_env()
     assert rc.ssh_key_data is None
 
 
-@patch('ansible_runner.config._base.open_fifo_write')
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_sshkey(mock_makedirs, open_fifo_write_mock):
+def test_prepare_env_sshkey(mocker):
+    mocker.patch('ansible_runner.config._base.open_fifo_write')
+    mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig('/')
 
     value = '01234567890'
     sshkey_side_effect = partial(load_file_side_effect, 'env/ssh_key', value)
 
-    with patch.object(rc.loader, 'load_file', side_effect=sshkey_side_effect):
-        rc.prepare_env()
-        assert rc.ssh_key_data == value
+    mocker.patch.object(rc.loader, 'load_file', side_effect=sshkey_side_effect)
+
+    rc.prepare_env()
+    assert rc.ssh_key_data == value
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_defaults(mock_makedirs):
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc = RunnerConfig('/')
-        rc.prepare_env()
-        assert rc.idle_timeout is None
-        assert rc.job_timeout is None
-        assert rc.pexpect_timeout == 5
-        assert rc.cwd == '/project'
+def test_prepare_env_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc = RunnerConfig('/')
+    rc.prepare_env()
+    assert rc.idle_timeout is None
+    assert rc.job_timeout is None
+    assert rc.pexpect_timeout == 5
+    assert rc.cwd == '/project'
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_env_directory_isolation(mock_makedirs):
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc = RunnerConfig('/')
-        rc.directory_isolation_path = '/tmp/foo'
-        rc.prepare_env()
-        assert rc.cwd == '/tmp/foo'
+def test_prepare_env_directory_isolation(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc = RunnerConfig('/')
+    rc.directory_isolation_path = '/tmp/foo'
+    rc.prepare_env()
+    assert rc.cwd == '/tmp/foo'
 
 
-@patch('os.makedirs', return_value=True)
-@patch('os.path.exists', return_value=True)
-def test_prepare_inventory(path_exists, mock_makedirs):
+def test_prepare_inventory(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+    path_exists = mocker.patch('os.path.exists', return_value=True)
+
     rc = RunnerConfig(private_data_dir='/')
     rc.prepare_inventory()
     assert rc.inventory == '/inventory'
@@ -217,12 +236,35 @@ def test_prepare_inventory(path_exists, mock_makedirs):
     assert rc.inventory is None
 
 
-@patch('os.makedirs', return_value=True)
-def test_generate_ansible_command(mock_makedirs):
+@pytest.mark.parametrize(
+    'extra_vars, expected',
+    (
+        ({'test': 'key'}, ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '{"test":"key"}', 'main.yaml']),
+        ('/tmp/extravars.yml', ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '@/tmp/extravars.yml', 'main.yaml']),
+        (None, ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', 'main.yaml']),
+    )
+)
+def test_generate_ansible_command_extra_vars(mocker, extra_vars, expected):
+    mocker.patch('os.makedirs', return_value=True)
+    mocker.patch('os.path.exists', return_value=True)
+
     rc = RunnerConfig(private_data_dir='/', playbook='main.yaml')
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc.prepare_inventory()
+    rc.inventory = '/inventory'
+    rc.prepare_inventory()
+
+    mocker.patch.object(rc.loader, 'isfile', side_effect=lambda x: True)
+
+    rc.extra_vars = extra_vars
+    cmd = rc.generate_ansible_command()
+    assert cmd == expected
+
+
+def test_generate_ansible_command(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+    mocker.patch('os.path.exists', return_value=True)
+
+    rc = RunnerConfig(private_data_dir='/', playbook='main.yaml')
+    rc.prepare_inventory()
     rc.extra_vars = None
 
     cmd = rc.generate_ansible_command()
@@ -231,16 +273,6 @@ def test_generate_ansible_command(mock_makedirs):
     rc.extra_vars = dict(test="key")
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '{"test":"key"}', 'main.yaml']
-
-    with patch.object(rc.loader, 'isfile', side_effect=lambda x: True):
-        cmd = rc.generate_ansible_command()
-        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '{"test":"key"}', 'main.yaml']
-        rc.extra_vars = '/tmp/extravars.yml'
-        cmd = rc.generate_ansible_command()
-        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', '-e', '@/tmp/extravars.yml', 'main.yaml']
-        rc.extra_vars = None
-        cmd = rc.generate_ansible_command()
-        assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '@/env/extravars', 'main.yaml']
     rc.extra_vars = None
 
     rc.inventory = "localhost,"
@@ -254,16 +286,17 @@ def test_generate_ansible_command(mock_makedirs):
     rc.inventory = []
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', 'main.yaml']
+
     rc.inventory = None
 
-    with patch('os.path.exists', return_value=False) as path_exists:
-        rc.prepare_inventory()
-        cmd = rc.generate_ansible_command()
+    mocker.patch('os.path.exists', return_value=False)
+    rc.prepare_inventory()
+    cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', 'main.yaml']
 
     rc.verbosity = 3
-    with patch('os.path.exists', return_value=True) as path_exists:
-        rc.prepare_inventory()
+    mocker.patch('os.path.exists', return_value=True)
+    rc.prepare_inventory()
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', '-vvv', 'main.yaml']
     rc.verbosity = None
@@ -290,23 +323,25 @@ def test_generate_ansible_command(mock_makedirs):
     assert cmd == ['ansible-playbook', '-i', '/inventory', '--forks', '5', 'main.yaml']
 
 
-@patch('os.makedirs', return_value=True)
-def test_generate_ansible_command_with_api_extravars(mock_makedirs):
+def test_generate_ansible_command_with_api_extravars(mocker):
+    mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo": "bar"})
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc.prepare_inventory()
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc.prepare_inventory()
 
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '{"foo":"bar"}', 'main.yaml']
 
 
-@patch('os.makedirs', return_value=True)
-def test_generate_ansible_command_with_dict_extravars(mock_makedirs):
+def test_generate_ansible_command_with_dict_extravars(mocker):
+    mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig(private_data_dir='/', playbook='main.yaml', extravars={"foo": "test \n hello"})
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc.prepare_inventory()
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc.prepare_inventory()
 
     cmd = rc.generate_ansible_command()
     assert cmd == ['ansible-playbook', '-i', '/inventory', '-e', '{"foo":"test \\n hello"}', 'main.yaml']
@@ -316,22 +351,25 @@ def test_generate_ansible_command_with_dict_extravars(mock_makedirs):
     (u'--tags foo --skip-tags', ['--tags', 'foo', '--skip-tags']),
     (u'--limit "䉪ቒ칸ⱷ?噂폄蔆㪗輥"', ['--limit', '䉪ቒ칸ⱷ?噂폄蔆㪗輥']),
 ])
-@patch('os.makedirs', return_value=True)
-def test_generate_ansible_command_with_cmdline_args(mock_makedirs, cmdline, tokens):
+def test_generate_ansible_command_with_cmdline_args(cmdline, tokens, mocker):
+    mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig(private_data_dir='/', playbook='main.yaml')
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc.prepare_inventory()
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc.prepare_inventory()
     rc.extra_vars = {}
 
     cmdline_side_effect = partial(load_file_side_effect, 'env/cmdline', cmdline)
-    with patch.object(rc.loader, 'load_file', side_effect=cmdline_side_effect):
-        cmd = rc.generate_ansible_command()
-        assert cmd == ['ansible-playbook'] + tokens + ['-i', '/inventory', 'main.yaml']
+    mocker.patch.object(rc.loader, 'load_file', side_effect=cmdline_side_effect)
+
+    cmd = rc.generate_ansible_command()
+    assert cmd == ['ansible-playbook'] + tokens + ['-i', '/inventory', 'main.yaml']
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_command_defaults(mock_makedirs):
+def test_prepare_command_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
 
     cmd_side_effect = partial(load_file_side_effect, 'args')
@@ -339,19 +377,21 @@ def test_prepare_command_defaults(mock_makedirs):
     def generate_side_effect():
         return StringIO(u'test "string with spaces"')
 
-    with patch.object(rc.loader, 'load_file', side_effect=cmd_side_effect):
-        with patch.object(rc, 'generate_ansible_command', side_effect=generate_side_effect):
-            rc.prepare_command()
-            rc.command == ['test', '"string with spaces"']
+    mocker.patch.object(rc.loader, 'load_file', side_effect=cmd_side_effect)
+    mocker.patch.object(rc, 'generate_ansible_command', side_effect=generate_side_effect)
+
+    rc.prepare_command()
+    rc.command == ['test', '"string with spaces"']
 
 
-@patch('os.makedirs', return_value=True)
-def test_prepare_with_defaults(mock_makedirs):
+def test_prepare_with_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
 
-    rc.prepare_inventory = Mock()
-    rc.prepare_env = Mock()
-    rc.prepare_command = Mock()
+    rc.prepare_inventory = mocker.Mock()
+    rc.prepare_env = mocker.Mock()
+    rc.prepare_command = mocker.Mock()
 
     rc.ssh_key_data = None
     rc.artifact_dir = '/'
@@ -363,15 +403,16 @@ def test_prepare_with_defaults(mock_makedirs):
     assert str(exc.value) == 'No executable for runner to run'
 
 
-@patch.dict('os.environ', {'PYTHONPATH': '/python_path_via_environ',
-                           'AWX_LIB_DIRECTORY': '/awx_lib_directory_via_environ'})
-@patch('os.makedirs', return_value=True)
-def test_prepare(mock_makedirs):
+def test_prepare(mocker):
+    mocker.patch.dict('os.environ', {
+        'PYTHONPATH': '/python_path_via_environ',
+        'AWX_LIB_DIRECTORY': '/awx_lib_directory_via_environ',
+    })
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
-
-    rc.prepare_inventory = Mock()
-    rc.prepare_command = Mock()
-
+    rc.prepare_inventory = mocker.Mock()
+    rc.prepare_command = mocker.Mock()
     rc.ssh_key_data = None
     rc.artifact_dir = '/'
     rc.env = {}
@@ -400,15 +441,15 @@ def test_prepare(mock_makedirs):
         "PYTHONPATH is the union of the explicit env['PYTHONPATH'] override and AWX_LIB_DIRECTORY"
 
 
-@patch('os.makedirs', return_value=True)
-@patch('ansible_runner.config._base.open_fifo_write')
-def test_prepare_with_ssh_key(open_fifo_write_mock, mock_makedirs):
+def test_prepare_with_ssh_key(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+    open_fifo_write_mock = mocker.patch('ansible_runner.config._base.open_fifo_write')
     rc = RunnerConfig('/')
 
-    rc.prepare_inventory = Mock()
-    rc.prepare_command = Mock()
+    rc.prepare_inventory = mocker.Mock()
+    rc.prepare_command = mocker.Mock()
 
-    rc.wrap_args_with_ssh_agent = Mock()
+    rc.wrap_args_with_ssh_agent = mocker.Mock()
 
     rc.ssh_key_data = None
     rc.artifact_dir = '/'
@@ -418,16 +459,17 @@ def test_prepare_with_ssh_key(open_fifo_write_mock, mock_makedirs):
     rc.ssh_key_data = '01234567890'
     rc.command = 'ansible-playbook'
 
-    with patch.dict('os.environ', {'AWX_LIB_DIRECTORY': '/'}):
-        rc.prepare()
+    mocker.patch.dict('os.environ', {'AWX_LIB_DIRECTORY': '/'})
+
+    rc.prepare()
 
     assert rc.ssh_key_path == '/ssh_key_data'
     assert rc.wrap_args_with_ssh_agent.called
     assert open_fifo_write_mock.called
 
 
-@patch('os.makedirs', return_value=True)
-def test_wrap_args_with_ssh_agent_defaults(mock_makedirs):
+def test_wrap_args_with_ssh_agent_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig('/')
     res = rc.wrap_args_with_ssh_agent(['ansible-playbook', 'main.yaml'], '/tmp/sshkey')
     assert res == [
@@ -437,8 +479,8 @@ def test_wrap_args_with_ssh_agent_defaults(mock_makedirs):
     ]
 
 
-@patch('os.makedirs', return_value=True)
-def test_wrap_args_with_ssh_agent_with_auth(mock_makedirs):
+def test_wrap_args_with_ssh_agent_with_auth(mocker):
+    mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig('/')
     res = rc.wrap_args_with_ssh_agent(['ansible-playbook', 'main.yaml'], '/tmp/sshkey', '/tmp/sshauth')
     assert res == [
@@ -448,8 +490,8 @@ def test_wrap_args_with_ssh_agent_with_auth(mock_makedirs):
     ]
 
 
-@patch('os.makedirs', return_value=True)
-def test_wrap_args_with_ssh_agent_silent(mock_makedirs):
+def test_wrap_args_with_ssh_agent_silent(mocker):
+    mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig('/')
     res = rc.wrap_args_with_ssh_agent(['ansible-playbook', 'main.yaml'], '/tmp/sshkey', silence_ssh_add=True)
     assert res == [
@@ -459,14 +501,14 @@ def test_wrap_args_with_ssh_agent_silent(mock_makedirs):
     ]
 
 
-@patch('ansible_runner.runner_config.RunnerConfig.prepare')
-@patch('ansible_runner.interface.sys')
-@patch('ansible_runner.utils.subprocess')
 @pytest.mark.parametrize('executable_present', [True, False])
-def test_process_isolation_executable_not_found(mock_subprocess, mock_sys, mock_prepare, executable_present):
+def test_process_isolation_executable_not_found(executable_present, mocker):
+    mocker.patch('ansible_runner.runner_config.RunnerConfig.prepare')
+    mock_sys = mocker.patch('ansible_runner.interface.sys')
+    mock_subprocess = mocker.patch('ansible_runner.utils.subprocess')
     # Mock subprocess.Popen indicates if
     # process isolation executable is present
-    mock_proc = Mock()
+    mock_proc = mocker.Mock()
     mock_proc.returncode = (0 if executable_present else 1)
     mock_subprocess.Popen.return_value = mock_proc
 
@@ -479,17 +521,20 @@ def test_process_isolation_executable_not_found(mock_subprocess, mock_sys, mock_
         assert mock_sys.exit.called
 
 
-@patch('os.makedirs', return_value=True)
-def test_bwrap_process_isolation_defaults(mock_makedirs):
+def test_bwrap_process_isolation_defaults(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
     rc.artifact_dir = '/tmp/artifacts'
     rc.playbook = 'main.yaml'
     rc.command = 'ansible-playbook'
     rc.process_isolation = True
     rc.process_isolation_executable = 'bwrap'
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc.prepare()
+
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc.prepare()
 
     assert rc.command == [
         'bwrap',
@@ -503,13 +548,13 @@ def test_bwrap_process_isolation_defaults(mock_makedirs):
     ]
 
 
-@patch('os.makedirs', return_value=True)
-@patch('shutil.copytree', return_value=True)
-@patch('tempfile.mkdtemp', return_value="/tmp/dirisolation/foo")
-@patch('os.chmod', return_value=True)
-@patch('shutil.rmtree', return_value=True)
-def test_bwrap_process_isolation_and_directory_isolation(mock_makedirs, mock_copytree, mock_mkdtemp,
-                                                         mock_chmod, mock_rmtree):
+def test_bwrap_process_isolation_and_directory_isolation(mocker):
+    mocker.patch('os.makedirs', return_value=True)
+    mocker.patch('shutil.copytree', return_value=True)
+    mocker.patch('tempfile.mkdtemp', return_value="/tmp/dirisolation/foo")
+    mocker.patch('os.chmod', return_value=True)
+    mocker.patch('shutil.rmtree', return_value=True)
+
     def new_exists(path):
         if path == "/project":
             return False
@@ -521,8 +566,9 @@ def test_bwrap_process_isolation_and_directory_isolation(mock_makedirs, mock_cop
     rc.command = 'ansible-playbook'
     rc.process_isolation = True
     rc.process_isolation_executable = 'bwrap'
-    with patch('os.path.exists', new=new_exists):
-        rc.prepare()
+    mocker.patch('os.path.exists', new=new_exists)
+
+    rc.prepare()
 
     assert rc.command == [
         'bwrap',
@@ -536,10 +582,11 @@ def test_bwrap_process_isolation_and_directory_isolation(mock_makedirs, mock_cop
     ]
 
 
-@patch('os.path.isdir', return_value=False)
-@patch('os.path.exists', return_value=True)
-@patch('os.makedirs', return_value=True)
-def test_process_isolation_settings(mock_isdir, mock_exists, mock_makedirs):
+def test_process_isolation_settings(mocker):
+    mocker.patch('os.path.isdir', return_value=False)
+    mocker.patch('os.path.exists', return_value=True)
+    mocker.patch('os.makedirs', return_value=True)
+
     rc = RunnerConfig('/')
     rc.artifact_dir = '/tmp/artifacts'
     rc.playbook = 'main.yaml'
@@ -551,9 +598,10 @@ def test_process_isolation_settings(mock_isdir, mock_exists, mock_makedirs):
     rc.process_isolation_ro_paths = ['/venv']
     rc.process_isolation_path = '/tmp'
 
-    with patch('os.path.exists') as path_exists:
-        path_exists.return_value = True
-        rc.prepare()
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc.prepare()
     print(rc.command)
     assert rc.command[0:8] == [
         'not_bwrap',
@@ -586,8 +634,9 @@ def test_process_isolation_settings(mock_isdir, mock_exists, mock_makedirs):
     assert rc.command[23:] == ['--chdir', '/project', 'ansible-playbook', '-i', '/inventory', 'main.yaml']
 
 
-@patch('os.mkdir', return_value=True)
-def test_profiling_plugin_settings(mock_mkdir):
+def test_profiling_plugin_settings(mocker):
+    mocker.patch('os.mkdir', return_value=True)
+
     rc = RunnerConfig('/')
     rc.playbook = 'main.yaml'
     rc.command = 'ansible-playbook'
@@ -618,8 +667,9 @@ def test_profiling_plugin_settings(mock_mkdir):
     assert rc.env['CGROUP_DISPLAY_RECAP'] == 'False'
 
 
-@patch('os.mkdir', return_value=True)
-def test_profiling_plugin_settings_with_custom_intervals(mock_mkdir):
+def test_profiling_plugin_settings_with_custom_intervals(mocker):
+    mocker.patch('os.mkdir', return_value=True)
+
     rc = RunnerConfig('/')
     rc.playbook = 'main.yaml'
     rc.command = 'ansible-playbook'
@@ -634,9 +684,10 @@ def test_profiling_plugin_settings_with_custom_intervals(mock_mkdir):
     assert rc.env['CGROUP_PID_POLL_INTERVAL'] == '1.5'
 
 
-@patch('os.path.isdir', return_value=True)
-@patch('os.path.exists', return_value=True)
-def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmp_path):
+def test_container_volume_mounting_with_Z(mocker, tmp_path):
+    mocker.patch('os.path.isdir', return_value=True)
+    mocker.patch('os.path.exists', return_value=True)
+
     rc = RunnerConfig(str(tmp_path))
     rc.container_volume_mounts = ['/tmp/project_path:/tmp/project_path:Z']
     rc.container_name = 'foo'
@@ -653,20 +704,21 @@ def test_container_volume_mounting_with_Z(mock_isdir, mock_exists, tmp_path):
 
 
 @pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-@patch('os.path.isdir', return_value=True)
-@patch('os.path.exists', return_value=True)
-def test_containerization_settings(mock_isdir, mock_exists, tmp_path, container_runtime):
-    with patch('ansible_runner.runner_config.RunnerConfig.containerized', new_callable=PropertyMock) as mock_containerized:
-        rc = RunnerConfig(tmp_path)
-        rc.ident = 'foo'
-        rc.playbook = 'main.yaml'
-        rc.command = 'ansible-playbook'
-        rc.process_isolation = True
-        rc.process_isolation_executable = container_runtime
-        rc.container_image = 'my_container'
-        rc.container_volume_mounts = ['/host1:/container1', '/host2:/container2']
-        mock_containerized.return_value = True
-        rc.prepare()
+def test_containerization_settings(tmp_path, container_runtime, mocker):
+    mocker.patch('os.path.isdir', return_value=True)
+    mocker.patch('os.path.exists', return_value=True)
+    mock_containerized = mocker.patch('ansible_runner.runner_config.RunnerConfig.containerized', new_callable=mocker.PropertyMock)
+    mock_containerized.return_value = True
+
+    rc = RunnerConfig(tmp_path)
+    rc.ident = 'foo'
+    rc.playbook = 'main.yaml'
+    rc.command = 'ansible-playbook'
+    rc.process_isolation = True
+    rc.process_isolation_executable = container_runtime
+    rc.container_image = 'my_container'
+    rc.container_volume_mounts = ['/host1:/container1', '/host2:/container2']
+    rc.prepare()
 
     extra_container_args = []
     if container_runtime == 'podman':

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -4,7 +4,6 @@ import codecs
 import os
 
 import json
-from unittest import mock
 import pexpect
 import pytest
 import six
@@ -35,11 +34,11 @@ def rc(request, tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def mock_sleep(request):
+def mock_sleep(request, mocker):
     # the handle_termination process teardown mechanism uses `time.sleep` to
     # wait on processes to respond to SIGTERM; these are tests and don't care
     # about being nice
-    m = mock.patch('time.sleep')
+    m = mocker.patch('time.sleep')
     m.start()
     request.addfinalizer(m.stop)
 
@@ -103,11 +102,11 @@ def test_env_vars(rc, value):
         assert value in f.read()
 
 
-def test_event_callback_data_check(rc):
+def test_event_callback_data_check(rc, mocker):
     rc.ident = "testident"
     rc.check_job_event_data = True
     runner = Runner(config=rc, remove_partials=False)
-    runner.event_handler = mock.Mock()
+    runner.event_handler = mocker.Mock()
 
     with pytest.raises(AnsibleRunnerException) as exc:
         runner.event_callback(dict(uuid="testuuid", counter=0))
@@ -115,40 +114,42 @@ def test_event_callback_data_check(rc):
     assert "Failed to open ansible stdout callback plugin partial data" in str(exc)
 
 
-def test_event_callback_interface_has_ident(rc):
+def test_event_callback_interface_has_ident(rc, mocker):
     rc.ident = "testident"
     runner = Runner(config=rc, remove_partials=False)
-    runner.event_handler = mock.Mock()
-    with mock.patch('codecs.open', mock.mock_open(read_data=json.dumps(dict(event="test")))):
-        with mock.patch('os.chmod', mock.Mock()) as chmod:
-            with mock.patch('os.mkdir', mock.Mock()):
-                runner.event_callback(dict(uuid="testuuid", counter=0))
+    runner.event_handler = mocker.Mock()
+    mocker.patch('codecs.open', mocker.mock_open(read_data=json.dumps(dict(event="test"))))
+    chmod = mocker.patch('os.chmod', mocker.Mock())
+    mocker.patch('os.mkdir', mocker.Mock())
+
+    runner.event_callback(dict(uuid="testuuid", counter=0))
     assert runner.event_handler.call_count == 1
     runner.event_handler.assert_called_with(dict(
         runner_ident='testident', counter=0, uuid='testuuid', event='test',
-        created=mock.ANY
+        created=mocker.ANY
     ))
     chmod.assert_called_once()
     runner.status_callback("running")
 
 
-def test_event_callback_interface_calls_event_handler_for_verbose_event(rc):
+def test_event_callback_interface_calls_event_handler_for_verbose_event(rc, mocker):
     rc.ident = "testident"
-    event_handler = mock.Mock()
+    event_handler = mocker.Mock()
     runner = Runner(config=rc, event_handler=event_handler)
-    with mock.patch('os.mkdir', mock.Mock()):
-        runner.event_callback(dict(uuid="testuuid", event='verbose', counter=0))
+    mocker.patch('os.mkdir', mocker.Mock())
+
+    runner.event_callback(dict(uuid="testuuid", event='verbose', counter=0))
     assert event_handler.call_count == 1
     event_handler.assert_called_with(dict(
         runner_ident='testident', counter=0, uuid='testuuid', event='verbose',
-        created=mock.ANY
+        created=mocker.ANY
     ))
 
 
-def test_status_callback_interface(rc):
+def test_status_callback_interface(rc, mocker):
     runner = Runner(config=rc)
     assert runner.status == 'unstarted'
-    runner.status_handler = mock.Mock()
+    runner.status_handler = mocker.Mock()
     runner.status_callback("running")
     assert runner.status_handler.call_count == 1
     runner.status_handler.assert_called_with(dict(status='running', runner_ident=str(rc.ident)), runner_config=runner.config)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -7,7 +7,6 @@ import io
 from pathlib import Path
 
 import pytest
-from unittest.mock import patch
 
 from ansible_runner.utils import (
     isplaybook,
@@ -53,162 +52,170 @@ def test_dump_artifacts_private_data_dir():
         dump_artifacts(kwargs)
 
 
-def test_dump_artifacts_playbook():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        # playbook as a native object
-        pb = [{'playbook': [{'hosts': 'all'}]}]
-        kwargs = {'private_data_dir': '/tmp', 'playbook': pb}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == json.dumps(pb)
-        assert fp == '/tmp/project'
-        assert fn == 'main.json'
+def test_dump_artifacts_playbook(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
 
+    # playbook as a native object
+    pb = [{'playbook': [{'hosts': 'all'}]}]
+    kwargs = {'private_data_dir': '/tmp', 'playbook': pb}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == json.dumps(pb)
+    assert fp == '/tmp/project'
+    assert fn == 'main.json'
+
+    mock_dump_artifact.reset_mock()
+
+    # playbook as a path
+    pb = 'test.yml'
+    kwargs = {'private_data_dir': '/tmp', 'playbook': pb}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 0
+    assert mock_dump_artifact.called is False
+
+    mock_dump_artifact.reset_mock()
+
+    # invalid playbook structures
+    for obj in ({'foo': 'bar'}, None, True, False, 'foo', []):
         mock_dump_artifact.reset_mock()
-
-        # playbook as a path
-        pb = 'test.yml'
-        kwargs = {'private_data_dir': '/tmp', 'playbook': pb}
+        kwargs = {'private_data_dir': '/tmp', 'playbook': obj}
         dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 0
         assert mock_dump_artifact.called is False
 
-        mock_dump_artifact.reset_mock()
 
-        # invalid playbook structures
-        for obj in ({'foo': 'bar'}, None, True, False, 'foo', []):
-            mock_dump_artifact.reset_mock()
-            kwargs = {'private_data_dir': '/tmp', 'playbook': obj}
-            dump_artifacts(kwargs)
-            assert mock_dump_artifact.call_count == 0
-            assert mock_dump_artifact.called is False
+def test_dump_artifacts_roles(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
 
-
-def test_dump_artifacts_roles():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        kwargs = dict(private_data_dir="/tmp",
-                      role="test",
-                      playbook=[{'playbook': [{'hosts': 'all'}]}])
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 2
-        data, envpath, fp = mock_dump_artifact.call_args[0]
-        assert fp == "envvars"
-        data = json.loads(data)
-        assert "ANSIBLE_ROLES_PATH" in data
-        assert data['ANSIBLE_ROLES_PATH'] == "/tmp/roles"
-        mock_dump_artifact.reset_mock()
-        kwargs = dict(private_data_dir="/tmp",
-                      role="test",
-                      roles_path="/tmp/altrole",
-                      playbook=[{'playbook': [{'hosts': 'all'}]}])
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 2
-        data, envpath, fp = mock_dump_artifact.call_args[0]
-        assert fp == "envvars"
-        data = json.loads(data)
-        assert "ANSIBLE_ROLES_PATH" in data
-        assert data['ANSIBLE_ROLES_PATH'] == "/tmp/altrole:/tmp/roles"
+    kwargs = dict(private_data_dir="/tmp",
+                  role="test",
+                  playbook=[{'playbook': [{'hosts': 'all'}]}])
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 2
+    data, envpath, fp = mock_dump_artifact.call_args[0]
+    assert fp == "envvars"
+    data = json.loads(data)
+    assert "ANSIBLE_ROLES_PATH" in data
+    assert data['ANSIBLE_ROLES_PATH'] == "/tmp/roles"
+    mock_dump_artifact.reset_mock()
+    kwargs = dict(private_data_dir="/tmp",
+                  role="test",
+                  roles_path="/tmp/altrole",
+                  playbook=[{'playbook': [{'hosts': 'all'}]}])
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 2
+    data, envpath, fp = mock_dump_artifact.call_args[0]
+    assert fp == "envvars"
+    data = json.loads(data)
+    assert "ANSIBLE_ROLES_PATH" in data
+    assert data['ANSIBLE_ROLES_PATH'] == "/tmp/altrole:/tmp/roles"
 
 
-def test_dump_artifacts_inventory():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        # inventory as a string (INI)
-        inv = '[all]\nlocalhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"'
-        kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == inv
-        assert fp == '/tmp/inventory'
-        assert fn == 'hosts'
+def test_dump_artifacts_inventory(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
 
-        mock_dump_artifact.reset_mock()
+    # inventory as a string (INI)
+    inv = '[all]\nlocalhost'
+    kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == inv
+    assert fp == '/tmp/inventory'
+    assert fn == 'hosts'
 
-        # inventory as a path
-        inv = '/tmp'
-        kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 0
-        assert mock_dump_artifact.called is False
-        assert kwargs['inventory'] == inv
+    mock_dump_artifact.reset_mock()
 
-        mock_dump_artifact.reset_mock()
+    # inventory as a path
+    inv = '/tmp'
+    kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 0
+    assert mock_dump_artifact.called is False
+    assert kwargs['inventory'] == inv
 
-        # inventory as a native object
-        inv = {'foo': 'bar'}
-        kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == json.dumps(inv)
-        assert fp == '/tmp/inventory'
-        assert fn == 'hosts.json'
+    mock_dump_artifact.reset_mock()
 
-
-def test_dump_artifacts_extravars():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        extravars = {'foo': 'bar'}
-        kwargs = {'private_data_dir': '/tmp', 'extravars': extravars}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == json.dumps(extravars)
-        assert fp == '/tmp/env'
-        assert fn == 'extravars'
-        assert 'extravars' not in kwargs
+    # inventory as a native object
+    inv = {'foo': 'bar'}
+    kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == json.dumps(inv)
+    assert fp == '/tmp/inventory'
+    assert fn == 'hosts.json'
 
 
-def test_dump_artifacts_passwords():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        passwords = {'foo': 'bar'}
-        kwargs = {'private_data_dir': '/tmp', 'passwords': passwords}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == json.dumps(passwords)
-        assert fp == '/tmp/env'
-        assert fn == 'passwords'
-        assert 'passwords' not in kwargs
+def test_dump_artifacts_extravars(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
+
+    extravars = {'foo': 'bar'}
+    kwargs = {'private_data_dir': '/tmp', 'extravars': extravars}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == json.dumps(extravars)
+    assert fp == '/tmp/env'
+    assert fn == 'extravars'
+    assert 'extravars' not in kwargs
 
 
-def test_dump_artifacts_settings():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        settings = {'foo': 'bar'}
-        kwargs = {'private_data_dir': '/tmp', 'settings': settings}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == json.dumps(settings)
-        assert fp == '/tmp/env'
-        assert fn == 'settings'
-        assert 'settings' not in kwargs
+def test_dump_artifacts_passwords(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
+
+    passwords = {'foo': 'bar'}
+    kwargs = {'private_data_dir': '/tmp', 'passwords': passwords}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == json.dumps(passwords)
+    assert fp == '/tmp/env'
+    assert fn == 'passwords'
+    assert 'passwords' not in kwargs
 
 
-def test_dump_artifacts_ssh_key():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        ssh_key = '1234567890'
-        kwargs = {'private_data_dir': '/tmp', 'ssh_key': ssh_key}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == ssh_key
-        assert fp == '/tmp/env'
-        assert fn == 'ssh_key'
-        assert 'ssh_key' not in kwargs
+def test_dump_artifacts_settings(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
+
+    settings = {'foo': 'bar'}
+    kwargs = {'private_data_dir': '/tmp', 'settings': settings}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == json.dumps(settings)
+    assert fp == '/tmp/env'
+    assert fn == 'settings'
+    assert 'settings' not in kwargs
 
 
-def test_dump_artifacts_cmdline():
-    with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
-        cmdline = '--tags foo --skip-tags'
-        kwargs = {'private_data_dir': '/tmp', 'cmdline': cmdline}
-        dump_artifacts(kwargs)
-        assert mock_dump_artifact.call_count == 1
-        data, fp, fn = mock_dump_artifact.call_args[0]
-        assert data == cmdline
-        assert fp == '/tmp/env'
-        assert fn == 'cmdline'
-        assert 'cmdline' not in kwargs
+def test_dump_artifacts_ssh_key(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
+
+    ssh_key = '1234567890'
+    kwargs = {'private_data_dir': '/tmp', 'ssh_key': ssh_key}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == ssh_key
+    assert fp == '/tmp/env'
+    assert fn == 'ssh_key'
+    assert 'ssh_key' not in kwargs
+
+
+def test_dump_artifacts_cmdline(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
+
+    cmdline = '--tags foo --skip-tags'
+    kwargs = {'private_data_dir': '/tmp', 'cmdline': cmdline}
+    dump_artifacts(kwargs)
+    assert mock_dump_artifact.call_count == 1
+    data, fp, fn = mock_dump_artifact.call_args[0]
+    assert data == cmdline
+    assert fp == '/tmp/env'
+    assert fn == 'cmdline'
+    assert 'cmdline' not in kwargs
 
 
 def test_fifo_write():


### PR DESCRIPTION
Using the `mocker` fixture rather than `unittest.Mock` directly has a number of benefits. The tests read easier since context managers within tests are unnecessary and patches are automatically scoped to the test where the fixture is used.

Also overhaul the tests in `test___main__.py` to test the code as intended.