### PR TITLE
Docker build breakout with: Error parsing /tmp/src/setup.cfg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,13 @@ RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \
 # over using existing wheels. Do this upstream too so we can better catch
 # issues.
 ENV PIP_OPTS=--no-build-isolation
+
+ENV PBR_VERSION=1.2.3
+
+WORKDIR /tmp/src
+
+RUN python3 setup.py sdist
+
 RUN assemble
 
 FROM $PYTHON_BASE_IMAGE


### PR DESCRIPTION
tested with buildah and docker.

```
Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name ansible-runner was given, but was not able to be found.
error in setup command: Error parsing /tmp/src/setup.cfg: Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name ansible-runner was given, but was not able to be found.
error building at STEP "RUN assemble": error while running runtime: exit status 1
[2/2] STEP 1/10: FROM quay.io/ansible/python-base:latest
ERRO[0054] exit status 1

```