### PR TITLE
Switch project to squash-merge mode

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,5 +1,6 @@
 ---
 - project:
+    merge-mode: squash-merge
     check:
       jobs: &id001
         - ansible-buildset-registry


### PR DESCRIPTION
Per the Zuul [documentation for project configuration](https://zuul-ci.org/docs/zuul/reference/project_def.html#attr-project.merge-mode), this should change our merge mode from `merge-resolve` (the default) to `squash-merge`.