### PR TITLE
Runner tests require a valid PATH

### DIFF
--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -21,7 +21,7 @@ def rc(tmp_path):
         pexpect.EOF: None
     }
     rc.cwd = str(tmp_path)
-    rc.env = {}
+    rc.env = {"PATH": os.environ["PATH"]}
     rc.job_timeout = 10
     rc.idle_timeout = 0
     rc.pexpect_timeout = 2.


### PR DESCRIPTION
It turns out that tests `test/integration/test_runner.py` and `test/unit/test_runner.py` try to execute tools like `bash`, but the `rc` fixture completely nulls out the `env`. This means that even the `PATH` is not available on which to find `bash`. This makes the tests fail if they run in a sandboxed environment like this build: https://hydra.nixos.org/build/157248684