### PR TITLE
Additionally mount ~/.ssh/ to /root/.ssh inside EEs

### DIFF
--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -433,6 +433,10 @@ def cli_mounts():
                     'dest': '/home/runner/.ssh/'
                 },
                 {
+                    'src': '{}/.ssh/'.format(os.environ['HOME']),
+                    'dest': '/root/.ssh/'
+                },
+                {
                     'src': '/etc/ssh/ssh_known_hosts',
                     'dest': '/etc/ssh/ssh_known_hosts'
                 }

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -309,7 +309,8 @@ def test_containerization_settings(tmp_path, container_runtime, mocker):
         '--interactive',
         '--workdir',
         '/runner/project',
-        '-v', '{}/.ssh/:/home/runner/.ssh/'.format(str(tmp_path))
+        '-v', '{}/.ssh/:/home/runner/.ssh/'.format(str(tmp_path)),
+        '-v', '{}/.ssh/:/root/.ssh/'.format(str(tmp_path)),
     ]
 
     if container_runtime == 'podman':

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -84,6 +84,7 @@ def test_prepare_config_command_with_containerization(tmp_path, container_runtim
         '--workdir',
         '/runner/project',
         '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
+        '-v', '{}/.ssh/:/root/.ssh/'.format(str(tmp_path)),
     ]
 
     if container_runtime == 'podman':

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -98,6 +98,7 @@ def test_prepare_run_command_with_containerization(tmp_path, container_runtime, 
         '/runner/project',
         '-v', '{}/:{}/'.format(cwd, cwd),
         '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
+        '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
     if container_runtime == 'podman':

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -94,6 +94,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_r
         '--workdir',
         '/runner/project',
         '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
+        '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
     if container_runtime == 'podman':
@@ -161,6 +162,7 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, container_r
         '--workdir',
         '/runner/project',
         '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
+        '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
     if container_runtime == 'podman':

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -119,6 +119,7 @@ def test_prepare_inventory_command_with_containerization(tmp_path, container_run
         '--workdir',
         '/runner/project',
         '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
+        '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
     if container_runtime == 'podman':


### PR DESCRIPTION
I accidentally closed https://github.com/ansible/ansible-runner/pull/805 with a force-push and can't figure out how to reopen.

Currently when running inside an EE as root, only SSH_AUTH_SOCK is working. This enables the usage of default key names under ~/.ssh/ on the host.
