### PR TITLE
Correctly define localhost in inventory

### DIFF
--- a/demo/inventory/hosts
+++ b/demo/inventory/hosts
@@ -1,1 +1,1 @@
-localhost
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/containerized/priv_data/inventory/hosts
+++ b/test/integration/containerized/priv_data/inventory/hosts
@@ -1,1 +1,1 @@
-localhost
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/inventory/localhost
+++ b/test/integration/inventory/localhost
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/inventory/localhost_preansible28
+++ b/test/integration/inventory/localhost_preansible28
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local ansible_python_interpreter-"/usr/bin/env python"
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/test___main__.py
+++ b/test/integration/test___main__.py
@@ -185,10 +185,7 @@ def test_cmdline_playbook(is_pre_ansible28):
 
         inventory = os.path.join(path, 'hosts')
         with open(inventory, 'w') as f:
-            if is_pre_ansible28:
-                f.write('[all]\nlocalhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"')
-            else:
-                f.write('[all]\nlocalhost ansible_connection=local')
+            f.write('[all]\nlocalhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"')
 
         cmdline('run', private_data_dir, '-p', playbook, '--inventory', inventory)
 
@@ -235,10 +232,7 @@ def test_cmdline_cmdline_override(is_pre_ansible28):
 
         inventory = os.path.join(path, 'hosts')
         with open(inventory, 'w') as f:
-            if is_pre_ansible28:
-                f.write('[all]\nlocalhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"')
-            else:
-                f.write('[all]\nlocalhost ansible_connection=local')
+            f.write('[all]\nlocalhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"')
 
         # privateip: removed --hosts command line option from test beause it is
         # not a supported combination of cli options

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -29,10 +29,7 @@ def executor(tmp_path, request, is_pre_ansible28):
     # python interpreter used is not of much interest, we really want to silence warnings
     envvars['ANSIBLE_PYTHON_INTERPRETER'] = 'auto_silent'
 
-    if is_pre_ansible28:
-        inventory = 'localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"'
-    else:
-        inventory = 'localhost ansible_connection=local'
+    inventory = 'localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"'
 
     r = init_runner(
         private_data_dir=private_data_dir,

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -114,7 +114,7 @@ def test_dump_artifacts_roles():
 def test_dump_artifacts_inventory():
     with patch('ansible_runner.utils.dump_artifact') as mock_dump_artifact:
         # inventory as a string (INI)
-        inv = '[all]\nlocalhost'
+        inv = '[all]\nlocalhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"'
         kwargs = {'private_data_dir': '/tmp', 'inventory': inv}
         dump_artifacts(kwargs)
         assert mock_dump_artifact.call_count == 1


### PR DESCRIPTION
Correct explicit localhost entries to match [implicit localhost](https://docs.ansible.com/ansible/latest/inventory/implicit_localhost.html#implicit-localhost).
