### PR TITLE
Set version in docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,8 @@ sphinx:
 
 python:
   install:
+    # Installation is needed in order to get the version string
+    - method: pip
+      path: .
+
     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,4 @@ sphinx:
 
 python:
   install:
-    - method: pip
-      path: .
-
     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,4 +16,7 @@ sphinx:
 
 python:
   install:
+    - method: pip
+      path: .
+
     - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
+import importlib.metadata
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('./'))
@@ -21,9 +24,16 @@ sys.path.insert(0, os.path.abspath('./'))
 
 # -- Project information -----------------------------------------------------
 
+def _get_version():
+    version_parts = importlib.metadata.version('ansible-runner').split('.', 3)[:3]
+
+    return '.'.join(version_parts)
+
+
 project = 'ansible-runner'
-copyright = '2018, Red Hat Ansible'
-author = 'Red Hat Ansible'
+copyright = f'2018-{datetime.datetime.today().year}, Red Hat, Inc'
+author = 'Red Hat, Inc.'
+version = _get_version()
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,18 +13,14 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import datetime
-import importlib.metadata
-import sys
 
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from ansible_runner.__main__ import VERSION
 
 
 # -- Project information -----------------------------------------------------
 
 def _get_version():
-    version_parts = importlib.metadata.version('ansible-runner').split('.', 3)[:3]
+    version_parts = VERSION.split('.', 3)[:3]
 
     return '.'.join(version_parts)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,12 +14,11 @@
 #
 import datetime
 import importlib.metadata
-import os
 import sys
 
-sys.path.insert(0, os.path.abspath('../'))
-sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath('./'))
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 
 # -- Project information -----------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ commands=
 
 [testenv:docs]
 description = Build documentation
+basepython = python3.8
 deps = -r{toxinidir}/docs/requirements.txt
 skip_install = True
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,6 @@ commands=
 
 [testenv:docs]
 description = Build documentation
-basepython = python3.8
 deps = -r{toxinidir}/docs/requirements.txt
-skip_install = True
 commands =
     sphinx-build -T -E -W --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs docs/build/html


### PR DESCRIPTION
Also update copyright information.

The EPUB build raises a warning when no version is provided. Since I changed the RTD configuration to treat warnings as errors it fails the actual build. Evidently the EPUB build is not done for PRs, so the failure only showed up after merging.

It may be a good idea to add an EPUB build to the `docs` environment.

