### PR TITLE
Prevent deletion of both prohibited paths and their resolved targets

### DIFF
--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -104,10 +104,11 @@ def delete_associated_folders(dir):
 
 def validate_pattern(pattern):
     # do not let user shoot themselves in foot by deleting these important linux folders
-    prohibited_paths = set(Path(s) for s in (
+    paths = (
         '/', '/bin', '/dev', '/home', '/lib', '/mnt', '/proc',
         '/run', '/sys', '/usr', '/boot', '/etc', '/opt', '/sbin', gettempdir(), '/var'
-    ))
+    )
+    prohibited_paths = {Path(s) for s in paths}.union(Path(s).resolve() for s in paths)
     bad_paths = [dir for dir in glob.glob(pattern) if Path(dir).resolve() in prohibited_paths]
     if bad_paths:
         raise RuntimeError(

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import random
 import time
 
@@ -80,6 +81,15 @@ def test_registry_auth_cleanup(tmp_path):
         ('/hom*', '/home'),
     )
 )
-def test_validate_pattern(pattern, match):
+def test_validate_pattern(pattern, match, monkeypatch):
+    def mock_resolve(path):
+        resolved = pathlib.Path(path)
+        if path.as_posix().startswith('/hom'):
+            resolved = pathlib.Path('/System/Volumes/Data/home')
+
+        return resolved
+
+    monkeypatch.setattr('ansible_runner.cleanup.Path.resolve', mock_resolve)
+
     with pytest.raises(RuntimeError, match=match):
         validate_pattern(pattern)


### PR DESCRIPTION
If the path is a symlink, only the symlinked path was protected from being deleted, not the target the link pointed to.

Add tests to cover this scenario.