### PR TITLE
Update docs to point to Quay.io

### DIFF
--- a/docs/container.rst
+++ b/docs/container.rst
@@ -5,23 +5,23 @@ Using Runner as a container interface to Ansible
 
 The design of **Ansible Runner** makes it especially suitable for controlling the execution of **Ansible** from within a container for single-purpose
 automation workflows. A reference container image definition is `provided <https://github.com/ansible/ansible-runner/blob/master/Dockerfile>`_ and
-is also published to `DockerHub <https://hub.docker.com/r/ansible/ansible-runner/>`_ you can try it out for yourself
+is also published to `Quay.io <https://quay.io/repository/ansible/ansible-runner>`_.
 
 .. code-block:: console
 
-  $ docker run --rm -e RUNNER_PLAYBOOK=test.yml -v $PWD/demo:/runner quay.io/ansible/ansible-runner:latest
+  $ podman run --rm -e RUNNER_PLAYBOOK=test.yml -v $PWD/demo:/runner quay.io/ansible/ansible-runner:latest
     PLAY [all] *********************************************************************
-    
+
     TASK [Gathering Facts] *********************************************************
     ok: [localhost]
-    
+
     TASK [debug] *******************************************************************
     ok: [localhost] => {
       "msg": "Test!"
     }
-    
+
     PLAY RECAP *********************************************************************
-    localhost                  : ok=2    changed=0    unreachable=0    failed=0   
+    localhost                  : ok=2    changed=0    unreachable=0    failed=0
 
 
 The reference container image is purposefully light-weight and only containing the dependencies necessary to run ``ansible-runner`` itself. It's


### PR DESCRIPTION
We no longer publish to Docker Hub. Update the docs to reflect this change.

Fixes #863.