### PR TITLE
Revert "Switch project to squash-merge mode"

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    merge-mode: squash-merge
     check:
       jobs: &id001
         - ansible-buildset-registry


### PR DESCRIPTION
Reverts ansible/ansible-runner#890

Doesn't look like this works as a setting in-repo for some unknown reason. Following suit with other projects that set this in `project-config`: https://github.com/ansible/project-config/pull/971