### PR TITLE
Fix settings and password dict update

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -147,7 +147,7 @@ class BaseConfig(object):
         self.runner_mode = runner_mode
         try:
             if self.settings and isinstance(self.settings, dict):
-                self.settings = self.settings.update(self.loader.load_file('env/settings', Mapping))
+                self.settings.update(self.loader.load_file('env/settings', Mapping))
             else:
                 self.settings = self.loader.load_file('env/settings', Mapping)
         except ConfigurationError:
@@ -157,7 +157,7 @@ class BaseConfig(object):
         if self.runner_mode == 'pexpect':
             try:
                 if self.passwords and isinstance(self.passwords, dict):
-                    self.passwords = self.passwords.update(self.loader.load_file('env/passwords', Mapping))
+                    self.passwords.update(self.loader.load_file('env/passwords', Mapping))
                 else:
                     self.passwords = self.passwords or self.loader.load_file('env/passwords', Mapping)
                 self.expect_passwords = {

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -1,0 +1,7 @@
+from ansible_runner.config._base import BaseConfig
+
+
+def test_combine_python_and_file_settings(project_fixtures):
+    rc = BaseConfig(private_data_dir=str(project_fixtures / 'job_env'), settings={'job_timeout': 40})
+    rc._prepare_env()
+    assert rc.settings == {'job_timeout': 40, 'process_isolation': True}


### PR DESCRIPTION
The update method on dict returns None, so we can not use the return value to set the variable as this will just delete the dictionary.

Let me know if I missunderstand something, but this did not work for me before the change.

How to reproduce:
use 
`ansible_runner.run(..., passwords={'expr': 'password'})` command with a dict as argument to `passwords`

Fixes #809
