### PR TITLE
Update key names in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = ansible-runner
 author = Ansible, Inc.
-author-email = info@ansible.com
+author_email = info@ansible.com
 summary = "Consistent Ansible Python API and CLI with container and process isolation runtime capabilities"
-home-page = https://ansible-runner.readthedocs.io
-description-file = README.md
-description-content-type = text/markdown
+home_page = https://ansible-runner.readthedocs.io
+description_file = README.md
+description_content_type = text/markdown
 license_file = LICENSE.md
 
 [entry_points]


### PR DESCRIPTION
Use underscore separated names since dash separated names are deprecated.