### PR TITLE
Run tests on all supported runtimes consistently

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,6 +33,8 @@ def skipif_pre_ansible28(is_pre_ansible28):
         pytest.skip("Valid only on Ansible 2.8+")
 
 
+# TODO: determine if we want to add docker / podman
+# to zuul instances in order to run these tests
 def pytest_generate_tests(metafunc):
     """If a test uses the custom marker ``test_all_runtimes``, generate marks
     for all supported container runtimes. The requires the test to accept

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -29,38 +29,6 @@ def rc(tmp_path):
     return rc
 
 
-# TODO: determine if we want to add docker / podman
-# to zuul instances in order to run these tests
-@pytest.fixture(scope="session", autouse=True)
-def container_runtime_available():
-    import subprocess
-    import warnings
-
-    runtimes_available = True
-    for runtime in ('docker', 'podman'):
-        try:
-            subprocess.run([runtime, '-v'])
-        except FileNotFoundError:
-            warnings.warn(UserWarning(f"{runtime} not available"))
-            runtimes_available = False
-    return runtimes_available
-
-
-# TODO: determine if we want to add docker / podman
-# to zuul instances in order to run these tests
-@pytest.fixture(scope="session")
-def container_runtime_installed():
-    import subprocess
-
-    for runtime in ('podman', 'docker'):
-        try:
-            subprocess.run([runtime, '-v'])
-            return runtime
-        except FileNotFoundError:
-            pass
-    pytest.skip('No container runtime is available.')
-
-
 @pytest.fixture(scope='session')
 def clear_integration_artifacts(request):
     '''Fixture is session scoped to allow parallel runs without error

--- a/test/integration/containerized/test_cleanup_images.py
+++ b/test/integration/containerized/test_cleanup_images.py
@@ -1,6 +1,5 @@
 import json
 import random
-import shutil
 
 from base64 import b64decode
 from string import ascii_lowercase
@@ -11,11 +10,8 @@ from ansible_runner.cleanup import cleanup_images, prune_images
 from ansible_runner.defaults import default_container_image
 
 
-@pytest.mark.parametrize('runtime', ['podman', 'docker'])
+@pytest.mark.test_all_runtimes
 def test_cleanup_new_image(cli, runtime, tmp_path):
-    if shutil.which(runtime) is None:
-        pytest.skip(f'{runtime} is unavailable')
-
     # Create new image just for this test with a unique layer
     random_string = ''.join(random.choice(ascii_lowercase) for i in range(10))
     special_string = f"Verify this in test - {random_string}"

--- a/test/integration/containerized/test_container_management.py
+++ b/test/integration/containerized/test_container_management.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import time
 import json
 
@@ -11,8 +10,9 @@ import pytest
 from ansible_runner.interface import run
 
 
-def is_running(cli, container_runtime_installed, container_name):
-    cmd = [container_runtime_installed, 'ps', '-aq', '--filter', f'name={container_name}']
+@pytest.mark.test_all_runtimes
+def is_running(cli, runtime, container_name):
+    cmd = [runtime, 'ps', '-aq', '--filter', f'name={container_name}']
     r = cli(cmd, bare=True)
     output = '{}{}'.format(r.stdout, r.stderr)
     print(' '.join(cmd))
@@ -49,18 +49,19 @@ class CancelStandIn:
         return True
 
 
-def test_cancel_will_remove_container(project_fixtures, container_runtime_installed, cli):
+@pytest.mark.test_all_runtimes
+def test_cancel_will_remove_container(project_fixtures, runtime, cli):
     private_data_dir = project_fixtures / 'sleep'
     ident = uuid4().hex[:12]
     container_name = f'ansible_runner_{ident}'
 
-    cancel_standin = CancelStandIn(container_runtime_installed, cli, container_name)
+    cancel_standin = CancelStandIn(runtime, cli, container_name)
 
     res = run(
         private_data_dir=private_data_dir,
         playbook='sleep.yml',
         settings={
-            'process_isolation_executable': container_runtime_installed,
+            'process_isolation_executable': runtime,
             'process_isolation': True
         },
         cancel_callback=cancel_standin.cancel,
@@ -70,14 +71,12 @@ def test_cancel_will_remove_container(project_fixtures, container_runtime_instal
     assert res.status == 'canceled'
 
     assert not is_running(
-        cli, container_runtime_installed, container_name
+        cli, runtime, container_name
     ), 'Found a running container, they should have all been stopped'
 
 
-@pytest.mark.parametrize('runtime', ['podman', 'docker'])
+@pytest.mark.test_all_runtimes
 def test_invalid_registry_host(tmp_path, runtime):
-    if shutil.which(runtime) is None:
-        pytest.skip(f'{runtime} is unavaialble')
     pdd_path = tmp_path / 'private_data_dir'
     pdd_path.mkdir()
     private_data_dir = str(pdd_path)
@@ -125,10 +124,8 @@ def test_invalid_registry_host(tmp_path, runtime):
         ])
 
 
-@pytest.mark.parametrize('runtime', ['podman', 'docker'])
+@pytest.mark.test_all_runtimes
 def test_registry_auth_file_cleanup(tmp_path, cli, runtime):
-    if shutil.which(runtime) is None:
-        pytest.skip(f'{runtime} is unavaialble')
     pdd_path = tmp_path / 'private_data_dir'
     pdd_path.mkdir()
     private_data_dir = str(pdd_path)

--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -8,10 +8,9 @@ import pytest
 from ansible_runner import defaults, run, run_async
 
 
+@pytest.mark.test_all_runtimes
 @pytest.mark.parametrize('containerized', [True, False])
-def test_basic_events(containerized, container_runtime_available, is_pre_ansible28, tmp_path, is_run_async=False, g_facts=False):
-    if containerized and not container_runtime_available:
-        pytest.skip('container runtime(s) not available')
+def test_basic_events(containerized, is_pre_ansible28, runtime, tmp_path, is_run_async=False, g_facts=False):
 
     if is_pre_ansible28:
         inventory = 'localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"'
@@ -25,7 +24,7 @@ def test_basic_events(containerized, container_runtime_available, is_pre_ansible
                 'playbook': playbook}
     if containerized:
         run_args.update({'process_isolation': True,
-                         'process_isolation_executable': 'podman',
+                         'process_isolation_executable': runtime,
                          'container_image': defaults.default_container_image,
                          'container_volume_mounts': [f'{tmp_path}:{tmp_path}']})
 
@@ -58,9 +57,10 @@ def test_basic_events(containerized, container_runtime_available, is_pre_ansible
     assert "event_data" in okay_event and len(okay_event['event_data']) > 0
 
 
+@pytest.mark.test_all_runtimes
 @pytest.mark.parametrize('containerized', [True, False])
-def test_async_events(containerized, container_runtime_available, is_pre_ansible28, tmp_path):
-    test_basic_events(containerized, container_runtime_available, is_pre_ansible28, tmp_path, is_run_async=True, g_facts=True)
+def test_async_events(containerized, is_pre_ansible28, runtime, tmp_path):
+    test_basic_events(containerized, is_pre_ansible28, runtime, tmp_path, is_run_async=True, g_facts=True)
 
 
 def test_basic_serializeable(is_pre_ansible28, tmp_path):

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -66,7 +66,8 @@ def test_env_accuracy(request, project_fixtures):
     assert actual_env == res.config.env
 
 
-def test_env_accuracy_inside_container(request, project_fixtures, container_runtime_installed):
+@pytest.mark.test_all_runtimes
+def test_env_accuracy_inside_container(request, project_fixtures, runtime):
     printenv_example = project_fixtures / 'printenv'
     os.environ['SET_BEFORE_TEST'] = 'MADE_UP_VALUE'
 
@@ -83,7 +84,7 @@ def test_env_accuracy_inside_container(request, project_fixtures, container_runt
         inventory=None,
         envvars={'FROM_TEST': 'FOOBAR'},
         settings={
-            'process_isolation_executable': container_runtime_installed,
+            'process_isolation_executable': runtime,
             'process_isolation': True
         }
     )
@@ -151,12 +152,13 @@ def test_run_command(project_fixtures):
     assert err == ''
 
 
-def test_run_ansible_command_within_container(project_fixtures, container_runtime_installed):
+@pytest.mark.test_all_runtimes
+def test_run_ansible_command_within_container(project_fixtures, runtime):
     private_data_dir = project_fixtures / 'debug'
     inventory = private_data_dir / 'inventory' / 'inv_1'
     playbook = private_data_dir / 'project' / 'debug.yml'
     container_kwargs = {
-        'process_isolation_executable': container_runtime_installed,
+        'process_isolation_executable': runtime,
         'process_isolation': True,
         'container_image': defaults.default_container_image
     }
@@ -171,12 +173,13 @@ def test_run_ansible_command_within_container(project_fixtures, container_runtim
     assert err == ''
 
 
-def test_run_script_within_container(project_fixtures, container_runtime_installed):
+@pytest.mark.test_all_runtimes
+def test_run_script_within_container(project_fixtures, runtime):
     private_data_dir = project_fixtures / 'debug'
     script_path = project_fixtures / 'files'
     container_volume_mounts = ["{}:{}:Z".format(script_path, script_path)]
     container_kwargs = {
-        'process_isolation_executable': container_runtime_installed,
+        'process_isolation_executable': runtime,
         'process_isolation': True,
         'container_image': defaults.default_container_image,
         'container_volume_mounts': container_volume_mounts
@@ -230,9 +233,10 @@ def test_get_plugin_docs_async():
     assert r.status == 'successful'
 
 
-def test_get_plugin_docs_within_container(container_runtime_installed):
+@pytest.mark.test_all_runtimes
+def test_get_plugin_docs_within_container(runtime):
     container_kwargs = {
-        'process_isolation_executable': container_runtime_installed,
+        'process_isolation_executable': runtime,
         'process_isolation': True,
         'container_image': defaults.default_container_image
     }
@@ -255,9 +259,10 @@ def test_get_plugin_docs_list():
     assert 'file' in out
 
 
-def test_get_plugin_docs_list_within_container(container_runtime_installed):
+@pytest.mark.test_all_runtimes
+def test_get_plugin_docs_list_within_container(runtime):
     container_kwargs = {
-        'process_isolation_executable': container_runtime_installed,
+        'process_isolation_executable': runtime,
         'process_isolation': True,
         'container_image': defaults.default_container_image
     }
@@ -293,9 +298,10 @@ def test_get_inventory(project_fixtures):
     assert 'host_2' in out['ungrouped']['hosts']
 
 
-def test_get_inventory_within_container(project_fixtures, container_runtime_installed):
+@pytest.mark.test_all_runtimes
+def test_get_inventory_within_container(project_fixtures, runtime):
     container_kwargs = {
-        'process_isolation_executable': container_runtime_installed,
+        'process_isolation_executable': runtime,
         'process_isolation': True,
         'container_image': defaults.default_container_image
     }

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -100,7 +100,7 @@ class TestStreamingUsage:
         self.check_artifacts(str(process_dir), job_type)
 
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
-    def test_remote_job_by_sockets(self, tmp_path, project_fixtures, container_runtime_installed, job_type):
+    def test_remote_job_by_sockets(self, tmp_path, project_fixtures, job_type):
         """This test case is intended to be close to how the AWX use case works
         the process interacts with receptorctl with sockets
         sockets are used here, but worker is manually called instead of invoked by receptor

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -279,8 +279,8 @@ def test_container_volume_mounting_with_Z(tmp_path, mocker):
         raise Exception('Could not find expected mount, args: {}'.format(new_args))
 
 
-@pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_containerization_settings(tmp_path, container_runtime, mocker):
+@pytest.mark.test_all_runtimes
+def test_containerization_settings(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
 
@@ -293,7 +293,7 @@ def test_containerization_settings(tmp_path, container_runtime, mocker):
     rc.command = ['ansible-playbook'] + rc.cmdline_args
     rc.process_isolation = True
     rc.runner_mode = 'pexpect'
-    rc.process_isolation_executable = container_runtime
+    rc.process_isolation_executable = runtime
     rc.container_image = 'my_container'
     rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
     rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
@@ -301,13 +301,13 @@ def test_containerization_settings(tmp_path, container_runtime, mocker):
     rc._handle_command_wrap(rc.execution_mode, rc.cmdline_args)
 
     extra_container_args = []
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
         extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
-        container_runtime,
+        runtime,
         'run',
         '--rm',
         '--tty',
@@ -318,7 +318,7 @@ def test_containerization_settings(tmp_path, container_runtime, mocker):
         '-v', '{}/.ssh/:/root/.ssh/'.format(str(tmp_path)),
     ]
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
     expected_command_start.extend([
@@ -337,13 +337,8 @@ def test_containerization_settings(tmp_path, container_runtime, mocker):
     assert expected_command_start == rc.command
 
 
-@pytest.mark.parametrize(
-    'container_runtime, expected', (
-        ('docker', None),
-        ('podman', '1')
-    )
-)
-def test_containerization_unsafe_write_setting(tmp_path, container_runtime, expected, mocker):
+@pytest.mark.test_all_runtimes
+def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
     mock_containerized = mocker.patch('ansible_runner.config._base.BaseConfig.containerized', new_callable=mocker.PropertyMock)
 
     rc = BaseConfig(private_data_dir=tmp_path)
@@ -352,7 +347,7 @@ def test_containerization_unsafe_write_setting(tmp_path, container_runtime, expe
     rc.command = ['ansible-playbook'] + rc.cmdline_args
     rc.process_isolation = True
     rc.runner_mode = 'pexpect'
-    rc.process_isolation_executable = container_runtime
+    rc.process_isolation_executable = runtime
     rc.container_image = 'my_container'
     rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
     mock_containerized.return_value = True
@@ -360,4 +355,9 @@ def test_containerization_unsafe_write_setting(tmp_path, container_runtime, expe
     rc._prepare_env()
     rc._handle_command_wrap(rc.execution_mode, rc.cmdline_args)
 
-    assert rc.env.get('ANSIBLE_UNSAFE_WRITES') == expected
+    expected = {
+        'docker': None,
+        'podman': 1,
+    }
+
+    assert rc.env.get('ANSIBLE_UNSAFE_WRITES') == expected[runtime]

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -52,8 +52,8 @@ def test_prepare_config_invalid_action():
     assert "Invalid action test, valid value is one of either list, dump, view" == exc.value.args[0]
 
 
-@pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_config_command_with_containerization(tmp_path, container_runtime, mocker):
+@pytest.mark.test_all_runtimes
+def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
 
@@ -61,7 +61,7 @@ def test_prepare_config_command_with_containerization(tmp_path, container_runtim
         'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
-        'process_isolation_executable': container_runtime
+        'process_isolation_executable': runtime
     }
     rc = AnsibleCfgConfig(**kwargs)
     rc.ident = 'foo'
@@ -69,13 +69,13 @@ def test_prepare_config_command_with_containerization(tmp_path, container_runtim
 
     assert rc.runner_mode == 'subprocess'
     extra_container_args = []
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
         extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
-        container_runtime,
+        runtime,
         'run',
         '--rm',
         '--interactive',
@@ -85,7 +85,7 @@ def test_prepare_config_command_with_containerization(tmp_path, container_runtim
         '-v', '{}/.ssh/:/root/.ssh/'.format(str(tmp_path)),
     ]
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
     expected_command_start.extend([

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -61,8 +61,8 @@ def test_prepare_run_command_generic():
     assert rc.execution_mode == BaseExecutionMode.GENERIC_COMMANDS
 
 
-@pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_run_command_with_containerization(tmp_path, container_runtime, mocker):
+@pytest.mark.test_all_runtimes
+def test_prepare_run_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
 
@@ -70,7 +70,7 @@ def test_prepare_run_command_with_containerization(tmp_path, container_runtime, 
         'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
-        'process_isolation_executable': container_runtime
+        'process_isolation_executable': runtime
     }
     cwd = os.getcwd()
     executable_cmd = 'ansible-playbook'
@@ -81,13 +81,13 @@ def test_prepare_run_command_with_containerization(tmp_path, container_runtime, 
 
     assert rc.runner_mode == 'pexpect'
     extra_container_args = []
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
         extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
-        container_runtime,
+        runtime,
         'run',
         '--rm',
         '--tty',
@@ -99,7 +99,7 @@ def test_prepare_run_command_with_containerization(tmp_path, container_runtime, 
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
     expected_command_start.extend([

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -58,8 +58,8 @@ def test_prepare_plugin_docs_command():
     assert rc.execution_mode == BaseExecutionMode.ANSIBLE_COMMANDS
 
 
-@pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_runtime, mocker):
+@pytest.mark.test_all_runtimes
+def test_prepare_plugin_docs_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
 
@@ -67,7 +67,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_r
         'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
-        'process_isolation_executable': container_runtime
+        'process_isolation_executable': runtime
     }
     rc = DocConfig(**kwargs)
     rc.ident = 'foo'
@@ -79,13 +79,13 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_r
     assert rc.runner_mode == 'subprocess'
     extra_container_args = []
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
         extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
-        container_runtime,
+        runtime,
         'run',
         '--rm',
         '--interactive',
@@ -95,7 +95,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, container_r
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
     expected_command_start.extend([
@@ -129,8 +129,8 @@ def test_prepare_plugin_list_command():
     assert rc.execution_mode == BaseExecutionMode.ANSIBLE_COMMANDS
 
 
-@pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_plugin_list_command_with_containerization(tmp_path, container_runtime, mocker):
+@pytest.mark.test_all_runtimes
+def test_prepare_plugin_list_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
 
@@ -138,7 +138,7 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, container_r
         'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
-        'process_isolation_executable': container_runtime
+        'process_isolation_executable': runtime
     }
     rc = DocConfig(**kwargs)
     rc.ident = 'foo'
@@ -147,13 +147,13 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, container_r
     assert rc.runner_mode == 'subprocess'
     extra_container_args = []
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
         extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
-        container_runtime,
+        runtime,
         'run',
         '--rm',
         '--interactive',
@@ -163,7 +163,7 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, container_r
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
     expected_command_start.extend([

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -84,8 +84,8 @@ def test_prepare_inventory_invalid_graph_response_format():
     assert "'graph' action supports only 'json' response format" == exc.value.args[0]
 
 
-@pytest.mark.parametrize('container_runtime', ['docker', 'podman'])
-def test_prepare_inventory_command_with_containerization(tmp_path, container_runtime, mocker):
+@pytest.mark.test_all_runtimes
+def test_prepare_inventory_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
 
@@ -93,7 +93,7 @@ def test_prepare_inventory_command_with_containerization(tmp_path, container_run
         'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
-        'process_isolation_executable': container_runtime
+        'process_isolation_executable': runtime
     }
     rc = InventoryConfig(**kwargs)
     rc.ident = 'foo'
@@ -104,13 +104,13 @@ def test_prepare_inventory_command_with_containerization(tmp_path, container_run
 
     assert rc.runner_mode == 'subprocess'
     extra_container_args = []
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         extra_container_args = ['--quiet']
     else:
         extra_container_args = [f'--user={os.getuid()}']
 
     expected_command_start = [
-        container_runtime,
+        runtime,
         'run',
         '--rm',
         '--interactive',
@@ -120,7 +120,7 @@ def test_prepare_inventory_command_with_containerization(tmp_path, container_run
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
-    if container_runtime == 'podman':
+    if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
     expected_command_start.extend([

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -47,7 +47,8 @@ def test_cleanup_command_grace_period(tmp_path):
     assert os.path.exists(new_dir)
 
 
-def test_registry_auth_cleanup(tmp_path):
+@pytest.mark.test_all_runtimes
+def test_registry_auth_cleanup(tmp_path, runtime):
     pdd_path = tmp_path / 'private_data_dir'
     pdd_path.mkdir()
     private_data_dir = str(pdd_path)
@@ -55,7 +56,7 @@ def test_registry_auth_cleanup(tmp_path):
     rc = RunnerConfig(
         private_data_dir=private_data_dir,
         playbook='ping.yml',
-        process_isolation_executable='podman',
+        process_isolation_executable=runtime,
         process_isolation=True,
         container_image='foo.invalid/alan/runner',
         container_auth_data={'host': 'https://somedomain.invalid', 'username': 'foouser', 'password': '349sk34'},


### PR DESCRIPTION
There were several approaches taken to running tests on one or both supported runtimes. Update tests so that they use a custom marker to run the test on supported runtimes and remove fixtures that are no longer needed.