### PR TITLE
Introduce `ansible-runner worker cleanup` as cleanup of last-resort for remote execution nodes

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -623,11 +623,11 @@ def main(sys_args=None):
     worker_subcommands = worker_subparser.add_subparsers(
         help="Sub-sub command to invoke",
         dest='worker_subcommand',
-        description="ansible-runner worker [sub-sub-command]"
+        description="ansible-runner worker [sub-sub-command]",
     )
     cleanup_command = worker_subcommands.add_parser(
         'cleanup',
-        help="Cleanup private_data_dir patterns from prior jobs and supporting temporary folders."
+        help="Cleanup private_data_dir patterns from prior jobs and supporting temporary folders.",
     )
     cleanup.add_cleanup_args(cleanup_command)
 

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -619,6 +619,44 @@ def main(sys_args=None):
         'worker',
         help="Execute work streamed from a controlling instance"
     )
+    worker_subcommands = worker_subparser.add_subparsers(
+        help="Sub-sub command to invoke",
+        dest='command',
+        description="ansible-runner worker [sub-sub-command]"
+    )
+    cleanup_command = worker_subcommands.add_parser(
+        'cleanup',
+        help="Cleanup private_data_dir patterns from prior jobs and supporting temporary folders."
+    )
+    cleanup_command.add_argument(
+        "--file-pattern",
+        help="A file glob to find private_data_dir folders to remove. "
+             "You may use {ident} in place of a ** to identify run IDs. "
+             "Example: --file-pattern=/tmp/foo_{ident}_**"
+    )
+    cleanup_command.add_argument(
+        "--exclude-idents",
+        help="A comma separated list of run IDs to preserve. "
+             "This will only work if the deletion pattern contains the {ident} syntax."
+    )
+    cleanup_command.add_argument(
+        "--untag-images",
+        help="A comma separated list of podman or docker tags to delete. "
+             "This will not remove the corresponding layers, use the image-prune option for that. "
+             "Example: --untag-images=quay.io/user/image:devel,quay.io/user/builder:latest"
+    )
+    cleanup_command.add_argument(
+        "--image-prune",
+        action="store_true",
+        help="If specified, will run docker / podman image prune --force. "
+             "This will only run after untagging."
+    )
+    cleanup_command.add_argument(
+        "--process-isolation-executable",
+        default="podman",
+        help="The container image to clean up images for (default=podman)"
+    )
+
     worker_subparser.add_argument(
         "--private-data-dir",
         help="base directory containing the ansible-runner metadata "

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -22,10 +22,12 @@ def add_cleanup_args(command):
     )
     command.add_argument(
         "--exclude-strings",
-        help="A comma separated list of keywords in directory to avoid deleting."
+        nargs='*',
+        help="A comma separated list of keywords in directory name or path to avoid deleting."
     )
     command.add_argument(
         "--remove-images",
+        nargs='*',
         help="A comma separated list of podman or docker tags to delete. "
              "This may not remove the corresponding layers, use the image-prune option to assure full deletion. "
              "Example: --remove-images=quay.io/user/image:devel,quay.io/user/builder:latest"
@@ -142,15 +144,9 @@ def prune_images(runtime='podman'):
     return True
 
 
-def comma_sep_parse(vargs, key):
-    if vargs.get(key):
-        return vargs.get(key).split(',')
-    return []
-
-
 def run_cleanup(vargs):
-    exclude_strings = comma_sep_parse(vargs, 'exclude_strings')
-    remove_images = comma_sep_parse(vargs, 'remove_images')
+    exclude_strings = vargs.get('exclude_strings') or []
+    remove_images = vargs.get('remove_images') or []
     file_pattern = vargs.get('file_pattern')
     dir_ct = image_ct = 0
     pruned = False

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -8,14 +8,12 @@ import sys
 from pathlib import Path
 from tempfile import gettempdir
 
+from ansible_runner.defaults import GRACE_PERIOD_DEFAULT
 from ansible_runner.defaults import registry_auth_prefix
 from ansible_runner.utils import cleanup_folder
 
 
 __all__ = ['add_cleanup_args', 'run_cleanup']
-
-
-GRACE_PERIOD_DEFAULT = 60  # minutes
 
 
 def add_cleanup_args(command):

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -30,7 +30,7 @@ def add_cleanup_args(command):
         nargs='*',
         help="A comma separated list of podman or docker tags to delete. "
              "This may not remove the corresponding layers, use the image-prune option to assure full deletion. "
-             "Example: --remove-images=quay.io/user/image:devel,quay.io/user/builder:latest"
+             "Example: --remove-images=quay.io/user/image:devel quay.io/user/builder:latest"
     )
     command.add_argument(
         "--grace-period",

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -128,6 +128,7 @@ def prune_images(runtime='podman'):
     stdout = run_command([runtime, 'image', 'prune', '-f'])
     if not stdout or stdout == "Total reclaimed space: 0B":
         return False
+    print('Pruned images')
     return True
 
 

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -1,9 +1,10 @@
-import glob
-import subprocess
-import os
-import sys
-import signal
 import datetime
+import glob
+import os
+import signal
+import subprocess
+import sys
+
 from pathlib import Path
 
 from ansible_runner.defaults import registry_auth_prefix
@@ -85,7 +86,7 @@ def is_alive(dir):
 
 
 def project_idents(dir):
-    """Give dir, give list of idents that we have artifacts for"""
+    """Given dir, give list of idents that we have artifacts for"""
     try:
         return os.listdir(os.path.join(dir, 'artifacts'))
     except (FileNotFoundError, NotADirectoryError):
@@ -120,8 +121,7 @@ def cleanup_dirs(pattern, exclude_strings=(), grace_period=GRACE_PERIOD_DEFAULT)
     try:
         validate_pattern(pattern)
     except RuntimeError as e:
-        print(str(e))
-        sys.exit(1)
+        sys.exit(str(e))
     ct = 0
     now_time = datetime.datetime.now()
     for dir in glob.glob(pattern):

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -1,0 +1,145 @@
+import glob
+import subprocess
+import shutil
+import os
+import signal
+
+from ansible_runner.defaults import registry_auth_prefix
+
+
+__all__ = ['add_cleanup_args', 'run_cleanup']
+
+
+def add_cleanup_args(command):
+    command.add_argument(
+        "--file-pattern",
+        help="A file glob pattern to find private_data_dir folders to remove. "
+             "Example: --file-pattern=/tmp/.ansible-runner-*"
+    )
+    command.add_argument(
+        "--exclude-idents",
+        help="A comma separated list of run IDs to preserve. "
+             "This will only work if the deletion pattern contains the {ident} syntax."
+    )
+    command.add_argument(
+        "--remove-images",
+        help="A comma separated list of podman or docker tags to delete. "
+             "This may not remove the corresponding layers, use the image-prune option to assure full deletion. "
+             "Example: --remove-images=quay.io/user/image:devel,quay.io/user/builder:latest"
+    )
+    command.add_argument(
+        "--image-prune",
+        action="store_true",
+        help="If specified, will run docker / podman image prune --force. "
+             "This will only run after untagging."
+    )
+    command.add_argument(
+        "--process-isolation-executable",
+        default="podman",
+        help="The container image to clean up images for (default=podman)"
+    )
+
+
+def run_command(cmd):
+    '''Given list cmd, runs command and returns standard out, expecting success'''
+    process = subprocess.run(cmd, capture_output=True)
+    stdout = str(process.stdout, encoding='utf-8')
+    if process.returncode != 0:
+        print('Error running command:')
+        print(' '.join(cmd))
+        print('Stdout:')
+        print(stdout)
+        raise RuntimeError('Error running command')
+    print('Successfully ran command: {}'.format(' '.join(cmd)))
+    print(stdout)
+    # import pdb; pdb.set_trace()
+    return stdout.strip()
+
+
+def is_alive(dir):
+    pidfile = os.path.join(dir, 'pid')
+
+    try:
+        with open(pidfile, 'r') as f:
+            pid = int(f.readline())
+    except IOError:
+        return False
+
+    try:
+        os.kill(pid, signal.SIG_DFL)
+        return(0)
+    except OSError:
+        return(1)
+
+
+def cleanup_dirs(pattern, exclude_idents=()):
+    discovered_dirs = glob.glob(pattern)
+    ct = 0
+    running_idents = []
+    for dir in discovered_dirs:
+        if any(ident in dir for ident in exclude_idents):
+            continue
+        if is_alive(dir):
+            running_idents.extend(os.path.listdir(os.path.join(dir, 'artifacts')))
+            continue
+        shutil.rmtree(dir)
+        print(f'Removed directory {dir}')
+        ct += 1
+    if running_idents:
+        print(f'Excluding from cleanup running jobs {running_idents}')
+    registry_auth_pattern = f'{registry_auth_prefix}{{ident}}_**'
+    registry_auth_dirs = glob.glob(registry_auth_pattern)
+    for dir in registry_auth_dirs:
+        if any(ident in dir for ident in exclude_idents) or any(ident in dir for ident in running_idents):
+            continue
+        shutil.rmtree(dir)
+        print(f'Removed associated registry auth dir {dir}')
+    return ct
+
+
+def cleanup_images(images, runtime='podman'):
+    """Note: docker will just untag while podman will remove layers with same command"""
+    rm_ct = 0
+    for image_tag in images:
+        stdout = run_command([runtime, 'images', '--format="{{.Repository}}:{{.Tag}}"', image_tag])
+        if not stdout:
+            continue
+        for discovered_tag in stdout.split('\n'):
+            stdout = run_command([runtime, 'rmi', discovered_tag.strip().strip('"'), '-f'])
+            rm_ct += stdout.count('Untagged:')
+    return rm_ct
+
+
+def prune_images(runtime='podman'):
+    """Run the prune images command and return changed status"""
+    stdout = run_command([runtime, 'image', 'prune', '-f'])
+    if not stdout or stdout == "Total reclaimed space: 0B":
+        return False
+    return True
+
+
+def comma_sep_parse(vargs, key):
+    if vargs.get(key):
+        return vargs.get(key).split(',')
+    return []
+
+
+def run_cleanup(vargs):
+    exclude_idents = comma_sep_parse(vargs, 'exclude_idents')
+    remove_images = comma_sep_parse(vargs, 'remove_images')
+    dir_ct = image_ct = 0
+    pruned = False
+
+    if vargs.get('file_pattern'):
+        dir_ct = cleanup_dirs(vargs.get('file_pattern'), exclude_idents=exclude_idents)
+
+    if remove_images:
+        image_ct = cleanup_images(remove_images, runtime=vargs.get('process_isolation_executable'))
+
+    if vargs.get('image_prune'):
+        pruned = prune_images(runtime=vargs.get('process_isolation_executable'))
+
+    if dir_ct or image_ct or pruned:
+        print('(changed: True)')
+    else:
+        print('(changed: False)')

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 from pathlib import Path
+from tempfile import gettempdir
 
 from ansible_runner.defaults import registry_auth_prefix
 from ansible_runner.utils import cleanup_folder
@@ -96,7 +97,7 @@ def project_idents(dir):
 def delete_associated_folders(dir):
     """Where dir is the private_data_dir for a completed job, this deletes related tmp folders it used"""
     for ident in project_idents(dir):
-        registry_auth_pattern = f'/tmp/{registry_auth_prefix}{ident}_*'
+        registry_auth_pattern = f'{gettempdir()}/{registry_auth_prefix}{ident}_*'
         for dir in glob.glob(registry_auth_pattern):
             changed = cleanup_folder(dir)
             if changed:
@@ -107,7 +108,7 @@ def validate_pattern(pattern):
     # do not let user shoot themselves in foot by deleting these important linux folders
     prohibited_paths = set(Path(s) for s in (
         '/', '/bin', '/dev', '/home', '/lib', '/mnt', '/proc',
-        '/run', '/sys', '/usr', '/boot', '/etc', '/opt', '/sbin', '/tmp', '/var'
+        '/run', '/sys', '/usr', '/boot', '/etc', '/opt', '/sbin', gettempdir(), '/var'
     ))
     bad_paths = [dir for dir in glob.glob(pattern) if Path(dir).resolve() in prohibited_paths]
     if bad_paths:

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -36,6 +36,7 @@ from six import iteritems, string_types
 from ansible_runner import defaults
 from ansible_runner.output import debug
 from ansible_runner.exceptions import ConfigurationError
+from ansible_runner.defaults import registry_auth_prefix
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.utils import (
     open_fifo_write,
@@ -542,7 +543,7 @@ class BaseConfig(object):
         token = "{}:{}".format(auth_data.get('username'), auth_data.get('password'))
         encoded_container_auth_data = {'auths': {host: {'auth': b64encode(token.encode('UTF-8')).decode('UTF-8')}}}
         # Create a new temp file with container auth data
-        path = tempfile.mkdtemp(prefix='ansible_runner_registry_%s_' % self.ident)
+        path = tempfile.mkdtemp(prefix='%s%s_' % (registry_auth_prefix, self.ident))
         register_for_cleanup(path)
 
         if self.process_isolation_executable == 'docker':

--- a/ansible_runner/defaults.py
+++ b/ansible_runner/defaults.py
@@ -1,3 +1,6 @@
 default_process_isolation_executable = 'podman'
 default_container_image = 'quay.io/ansible/ansible-runner:devel'
 registry_auth_prefix = 'ansible_runner_registry_'
+
+# for ansible-runner worker cleanup command
+GRACE_PERIOD_DEFAULT = 60  # minutes

--- a/ansible_runner/defaults.py
+++ b/ansible_runner/defaults.py
@@ -1,2 +1,3 @@
 default_process_isolation_executable = 'podman'
 default_container_image = 'quay.io/ansible/ansible-runner:devel'
+registry_auth_prefix = 'ansible_runner_registry_'

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -27,11 +27,13 @@ from io import StringIO
 from six import string_types, PY2, PY3, text_type, binary_type
 
 
-def _cleanup_folder(folder):
+def cleanup_folder(folder):
+    """Deletes folder, returns True or False based on whether a change happened."""
     try:
         shutil.rmtree(folder)
-    except FileNotFoundError:
-        pass
+        return True
+    except (FileNotFoundError, NotADirectoryError):
+        return False
 
 
 def register_for_cleanup(folder):
@@ -39,7 +41,7 @@ def register_for_cleanup(folder):
     Provide the path to a folder to make sure it is deleted when execution finishes.
     The folder need not exist at the time when this is called.
     '''
-    atexit.register(_cleanup_folder, folder)
+    atexit.register(cleanup_folder, folder)
 
 
 class Bunch(object):

--- a/docs/remote_jobs.rst
+++ b/docs/remote_jobs.rst
@@ -25,13 +25,30 @@ The `ansible-runner worker` command accepts this stream, runs the playbook, and 
 stream of the resulting job events and artifacts.
 This command optionally accepts the `--private-data-dir` option.
 If provided, it will extract the contents sent from `ansible-runner transmit` into that directory.
-If no `--private-data-dir` is given, then it will extract the contents to a temporary directory,
-which will be deleted at the end of execution.
-You can use the `--delete` flag to assure that files are deleted from a location specified by `--private-data-dir` as well.
 
 The `ansible-runner process` command accepts the result stream from the worker, and fires all the normal callbacks
 and does job event processing.  In the command above, this results in printing the playbook output and saving
 artifacts to the data dir.  The `process` command takes a data dir as a parameter, to know where to save artifacts.
+
+Private Data Directory Cleanup
+------------------------------
+
+When running `ansible-runner worker`, if no `--private-data-dir` is given,
+it will extract the contents to a temporary directory which is deleted at the end of execution.
+You can use the `--delete` flag in conjunction with `--private-data-dir` to assure that
+the provided directory is deleted at the end of execution.
+
+The following command offers out-of-band cleanup.
+
+    $ ansible-runner worker cleanup --file-pattern=/tmp/foo_*
+
+This would assure that old directories that fit the file glob "/tmp/foo_*" are deleted,
+which would could be used to assure cleanup of paths created by commands like
+`ansible-runner worker --private_data_dir=/tmp/foo_3`, for example.
+NOTE: see the `--grace-period` option, which sets the time window.
+
+The transmit and process commands do not offer any automatic deletion of the
+private data directory or artifacts, because these are how the user interacts with runner.
 
 Python API
 ----------

--- a/docs/remote_jobs.rst
+++ b/docs/remote_jobs.rst
@@ -30,8 +30,11 @@ The `ansible-runner process` command accepts the result stream from the worker, 
 and does job event processing.  In the command above, this results in printing the playbook output and saving
 artifacts to the data dir.  The `process` command takes a data dir as a parameter, to know where to save artifacts.
 
-Private Data Directory Cleanup
-------------------------------
+Cleanup of Resources Used by Jobs
+---------------------------------
+
+The transmit and process commands do not offer any automatic deletion of the
+private data directory or artifacts, because these are how the user interacts with runner.
 
 When running `ansible-runner worker`, if no `--private-data-dir` is given,
 it will extract the contents to a temporary directory which is deleted at the end of execution.
@@ -47,8 +50,10 @@ which would could be used to assure cleanup of paths created by commands like
 `ansible-runner worker --private_data_dir=/tmp/foo_3`, for example.
 NOTE: see the `--grace-period` option, which sets the time window.
 
-The transmit and process commands do not offer any automatic deletion of the
-private data directory or artifacts, because these are how the user interacts with runner.
+This command also takes a `--remove-images` option to run the podman or docker `rmi` command.
+There is otherwise no automatic cleanup of images used by a run,
+even if `container_auth_data` is used to pull from a private container registry.
+To be sure that layers are deleted as well, the `--image-prune` flag is necessary.
 
 Python API
 ----------

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -14,7 +14,7 @@ from ansible_runner.defaults import default_container_image
 @pytest.mark.parametrize('runtime', ['podman', 'docker'])
 def test_cleanup_new_image(cli, runtime, tmp_path):
     if shutil.which(runtime) is None:
-        pytest.skip(f'{runtime} is unavaialble')
+        pytest.skip(f'{runtime} is unavailable')
 
     # Create new image just for this test with a unique layer
     random_string = ''.join(random.choice(ascii_lowercase) for i in range(10))

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -1,6 +1,9 @@
-import shutil
 import json
+import random
+import shutil
+
 from base64 import b64decode
+from string import ascii_lowercase
 
 import pytest
 
@@ -14,13 +17,14 @@ def test_cleanup_new_image(cli, runtime, tmp_path):
         pytest.skip(f'{runtime} is unavaialble')
 
     # Create new image just for this test with a unique layer
-    special_string = "Verify this in test - 1QT4r18a7E"
+    random_string = ''.join(random.choice(ascii_lowercase) for i in range(10))
+    special_string = f"Verify this in test - {random_string}"
     dockerfile_path = tmp_path / 'Dockerfile'
     dockerfile_path.write_text('\n'.join([
-        'FROM {}'.format(default_container_image),
-        'RUN echo {} > /tmp/for_test.txt'.format(special_string)
+        f'FROM {default_container_image}',
+        f'RUN echo {special_string} > /tmp/for_test.txt'
     ]))
-    image_name = 'quay.io/fortest/hasfile:latest'
+    image_name = f'quay.io/fortest/{random_string}:latest'
     build_cmd = [runtime, 'build', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)]
     cli(build_cmd, bare=True)
 

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -32,12 +32,12 @@ def test_cleanup_new_image(cli, runtime, tmp_path):
     assert layer_id in cli([runtime, 'images'], bare=True).stdout
 
     # workaround for https://github.com/ansible/ansible-runner/issues/758
-    os.mkdir(str(tmp_path / 'project'))
+    tmp_path.joinpath('project').mkdir()
 
     # force no colors so that we can JSON load ad hoc output
-    os.mkdir(str(tmp_path / 'env'))
-    with open(str(tmp_path / 'env' / 'envvars'), 'w') as f:
-        f.write('{"ANSIBLE_NOCOLOR": "true"}')
+    env_path = tmp_path.joinpath('env')
+    env_path.mkdir()
+    env_path.joinpath('envvars').write_text('{"ANSIBLE_NOCOLOR": "true"}')
 
     # assure that the image is usable in ansible-runner as an EE
     r = cli([

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -16,14 +16,13 @@ def test_cleanup_new_image(cli, runtime, tmp_path):
 
     # Create new image just for this test with a unique layer
     special_string = "Verify this in test - 1QT4r18a7E"
-    dockerfile_path = str(tmp_path / 'Dockerfile')
-    with open(dockerfile_path, 'w') as f:
-        f.write('\n'.join([
-            'FROM {}'.format(default_container_image),
-            'RUN echo {} > /tmp/for_test.txt'.format(special_string)
-        ]))
-    image_name = 'quay.io/fortest/hasfile:latest'
-    build_cmd = [runtime, 'build', '--rm=true', '-t', image_name, '-f', dockerfile_path, str(tmp_path)]
+dockerfile_path = tmp_path / 'Dockerfile'
+dockerfile_path.write_text('\n'.join([
+    'FROM {}'.format(default_container_image),
+    'RUN echo {} > /tmp/for_test.txt'.format(special_string)
+]))
+image_name = 'quay.io/fortest/hasfile:latest'
+build_cmd = [runtime, 'build', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)]
     cli(build_cmd, bare=True)
 
     # get an id for the unique layer

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -51,7 +51,7 @@ def test_cleanup_new_image(cli, runtime, tmp_path):
 
     image_ct = cleanup_images(images=[image_name], runtime=runtime)
     assert image_ct == 1
-    prune_images()  # May or may not do anything, depends on docker / podman
+    prune_images(runtime=runtime)  # May or may not do anything, depends on docker / podman
 
     assert layer_id not in cli([runtime, 'images'], bare=True).stdout  # establishes that cleanup was genuine
 

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -34,26 +34,25 @@ def test_cleanup_new_image(cli, runtime, tmp_path):
     # workaround for https://github.com/ansible/ansible-runner/issues/758
     os.mkdir(str(tmp_path / 'project'))
 
+    # force no colors so that we can JSON load ad hoc output
+    os.mkdir(str(tmp_path / 'env'))
+    with open(str(tmp_path / 'env' / 'envvars'), 'w') as f:
+        f.write('{"ANSIBLE_NOCOLOR": "true"}')
+
     # assure that the image is usable in ansible-runner as an EE
     r = cli([
-        'run', str(tmp_path), '-m', 'slurp', '-a', 'src=/tmp/for_test.txt', '--hosts=localhost',
+        'run', str(tmp_path), '-m', 'slurp', '-a', 'src=/tmp/for_test.txt', '--hosts=localhost', '--ident', 'for_test',
         '--container-image', image_name, '--process-isolation', '--process-isolation-executable', runtime
     ])
-    print('before parse')
-    print(r.stdout)
-    print('to load')
-    print(r.stdout[r.stdout.index('{'):r.stdout.index('}') + 1])
-    # TODO: can't rely on r.stdout due to ansii encoding, probably have to dive into job events stdout
-    data = json.loads(r.stdout[r.stdout.index('{'):r.stdout.index('}') + 1])
-    print('data')
-    print(data)
+    stdout = r.stdout
+    data = json.loads(stdout[stdout.index('{'):stdout.index('}') + 1])
     assert 'content' in data
-    assert special_string == b64decode(data['content']).strip()
+    assert special_string == str(b64decode(data['content']).strip(), encoding='utf-8')
 
-    image_ct = cleanup_images(images=[image_name])
+    image_ct = cleanup_images(images=[image_name], runtime=runtime)
     assert image_ct == 1
     prune_images()  # May or may not do anything, depends on docker / podman
 
     assert layer_id not in cli([runtime, 'images'], bare=True).stdout  # establishes that cleanup was genuine
 
-    assert cleanup_images(images=[image_name]) == 0  # should be no-op
+    assert cleanup_images(images=[image_name], runtime=runtime) == 0  # should be no-op

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -1,7 +1,6 @@
 import shutil
 import json
 from base64 import b64decode
-import os
 
 import pytest
 
@@ -16,13 +15,13 @@ def test_cleanup_new_image(cli, runtime, tmp_path):
 
     # Create new image just for this test with a unique layer
     special_string = "Verify this in test - 1QT4r18a7E"
-dockerfile_path = tmp_path / 'Dockerfile'
-dockerfile_path.write_text('\n'.join([
-    'FROM {}'.format(default_container_image),
-    'RUN echo {} > /tmp/for_test.txt'.format(special_string)
-]))
-image_name = 'quay.io/fortest/hasfile:latest'
-build_cmd = [runtime, 'build', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)]
+    dockerfile_path = tmp_path / 'Dockerfile'
+    dockerfile_path.write_text('\n'.join([
+        'FROM {}'.format(default_container_image),
+        'RUN echo {} > /tmp/for_test.txt'.format(special_string)
+    ]))
+    image_name = 'quay.io/fortest/hasfile:latest'
+    build_cmd = [runtime, 'build', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)]
     cli(build_cmd, bare=True)
 
     # get an id for the unique layer

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -1,0 +1,59 @@
+import shutil
+import json
+from base64 import b64decode
+import os
+
+import pytest
+
+from ansible_runner.cleanup import cleanup_images, prune_images
+from ansible_runner.defaults import default_container_image
+
+
+@pytest.mark.parametrize('runtime', ['podman', 'docker'])
+def test_cleanup_new_image(cli, runtime, tmp_path):
+    if shutil.which(runtime) is None:
+        pytest.skip(f'{runtime} is unavaialble')
+
+    # Create new image just for this test with a unique layer
+    special_string = "Verify this in test - 1QT4r18a7E"
+    dockerfile_path = str(tmp_path / 'Dockerfile')
+    with open(dockerfile_path, 'w') as f:
+        f.write('\n'.join([
+            'FROM {}'.format(default_container_image),
+            'RUN echo {} > /tmp/for_test.txt'.format(special_string)
+        ]))
+    image_name = 'quay.io/fortest/hasfile:latest'
+    build_cmd = [runtime, 'build', '--rm=true', '-t', image_name, '-f', dockerfile_path, str(tmp_path)]
+    cli(build_cmd, bare=True)
+
+    # get an id for the unique layer
+    r = cli([runtime, 'images', image_name, '--format="{{.ID}}"'], bare=True)
+    layer_id = r.stdout.strip()
+    assert layer_id in cli([runtime, 'images'], bare=True).stdout
+
+    # workaround for https://github.com/ansible/ansible-runner/issues/758
+    os.mkdir(str(tmp_path / 'project'))
+
+    # assure that the image is usable in ansible-runner as an EE
+    r = cli([
+        'run', str(tmp_path), '-m', 'slurp', '-a', 'src=/tmp/for_test.txt', '--hosts=localhost',
+        '--container-image', image_name, '--process-isolation', '--process-isolation-executable', runtime
+    ])
+    print('before parse')
+    print(r.stdout)
+    print('to load')
+    print(r.stdout[r.stdout.index('{'):r.stdout.index('}') + 1])
+    # TODO: can't rely on r.stdout due to ansii encoding, probably have to dive into job events stdout
+    data = json.loads(r.stdout[r.stdout.index('{'):r.stdout.index('}') + 1])
+    print('data')
+    print(data)
+    assert 'content' in data
+    assert special_string == b64decode(data['content']).strip()
+
+    image_ct = cleanup_images(images=[image_name])
+    assert image_ct == 1
+    prune_images()  # May or may not do anything, depends on docker / podman
+
+    assert layer_id not in cli([runtime, 'images'], bare=True).stdout  # establishes that cleanup was genuine
+
+    assert cleanup_images(images=[image_name]) == 0  # should be no-op

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -16,7 +16,6 @@ def test_simple_dir_cleanup_with_exclusions(tmp_path):
         path.mkdir()
         paths.append(path)
 
-
     a_file_path = tmp_path / 'pattern_32_donotcleanme'
     a_file_path.write_text('this is a file and should not be cleaned by the cleanup command')
 

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -2,7 +2,9 @@ import random
 import os
 import time
 
-from ansible_runner.cleanup import cleanup_dirs
+import pytest
+
+from ansible_runner.cleanup import cleanup_dirs, validate_pattern
 from ansible_runner.config.runner import RunnerConfig
 
 
@@ -68,3 +70,17 @@ def test_registry_auth_cleanup(tmp_path):
 
     assert not os.path.exists(private_data_dir)
     assert not os.path.exists(rc.registry_auth_path)
+
+
+@pytest.mark.parametrize('pattern', ['/', '/home'])
+def test_validate_pattern(pattern):
+    with pytest.raises(RuntimeError) as e:
+        validate_pattern(pattern)
+    assert pattern in str(e)
+    assert 'Provided pattern could result in deleting system folders' in str(e)
+
+
+def test_weird_pattern():
+    with pytest.raises(RuntimeError) as e:
+        validate_pattern('/hom*')
+    assert '/home' in str(e)

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -47,7 +47,6 @@ def test_registry_auth_cleanup(tmp_path):
         ident='awx_123'
     )
     rc.prepare()
-    # raise Exception((private_data_dir, rc.registry_auth_path))
     assert rc.registry_auth_path
     assert os.path.exists(rc.registry_auth_path)
 

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -1,0 +1,58 @@
+import random
+import os
+
+from ansible_runner.cleanup import cleanup_dirs
+from ansible_runner.config.runner import RunnerConfig
+
+
+def test_simple_dir_cleanup_with_exclusions(tmp_path):
+    paths = []
+    for i in range(0, 6, 2):
+        trailing = ''.join(random.choice("abcdefica3829") for i in range(8))
+        path = tmp_path / f'pattern_{i}_{trailing}'
+        path.mkdir()
+        paths.append(str(path))
+
+    a_file_path = os.path.join(tmp_path, 'pattern_32_donotcleanme')
+    with open(a_file_path, 'w') as f:
+        f.write('this is a file and should not be cleaned by the cleanup command')
+
+    keep_dir_path = tmp_path / 'pattern_42_alsokeepme'
+    keep_dir_path.mkdir()
+
+    ct = cleanup_dirs(pattern=str(tmp_path / 'pattern_*_*'), exclude_strings=[42])
+    assert ct == 3  # cleaned up 3 private_data_dirs
+
+    for path in paths:
+        assert not os.path.exists(path)
+
+    assert os.path.exists(a_file_path)
+    assert os.path.exists(str(keep_dir_path))
+
+    assert cleanup_dirs(pattern=str(tmp_path / 'pattern_*_*'), exclude_strings=[42]) == 0  # no more to cleanup
+
+
+def test_registry_auth_cleanup(tmp_path):
+    pdd_path = tmp_path / 'private_data_dir'
+    pdd_path.mkdir()
+    private_data_dir = str(pdd_path)
+
+    rc = RunnerConfig(
+        private_data_dir=private_data_dir,
+        playbook='ping.yml',
+        process_isolation_executable='podman',
+        process_isolation=True,
+        container_image='foo.invalid/alan/runner',
+        container_auth_data={'host': 'https://somedomain.invalid', 'username': 'foouser', 'password': '349sk34'},
+        ident='awx_123'
+    )
+    rc.prepare()
+    # raise Exception((private_data_dir, rc.registry_auth_path))
+    assert rc.registry_auth_path
+    assert os.path.exists(rc.registry_auth_path)
+
+    ct = cleanup_dirs(pattern=private_data_dir)
+    assert ct == 1
+
+    assert not os.path.exists(private_data_dir)
+    assert not os.path.exists(rc.registry_auth_path)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from ansible_runner.utils import (
+    cleanup_folder,
     isplaybook,
     isinventory,
     dump_artifacts,
@@ -16,6 +17,28 @@ from ansible_runner.utils import (
     sanitize_container_name
 )
 from ansible_runner.utils.streaming import stream_dir, unstream_dir
+
+
+def test_cleanup_folder(tmp_path):
+    folder_path = tmp_path / 'a_folder'
+    folder_path.mkdir()
+    assert folder_path.exists()  # sanity
+    cleanup_folder(str(folder_path))
+    assert not folder_path.exists()
+
+
+def test_cleanup_folder_already_deleted(tmp_path):
+    missing_dir = tmp_path / 'missing'
+    assert not missing_dir.exists()  # sanity
+    cleanup_folder(str(missing_dir))
+    assert not missing_dir.exists()
+
+
+def test_cleanup_folder_file_no_op(tmp_path):
+    file_path = tmp_path / 'a_file'
+    file_path.write_text('foobar')
+    cleanup_folder(str(file_path))
+    assert file_path.exists()
 
 
 def test_isplaybook():


### PR DESCRIPTION
As of creating the draft PR, I might have all the test cases I brainstormed taken care of. I had some content for manually running demos:

https://gist.github.com/AlanCoding/99de3b85031cae3b7f2c7c8f81560359#file-cleanup_demo-md

I don't want to merge this until AWX changes have been finished (in basic terms) and tested locally. I do want to make sure runner CI is running and that I don't get any surprises.

----

EDIT: I am now pretty happy with the testing in conjunction with AWX.