### PR TITLE
Keep worker --private-data-dir when --delete not given

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -792,10 +792,12 @@ def main(sys_args=None):
             print(safe_dump(info, default_flow_style=True))
             parser.exit(0)
 
-        if vargs.get('private_data_dir') and vargs.get('delete_directory', False):
-            cleanup_folder(vargs['private_data_dir'])
-            register_for_cleanup(vargs['private_data_dir'])
-        elif not vargs.get('private_data_dir'):
+        private_data_dir = vargs.get('private_data_dir')
+        delete_directory = vargs.get('delete_directory', False)
+        if private_data_dir and delete_directory:
+            shutil.rmtree(private_data_dir, True)
+            register_for_cleanup(private_data_dir)removed?
+        elif private_data_dir is None:
             temp_private_dir = tempfile.mkdtemp()
             vargs['private_data_dir'] = temp_private_dir
             register_for_cleanup(temp_private_dir)

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -28,6 +28,7 @@ import errno
 import json
 import stat
 import os
+import shutil
 import textwrap
 import tempfile
 
@@ -39,7 +40,7 @@ from yaml import safe_dump, safe_load
 from ansible_runner import run
 from ansible_runner import output
 from ansible_runner import cleanup
-from ansible_runner.utils import dump_artifact, Bunch, register_for_cleanup, cleanup_folder
+from ansible_runner.utils import dump_artifact, Bunch, register_for_cleanup
 from ansible_runner.utils.capacity import get_cpu_count, get_mem_in_bytes, ensure_uuid
 from ansible_runner.runner import Runner
 from ansible_runner.exceptions import AnsibleRunnerException
@@ -503,7 +504,7 @@ def role_manager(vargs):
     if vargs.get('role'):
         if not project_exists and os.path.exists(project_path):
             logger.debug('removing dynamically generated project folder')
-            cleanup_folder(project_path)
+            shutil.rmtree(project_path)
         elif playbook and os.path.isfile(playbook):
             logger.debug('removing dynamically generated playbook')
             os.remove(playbook)
@@ -520,7 +521,7 @@ def role_manager(vargs):
         # since ansible-runner created the env folder, remove it
         if not env_exists and os.path.exists(env_path):
             logger.debug('removing dynamically generated env folder')
-            cleanup_folder(env_path)
+            shutil.rmtree(env_path)
 
 
 def print_common_usage():
@@ -795,8 +796,8 @@ def main(sys_args=None):
         private_data_dir = vargs.get('private_data_dir')
         delete_directory = vargs.get('delete_directory', False)
         if private_data_dir and delete_directory:
-            shutil.rmtree(private_data_dir, True)
-            register_for_cleanup(private_data_dir)removed?
+            shutil.rmtree(private_data_dir, ignore_errors=True)
+            register_for_cleanup(private_data_dir)
         elif private_data_dir is None:
             temp_private_dir = tempfile.mkdtemp()
             vargs['private_data_dir'] = temp_private_dir

--- a/docs/remote_jobs.rst
+++ b/docs/remote_jobs.rst
@@ -38,8 +38,8 @@ private data directory or artifacts, because these are how the user interacts wi
 
 When running `ansible-runner worker`, if no `--private-data-dir` is given,
 it will extract the contents to a temporary directory which is deleted at the end of execution.
-You can use the `--delete` flag in conjunction with `--private-data-dir` to assure that
-the provided directory is deleted at the end of execution.
+If the `--private-data-dir` option is given, then the directory will persist after the run finishes,
+unless you give the `--delete` flag, in which case the directory will be deleted both before and after the run.
 
 The following command offers out-of-band cleanup.
 

--- a/docs/remote_jobs.rst
+++ b/docs/remote_jobs.rst
@@ -38,8 +38,8 @@ private data directory or artifacts, because these are how the user interacts wi
 
 When running `ansible-runner worker`, if no `--private-data-dir` is given,
 it will extract the contents to a temporary directory which is deleted at the end of execution.
-If the `--private-data-dir` option is given, then the directory will persist after the run finishes,
-unless you give the `--delete` flag, in which case the directory will be deleted both before and after the run.
+If the ``--private-data-dir`` option is given, then the directory will persist after the run finishes
+unless the ``--delete`` flag is also set. In that case, the private data directory will be deleted before execution if it exists and also removed after execution.
 
 The following command offers out-of-band cleanup.
 

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -207,6 +207,28 @@ def test_worker_preserve_or_delete_dir(tmp_path, cli, transmit_stream, delete):
             assert test_path.exists()
 
 
+@pytest.mark.parametrize('delete', [False, True])
+def test_worker_preserve_or_delete_new_dir(tmp_path, cli, transmit_stream, delete):
+    """
+    Cases where non-existing --private-data-dir is provided to worker command
+    it should create it as needed, and delete it depending on the --delete flag
+    """
+    worker_dir = tmp_path / 'for_worker'
+
+    with open(transmit_stream, 'rb') as f:
+        worker_args = ['worker', '--private-data-dir', str(worker_dir)]
+        if delete is True:
+            worker_args.append('--delete')
+        r = cli(worker_args, stdin=f)
+
+    assert '{"eof": true}' in r.stdout
+    for test_path in (worker_dir, worker_dir / 'project' / 'debug.yml'):
+        if delete:
+            assert not test_path.exists()
+        else:
+            assert test_path.exists()
+
+
 def test_missing_private_dir_transmit(tmpdir):
     outgoing_buffer = io.BytesIO()
 

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -184,49 +184,67 @@ def transmit_stream(project_fixtures, tmp_path):
         return outgoing_buffer
 
 
-@pytest.mark.parametrize('old_dir', [False, True])
-def test_worker_without_delete(tmp_path, cli, transmit_stream, old_dir):
+def test_worker_without_delete_no_dir(tmp_path, cli, transmit_stream):
     worker_dir = tmp_path / 'for_worker'
 
-    test_file_path = None
-    if old_dir:
-        worker_dir.mkdir()
-        test_file_path = worker_dir / 'test_file.txt'
-        with test_file_path.open('w') as f:
-            f.write('foobar')
-
-    with open(transmit_stream, 'rb') as f:
+    with open(transmit_stream, 'rb') as stream:
         worker_args = ['worker', '--private-data-dir', str(worker_dir)]
-        r = cli(worker_args, stdin=f)
+        r = cli(worker_args, stdin=stream)
 
     assert '{"eof": true}' in r.stdout
-    check_paths = [worker_dir / 'project' / 'debug.yml']
-    if test_file_path:
-        check_paths.append(test_file_path)
-    for test_path in check_paths:
-        assert test_path.exists()
+    assert worker_dir.joinpath('project', 'debug.yml').exists()
 
 
-@pytest.mark.parametrize('old_dir', [False, True])
-def test_worker_with_delete(tmp_path, cli, transmit_stream, old_dir):
+def test_worker_without_delete_dir_exists(tmp_path, cli, transmit_stream):
+    worker_dir = tmp_path / 'for_worker'
+    worker_dir.mkdir()
+
+    test_file_path = worker_dir / 'test_file.txt'
+    test_file_path.write_text('data\n')
+
+    with open(transmit_stream, 'rb') as stream:
+        worker_args = ['worker', '--private-data-dir', str(worker_dir)]
+        r = cli(worker_args, stdin=stream)
+
+    assert '{"eof": true}' in r.stdout
+    assert worker_dir.joinpath('project', 'debug.yml').exists()
+    assert test_file_path.exists()
+
+
+def test_worker_delete_no_dir(tmp_path, cli, transmit_stream):
     """
-    Cases where non-existing --delete is provided to worker command
+    Case where non-existing --delete is provided to worker command
     it should always delete everything both before and after the run
     """
     worker_dir = tmp_path / 'for_worker'
-
-    if old_dir:
-        worker_dir.mkdir()
-        with (worker_dir / 'test_file.txt').open('w') as f:
-            f.write('foobar')
 
     with open(transmit_stream, 'rb') as f:
         worker_args = ['worker', '--private-data-dir', str(worker_dir), '--delete']
         r = cli(worker_args, stdin=f)
 
     assert '{"eof": true}' in r.stdout
-    for test_path in (worker_dir, worker_dir / 'project' / 'debug.yml'):
-        assert not test_path.exists()
+    assert not worker_dir.exists()
+    assert not worker_dir.joinpath('project', 'debug.yml').exists()
+
+
+def test_worker_delete_dir_exists(tmp_path, cli, transmit_stream):
+    """
+    Case where non-existing --delete is provided to worker command
+    it should always delete everything both before and after the run
+    """
+    worker_dir = tmp_path / 'for_worker'
+    worker_dir.mkdir()
+
+    test_file = worker_dir / 'test_file.txt'
+    test_file.write_text('data\n')
+
+    with open(transmit_stream, 'rb') as f:
+        worker_args = ['worker', '--private-data-dir', str(worker_dir), '--delete']
+        r = cli(worker_args, stdin=f)
+
+    assert '{"eof": true}' in r.stdout
+    assert not worker_dir.exists()
+    assert not worker_dir.joinpath('project', 'debug.yml').exists()
 
 
 def test_missing_private_dir_transmit(tmpdir):

--- a/test/unit/__main__/main/test_worker.py
+++ b/test/unit/__main__/main/test_worker.py
@@ -1,0 +1,45 @@
+import ansible_runner.__main__ as ansible_runner__main__
+import pytest
+
+
+def test_worker_delete(mocker):
+    mock_output = mocker.patch.object(ansible_runner__main__, 'output')
+    mock_output.configure.side_effect = AttributeError('Raised intentionally')
+
+    mock_register_for_cleanup = mocker.patch.object(ansible_runner__main__, 'register_for_cleanup')
+    mock_rmtree = mocker.patch.object(ansible_runner__main__.shutil, 'rmtree')
+    mock_mkdtemp = mocker.patch.object(ansible_runner__main__.tempfile, 'mkdtemp', return_value='some_tmp_dir')
+
+    sys_args = [
+        'worker',
+        '--delete',
+    ]
+
+    with pytest.raises(AttributeError, match='Raised intentionally'):
+        ansible_runner__main__.main(sys_args)
+
+    mock_rmtree.assert_not_called()
+    mock_register_for_cleanup.assert_called_once_with('some_tmp_dir')
+    mock_mkdtemp.assert_called_once()
+
+
+def test_worker_delete_private_data_dir(mocker, tmp_path):
+    mock_output = mocker.patch.object(ansible_runner__main__, 'output')
+    mock_output.configure.side_effect = AttributeError('Raised intentionally')
+
+    mock_register_for_cleanup = mocker.patch.object(ansible_runner__main__, 'register_for_cleanup')
+    mock_rmtree = mocker.patch.object(ansible_runner__main__.shutil, 'rmtree')
+    mock_mkdtemp = mocker.patch.object(ansible_runner__main__.tempfile, 'mkdtemp', return_value='some_tmp_dir')
+
+    sys_args = [
+        'worker',
+        '--private-data-dir', str(tmp_path),
+        '--delete',
+    ]
+
+    with pytest.raises(AttributeError, match='Raised intentionally'):
+        ansible_runner__main__.main(sys_args)
+
+    mock_rmtree.assert_called_once_with(str(tmp_path), ignore_errors=True)
+    mock_register_for_cleanup.assert_called_once_with(str(tmp_path))
+    mock_mkdtemp.assert_not_called()


### PR DESCRIPTION
I messed up our requirements a little bit with https://github.com/ansible/ansible-runner/pull/820, and now I'm getting reports that people _want_ the private_data_dir to be kept on the node running the `ansible-runner worker` command, and it is (unwantedly) getting deleted at the end of the run.

If you look at how I wrote the docs, I was dodgy about this case. I wrote it so that it would get cleaned up if it was a _new_ directory. That didn't even work for the AWX use case, for which there is an intent to respect the setting `AWX_CLEANUP_PATHS` on both control and worker nodes.

I will take out of draft when I have confirmed this works with a production install.