### PR TITLE
Pre-pull some build images

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -3,6 +3,7 @@
     name: ansible-runner-container-image-base
     abstract: true
     description: Base ansible-runner container image
+    pre-run: .zuul.d/playbooks/ansible-runner-container-image-base/pre.yaml
     required-projects:
       - name: github.com/ansible/ansible-runner
     timeout: 5400

--- a/.zuul.d/playbooks/ansible-runner-container-image-base/pre.yaml
+++ b/.zuul.d/playbooks/ansible-runner-container-image-base/pre.yaml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  tasks:
+      - name: Pull container images
+        command: "{{ container_command }} pull {{ item }}"
+        delay: 30
+        retries: 3
+        register: result
+        until: result is success
+        loop:
+            - quay.io/ansible/python-builder:latest
+            - quay.io/ansible/python-base:latest


### PR DESCRIPTION
For our container build jobs, use a pre-run playbook that will retry pulling the `python-builder` and `python-base` images. This should help avoid (most of) the occasional network anomalies we see when interacting with quay.