### PR TITLE
Add action to label new issues and pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+needs_triage:
+    - '.*'
+    - '.*/*'
+    - '*'
+    - '*/*'
+
+docs:
+    - docs/*
+
+test:
+    - 'test/*'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,26 @@
+name: Triage
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+on:
+  issues:
+    types:
+      - opened
+
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    name: Label
+
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This will label new issues and pull requests with the `needs_triage` label in order to help with our new triage process.