### PR TITLE
Set multiprocessing start method to fork in tests

### DIFF
--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -284,11 +284,17 @@ def test_role_run_inventory_missing(is_pre_ansible28):
 def test_role_start():
 
     with temp_directory() as temp_dir:
-        p = multiprocessing.Process(target=main,
-                                    args=[['start', '-r', 'benthomasson.hello_role',
-                                           '--hosts', 'localhost',
-                                           '--roles-path', os.path.join(HERE, 'project/roles'),
-                                           temp_dir]])
+        mpcontext = multiprocessing.get_context('fork')
+        p = mpcontext.Process(
+            target=main,
+            args=[[
+                'start',
+                '-r', 'benthomasson.hello_role',
+                '--hosts', 'localhost',
+                '--roles-path', os.path.join(HERE, 'project/roles'),
+                temp_dir,
+            ]]
+        )
         p.start()
         p.join()
 
@@ -303,13 +309,16 @@ def test_playbook_start(skipif_pre_ansible28):
         ensure_directory(os.path.join(temp_dir, 'inventory'))
         shutil.copy(os.path.join(HERE, inv), os.path.join(temp_dir, 'inventory/localhost'))
 
-        # privateip: removed --hosts command line option from test beause it is
-        # not a supported combination of cli options
-        p = multiprocessing.Process(target=main,
-                                    args=[['start', '-p', 'hello.yml',
-                                           '--inventory', os.path.join(HERE, 'inventory/localhost'),
-                                           # '--hosts', 'localhost',
-                                           temp_dir]])
+        mpcontext = multiprocessing.get_context('fork')
+        p = mpcontext.Process(
+            target=main,
+            args=[[
+                'start',
+                '-p', 'hello.yml',
+                '--inventory', os.path.join(HERE, 'inventory/localhost'),
+                temp_dir,
+            ]]
+        )
         p.start()
 
         pid_path = os.path.join(temp_dir, 'pid')


### PR DESCRIPTION
Since Python 3.8, the default start method on macOS changed to spawn, which causes the tests to fail.

I'm not sure if this has bigger implications for the actual code and not just the tests. A [change was made in Ansible Core](https://github.com/ansible/ansible/pull/63581) to account for this in the early days of Python 3.8.