### PR TITLE
Fix podman specific failure == applied to string and int

### DIFF
--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -360,4 +360,4 @@ def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
         'podman': '1',
     }
 
-    assert str(rc.env.get('ANSIBLE_UNSAFE_WRITES')) == expected[runtime]
+    assert rc.env.get('ANSIBLE_UNSAFE_WRITES') == expected[runtime]

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -360,4 +360,4 @@ def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
         'podman': 1,
     }
 
-    assert rc.env.get('ANSIBLE_UNSAFE_WRITES') == expected[runtime]
+    assert str(rc.env.get('ANSIBLE_UNSAFE_WRITES')) == str(expected[runtime])

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -357,7 +357,7 @@ def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
 
     expected = {
         'docker': None,
-        'podman': 1,
+        'podman': '1',
     }
 
     assert str(rc.env.get('ANSIBLE_UNSAFE_WRITES')) == str(expected[runtime])

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -360,4 +360,4 @@ def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
         'podman': '1',
     }
 
-    assert str(rc.env.get('ANSIBLE_UNSAFE_WRITES')) == str(expected[runtime])
+    assert str(rc.env.get('ANSIBLE_UNSAFE_WRITES')) == expected[runtime]


### PR DESCRIPTION
I ran the full set of tests locally on my own computer and hit this 1 failure.

```
======================================================== FAILURES =========================================================
___________________________________ test_containerization_unsafe_write_setting[podman] ____________________________________
[gw3] linux -- Python 3.9.7 /home/alancoding/repos/awx/env/bin/python3

tmp_path = PosixPath('/tmp/pytest-of-alancoding/pytest-10/popen-gw3/test_containerization_unsafe_w0'), runtime = 'podman'
mocker = <pytest_mock.plugin.MockerFixture object at 0x7fbc7ef15cd0>

    @pytest.mark.test_all_runtimes
    def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
        mock_containerized = mocker.patch('ansible_runner.config._base.BaseConfig.containerized', new_callable=mocker.PropertyMock)
    
        rc = BaseConfig(private_data_dir=tmp_path)
        rc.ident = 'foo'
        rc.cmdline_args = ['main.yaml', '-i', '/tmp/inventory']
        rc.command = ['ansible-playbook'] + rc.cmdline_args
        rc.process_isolation = True
        rc.runner_mode = 'pexpect'
        rc.process_isolation_executable = runtime
        rc.container_image = 'my_container'
        rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
        mock_containerized.return_value = True
        rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
        rc._prepare_env()
        rc._handle_command_wrap(rc.execution_mode, rc.cmdline_args)
    
        expected = {
            'docker': None,
            'podman': 1,
        }
    
>       assert rc.env.get('ANSIBLE_UNSAFE_WRITES') == expected[runtime]
E       AssertionError: assert '1' == 1
E         +'1'
E         -1

expected   = {'docker': None, 'podman': 1}
mock_containerized = <PropertyMock name='containerized' id='140447560400752'>
mocker     = <pytest_mock.plugin.MockerFixture object at 0x7fbc7ef15cd0>
rc         = <ansible_runner.config._base.BaseConfig object at 0x7fbc7eeffdf0>
runtime    = 'podman'
tmp_path   = PosixPath('/tmp/pytest-of-alancoding/pytest-10/popen-gw3/test_containerization_unsafe_w0')

test/unit/config/test__base.py:363: AssertionError
================================================== slowest 10 durations ===================================================
11.98s call     test/integration/containerized/test_cleanup_images.py::test_cleanup_new_image[podman]
11.61s call     test/integration/test_runner.py::test_run_command_long_running_children
11.16s call     test/integration/test_runner.py::test_run_command_long_running
10.66s call     test/integration/containerized/test_container_management.py::test_cancel_will_remove_container[podman]
10.58s call     test/integration/containerized/test_container_management.py::test_cancel_will_remove_container[docker]
9.79s call     test/integration/containerized/test_cli_containerized.py::test_provide_env_var[podman]
7.09s call     test/integration/test_events.py::test_async_events[podman-False]
7.06s call     test/integration/test_display_callback.py::test_module_level_no_log[playbook0]
6.76s call     test/integration/containerized/test_cli_containerized.py::test_cli_kill_cleanup[podman]
6.59s call     test/integration/containerized/test_cli_containerized.py::test_cli_kill_cleanup[docker]
================================================= short test summary info =================================================
SKIPPED [1] test/integration/test_events.py:150: cgexec not available
FAILED test/unit/config/test__base.py::test_containerization_unsafe_write_setting[podman] - AssertionError: assert '1' == 1
================================== 1 failed, 2078 passed, 1 skipped in 123.61s (0:02:03) ==================================
```

Consider that CI is only running docker, and not podman, this probably isn't just a local issue.