### PR TITLE
[release_2.0] Fix podman specific failure == applied to string and int (#900)

### DIFF
--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -356,7 +356,7 @@ def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
 
     expected = {
         'docker': None,
-        'podman': 1,
+        'podman': '1',
     }
 
     assert rc.env.get('ANSIBLE_UNSAFE_WRITES') == expected[runtime]


### PR DESCRIPTION
Backport of #900 for Ansible Runner 2.0.