### PR TITLE
Add coverage reporting to tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+source = ansible_runner
+data_file = test/coverage/data/coverage
+
+[report]
+skip_covered = True
+skip_empty = True
+
+[html]
+directory = test/coverage/reports/html
+
+[xml]
+output = test/coverage/reports/coverage.xml
+
+[json]
+output = test/coverage/reports/coverage.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /dist
 /build
 /rpm-build
+/test/coverage
 /deb-build
 /*.egg-info
 *.py[c,o]

--- a/.gitignore
+++ b/.gitignore
@@ -1,30 +1,35 @@
-# Mac OS X
-*.DS_Store
+# Test artifacts
+*.py,cover
+.pytest_cache/
+docs/_build/
+docs/build/
+pytestdebug.log
+test/coverage/
 
-# Editors
-*.sw[poj]
-*~
-/.idea
+# Byte-complied files
+*.py[cod]
+__pycache__/
 
+# Distribution / packaging
+*.egg
+*.egg-info/
+.eggs/
+AUTHORS
+Changelog
+build/
+deb-build/
+dist/
+eggs/
+rpm-build/
+
+# Environments
+.env
+.python-version
+.tox/
+.venv
+env/
+venv/
+
+# Demo files
 /demo/artifacts
 /demo/daemon.log
-/docs/_build
-/.tox
-/dist
-/build
-/rpm-build
-/test/coverage
-/deb-build
-/*.egg-info
-*.py[c,o]
-.pytest_cache
-pytestdebug.log
-.coverage
-*,cover
-.venv
-/venv
-.env
-/.eggs/
-docs/build
-AUTHORS
-ChangeLog

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,7 @@ addopts =
     --durations 10
     --durations-min 1
     --strict-markers
+    --cov
+    --cov-report html
+    --cov-report term
+    --cov-report xml

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-cov
 pytest-mock
 pytest-timeout
 pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -29,3 +29,12 @@ description = Build documentation
 deps = -r{toxinidir}/docs/requirements.txt
 commands =
     sphinx-build -T -E -W --keep-going {tty:--color} -j auto -d docs/build/doctrees -b html docs docs/build/html
+
+[testenv:clean]
+description = Erase docs and coverage artifacts
+deps =
+skip_install = True
+allow_external = /bin/sh
+commands =
+    /bin/sh -c "rm -rf {toxinidir}/test/coverage/*"
+    /bin/sh -c "rm -rf {toxinidir}/docs/{_,}build"


### PR DESCRIPTION
Enable and configure test coverage.
Add a `tox` environment for cleaning up coverage reports and docs builds.