### PR TITLE
Add custom linter job

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -257,3 +257,12 @@
 - job:
     name: ansible-runner-integration
     parent: ansible-tox-py38
+
+
+# =============================================================================
+
+- job:
+    name: ansible-runner-tox-linters
+    parent: ansible-tox-linters
+    pre-run: .zuul.d/playbooks/ansible-runner-tox-linters/pre.yaml
+    nodeset: centos-8-stream

--- a/.zuul.d/playbooks/ansible-runner-tox-linters/pre.yaml
+++ b/.zuul.d/playbooks/ansible-runner-tox-linters/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Ensure python3.8 is present
+      become: true
+      package:
+        name: python38-devel
+        state: present

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -9,6 +9,7 @@
         - ansible-runner-build-container-image-stable-2.11
         - ansible-runner-build-container-image-stable-2.12
         - ansible-runner-integration
+        - ansible-runner-tox-linters
         - ansible-tox-docs:
             vars:
               sphinx_build_dir: docs/build

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands=
 
 [testenv:linters]
 description = Run code linters
-basepython = python3
+basepython = python3.8
 commands=
     flake8 --version
     flake8 docs ansible_runner test


### PR DESCRIPTION
Replacing the linter job defined in `project-config` with an in-repo version so we can use python 3.8 for the linter.

Depends-On: https://github.com/ansible/project-config/pull/950