### PR TITLE
Fix incorrect formatting in docs

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -548,11 +548,9 @@ def add_args_to_parser(parser, args):
     """
     Traverse a tuple of argments to add to a parser
 
-    :param parser: Instance of a parser, subparser, or argument group
-    :type sys_args: argparse.ArgumentParser
+    :param argparse.ArgumentParser parser: Instance of a parser, subparser, or argument group
 
-    :param args: Tuple of tuples, format ((arg1, arg2), {'kwarg1':'val1'},)
-    :type sys_args: tuple
+    :param tuple args: Tuple of tuples, format ((arg1, arg2), {'kwarg1':'val1'},)
 
     :returns: None
     """
@@ -566,8 +564,7 @@ def main(sys_args=None):
     When the ```ansible-runner``` command is executed, this function
     is the main entry point that is called and executed.
 
-    :param sys_args: List of arguments to be parsed by the parser
-    :type sys_args: list
+    :param list sys_args: List of arguments to be parsed by the parser
 
     :returns: an instance of SystemExit
     :rtype: SystemExit

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -259,7 +259,7 @@ def run(**kwargs):
     :type only_failed_event_data: bool
     :type check_job_event_data: bool
 
-    :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing `rc` if run remotely
+    :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing ``rc`` if run remotely
     '''
     r = init_runner(**kwargs)
     r.run()

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -211,7 +211,7 @@ def run(**kwargs):
     :type private_data_dir: str
     :type ident: str
     :type json_mode: bool
-    :type playbook: str or filename or list
+    :type playbook: str or list
     :type inventory: str or dict or list
     :type role: str
     :type roles_path: dict or list
@@ -230,13 +230,13 @@ def run(**kwargs):
     :type quiet: bool
     :type verbosity: int
     :type streamer: str
-    :type _input: file
-    :type _output: file
-    :type event_handler: function
-    :type cancel_callback: function
-    :type finished_callback: function
-    :type status_handler: function
-    :type artifacts_handler: function
+    :type _input: io.FileIO
+    :type _output: io.FileIO
+    :type event_handler: Callable
+    :type cancel_callback: Callable
+    :type finished_callback: Callable
+    :type status_handler: Callable
+    :type artifacts_handler: Callable
     :type process_isolation: bool
     :type process_isolation_executable: str
     :type process_isolation_path: str
@@ -360,9 +360,9 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
 
     :type executable_cmd: str
     :type cmdline_args: list
-    :type input_fd: file descriptor
-    :type output_fd: file descriptor
-    :type error_fd: file descriptor
+    :type input_fd: int
+    :type output_fd: int
+    :type error_fd: int
     :type runner_mode: str
     :type host_cwd: str
     :type envvars: dict
@@ -385,11 +385,11 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
-    :type event_handler: function
-    :type cancel_callback: function
-    :type finished_callback: function
-    :type status_handler: function
-    :type artifacts_handler: function
+    :type event_handler: Callable
+    :type cancel_callback: Callable
+    :type finished_callback: Callable
+    :type status_handler: Callable
+    :type artifacts_handler: Callable
     :type check_job_event_data: bool
 
     :returns: Returns a tuple of response, error string and return code.
@@ -523,11 +523,11 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
-    :type event_handler: function
-    :type cancel_callback: function
-    :type finished_callback: function
-    :type status_handler: function
-    :type artifacts_handler: function
+    :type event_handler: Callable
+    :type cancel_callback: Callable
+    :type finished_callback: Callable
+    :type status_handler: Callable
+    :type artifacts_handler: Callable
     :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
@@ -639,11 +639,11 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
-    :type event_handler: function
-    :type cancel_callback: function
-    :type finished_callback: function
-    :type status_handler: function
-    :type artifacts_handler: function
+    :type event_handler: Callable
+    :type cancel_callback: Callable
+    :type finished_callback: Callable
+    :type status_handler: Callable
+    :type artifacts_handler: Callable
     :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as
@@ -738,7 +738,7 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :type vault_ids: str
     :type vault_password_file: str
     :type output_file: str
-    :type: export: bool
+    :type export: bool
     :type runner_mode: str
     :type host_cwd: str
     :type envvars: dict
@@ -761,11 +761,11 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :type ssh_key: str
     :type quiet: bool
     :type json_mode: bool
-    :type event_handler: function
-    :type cancel_callback: function
-    :type finished_callback: function
-    :type status_handler: function
-    :type artifacts_handler: function
+    :type event_handler: Callable
+    :type cancel_callback: Callable
+    :type finished_callback: Callable
+    :type status_handler: Callable
+    :type artifacts_handler: Callable
     :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is
@@ -868,12 +868,12 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :type timeout: int
     :type ssh_key: str
     :type quiet: bool
-    :type: json_mode: bool
-    :type event_handler: function
-    :type cancel_callback: function
-    :type finished_callback: function
-    :type status_handler: function
-    :type artifacts_handler: function
+    :type json_mode: bool
+    :type event_handler: Callable
+    :type cancel_callback: Callable
+    :type finished_callback: Callable
+    :type status_handler: Callable
+    :type artifacts_handler: Callable
     :type check_job_event_data: bool
 
     :returns: Returns a tuple of response and error string. In case if ``runner_mode`` is set to ``pexpect`` the error value is
@@ -940,12 +940,12 @@ def get_role_list(collection=None, playbook_dir=None, **kwargs):
         module. Output artifacts will also be stored here for later consumption.
     :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
         the artifact directory holding the results of the invocation.
-    :param function event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
-    :param function cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
-    :param function finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
-    :param function status_handler: An optional callback that will be invoked any time the status changes
+    :param Callable event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
+    :param Callable cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
+    :param Callable finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
+    :param Callable status_handler: An optional callback that will be invoked any time the status changes
         (for example: started, running, failed, successful, timeout)
-    :param function artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param Callable artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
     :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
         value is set to 'True' it will raise 'AnsibleRunnerException' exception. If set to 'False', log a debug message and continue execution.
         Default value is 'False'
@@ -1017,12 +1017,12 @@ def get_role_argspec(role, collection=None, playbook_dir=None, **kwargs):
         module. Output artifacts will also be stored here for later consumption.
     :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
         the artifact directory holding the results of the invocation.
-    :param function event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
-    :param function cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
-    :param function finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
-    :param function status_handler: An optional callback that will be invoked any time the status changes
+    :param Callable event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
+    :param Callable cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
+    :param Callable finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
+    :param Callable status_handler: An optional callback that will be invoked any time the status changes
         (for example: started, running, failed, successful, timeout)
-    :param function artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param Callable artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
     :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
         value is set to 'True' it will raise 'AnsibleRunnerException' exception. If set to 'False', log a debug message and continue execution.
         Default value is 'False'

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -135,17 +135,17 @@ def run(**kwargs):
     '''
     Run an Ansible Runner task in the foreground and return a Runner object when complete.
 
-    :param private_data_dir: The directory containing all runner metadata needed to invoke the runner
+    :param str private_data_dir: The directory containing all runner metadata needed to invoke the runner
                              module. Output artifacts will also be stored here for later consumption.
-    :param ident: The run identifier for this invocation of Runner. Will be used to create and name
+    :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
                   the artifact directory holding the results of the invocation.
-    :param json_mode: Store event data in place of stdout on the console and in the stdout file
-    :param playbook: The playbook (either a list or dictionary of plays, or as a path relative to
+    :param bool json_mode: Store event data in place of stdout on the console and in the stdout file
+    :param str or list playbook: The playbook (either a list or dictionary of plays, or as a path relative to
                      ``private_data_dir/project``) that will be invoked by runner when executing Ansible.
-    :param module: The module that will be invoked in ad-hoc mode by runner when executing Ansible.
-    :param module_args: The module arguments that will be supplied to ad-hoc mode.
-    :param host_pattern: The host pattern to match when running in ad-hoc mode.
-    :param inventory: Overrides the inventory directory/file (supplied at ``private_data_dir/inventory``) with
+    :param str module: The module that will be invoked in ad-hoc mode by runner when executing Ansible.
+    :param str module_args: The module arguments that will be supplied to ad-hoc mode.
+    :param str host_pattern: The host pattern to match when running in ad-hoc mode.
+    :param str or dict or list inventory: Overrides the inventory directory/file (supplied at ``private_data_dir/inventory``) with
         a specific host or list of hosts. This can take the form of:
 
             - Path to the inventory file in the ``private_data_dir``
@@ -153,111 +153,62 @@ def run(**kwargs):
             - A text INI formatted string
             - A list of inventory sources, or an empty list to disable passing inventory
 
-    :param role: Name of the role to execute.
-    :param roles_path: Directory or list of directories to assign to ANSIBLE_ROLES_PATH
-    :param envvars: Environment variables to be used when running Ansible. Environment variables will also be
+    :param str role: Name of the role to execute.
+    :param dict or list roles_path: Directory or list of directories to assign to ANSIBLE_ROLES_PATH
+    :param dict envvars: Environment variables to be used when running Ansible. Environment variables will also be
                     read from ``env/envvars`` in ``private_data_dir``
-    :param extravars: Extra variables to be passed to Ansible at runtime using ``-e``. Extra vars will also be
+    :param dict extravars: Extra variables to be passed to Ansible at runtime using ``-e``. Extra vars will also be
                       read from ``env/extravars`` in ``private_data_dir``.
-    :param passwords: A dictionary containing password prompt patterns and response values used when processing output from
+    :param dict passwords: A dictionary containing password prompt patterns and response values used when processing output from
                       Ansible. Passwords will also be read from ``env/passwords`` in ``private_data_dir``.
-    :param settings: A dictionary containing settings values for the ``ansible-runner`` runtime environment. These will also
+    :param dict settings: A dictionary containing settings values for the ``ansible-runner`` runtime environment. These will also
                      be read from ``env/settings`` in ``private_data_dir``.
-    :param ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
-    :param cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
-    :param limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
-    :param forks: Control Ansible parallel concurrency
-    :param verbosity: Control how verbose the output of ansible-playbook is
-    :param quiet: Disable all output
-    :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
-    :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
-    :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
-    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+    :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
+    :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
+    :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
+    :param int forks: Control Ansible parallel concurrency
+    :param int verbosity: Control how verbose the output of ansible-playbook is
+    :param bool quiet: Disable all output
+    :param str artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
+    :param str project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
+    :param int rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param int timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
                     (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
                     execution.
-    :param streamer: Optionally invoke ansible-runner as one of the steps in the streaming pipeline
-    :param _input: An optional file or file-like object for use as input in a streaming pipeline
-    :param _output: An optional file or file-like object for use as output in a streaming pipeline
-    :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
-    :param cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
-    :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
-    :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
-    :param artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
-    :param process_isolation: Enable process isolation, using either a container engine (e.g. podman) or a sandbox (e.g. bwrap).
-    :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
-    :param process_isolation_path: Path that an isolated playbook run will use for staging. (default: /tmp)
-    :param process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
-    :param process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
-    :param process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
-    :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
-    :param container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir. (default: None)
-    :param container_options: List of container options to pass to execution engine.
-    :param resource_profiling: Enable collection of resource utilization data during playbook execution.
-    :param resource_profiling_base_cgroup: Name of existing cgroup which will be sub-grouped in order to measure resource utilization (default: ansible-runner)
-    :param resource_profiling_cpu_poll_interval: Interval (in seconds) between CPU polling for determining CPU usage (default: 0.25)
-    :param resource_profiling_memory_poll_interval: Interval (in seconds) between memory polling for determining memory usage (default: 0.25)
-    :param resource_profiling_pid_poll_interval: Interval (in seconds) between polling PID count for determining number of processes used (default: 0.25)
-    :param resource_profiling_results_dir: Directory where profiling data files should be saved (defaults to profiling_data folder inside private data dir)
-    :param directory_isolation_base_path: An optional path will be used as the base path to create a temp directory, the project contents will be
+    :param str streamer: Optionally invoke ansible-runner as one of the steps in the streaming pipeline
+    :param io.FileIO _input: An optional file or file-like object for use as input in a streaming pipeline
+    :param io.FileIO _output: An optional file or file-like object for use as output in a streaming pipeline
+    :param Callable event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
+    :param Callable cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
+    :param Callable finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
+    :param Callable status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
+    :param Callable artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param bool process_isolation: Enable process isolation, using either a container engine (e.g. podman) or a sandbox (e.g. bwrap).
+    :param str process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
+    :param str process_isolation_path: Path that an isolated playbook run will use for staging. (default: /tmp)
+    :param str or list process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
+    :param str or list process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
+    :param str or list process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
+    :param str container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
+    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir. (default: None)
+    :param list container_options: List of container options to pass to execution engine.
+    :param bool resource_profiling: Enable collection of resource utilization data during playbook execution.
+    :param str resource_profiling_base_cgroup: Name of existing cgroup which will be sub-grouped in order to measure
+                    resource utilization (default: ansible-runner)
+    :param float resource_profiling_cpu_poll_interval: Interval (in seconds) between CPU polling for determining CPU usage (default: 0.25)
+    :param float resource_profiling_memory_poll_interval: Interval (in seconds) between memory polling for determining memory usage (default: 0.25)
+    :param float resource_profiling_pid_poll_interval: Interval (in seconds) between polling PID count for determining number of processes used (default: 0.25)
+    :param str resource_profiling_results_dir: Directory where profiling data files should be saved (defaults to profiling_data folder inside private data dir)
+    :param str directory_isolation_base_path: An optional path will be used as the base path to create a temp directory, the project contents will be
                                           copied to this location which will then be used as the working directory during playbook execution.
-    :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
+    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
                        This is only used for 'jsonfile' type fact caches.
-    :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
-    :param omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
-    :param only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
-    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+    :param str fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
+    :param bool omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
+    :param bool only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
+    :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
                                  value is set to 'True' it will raise 'AnsibleRunnerException' exception,
                                  if set to 'False' it log a debug message and continue execution. Default value is 'False'
-    :type private_data_dir: str
-    :type ident: str
-    :type json_mode: bool
-    :type playbook: str or list
-    :type inventory: str or dict or list
-    :type role: str
-    :type roles_path: dict or list
-    :type envvars: dict
-    :type extravars: dict
-    :type passwords: dict
-    :type settings: dict
-    :type ssh_key: str
-    :type artifact_dir: str
-    :type project_dir: str
-    :type rotate_artifacts: int
-    :type timeout: int
-    :type cmdline: str
-    :type limit: str
-    :type forks: int
-    :type quiet: bool
-    :type verbosity: int
-    :type streamer: str
-    :type _input: io.FileIO
-    :type _output: io.FileIO
-    :type event_handler: Callable
-    :type cancel_callback: Callable
-    :type finished_callback: Callable
-    :type status_handler: Callable
-    :type artifacts_handler: Callable
-    :type process_isolation: bool
-    :type process_isolation_executable: str
-    :type process_isolation_path: str
-    :type process_isolation_hide_paths: str or list
-    :type process_isolation_show_paths: str or list
-    :type process_isolation_ro_paths: str or list
-    :type container_image: str
-    :type container_volume_mounts: list
-    :type container_options: list
-    :type resource_profiling: bool
-    :type resource_profiling_base_cgroup: str
-    :type resource_profiling_cpu_poll_interval: float
-    :type resource_profiling_memory_poll_interval: float
-    :type resource_profiling_pid_poll_interval: float
-    :type resource_profiling_results_dir: str
-    :type directory_isolation_base_path: str
-    :type fact_cache: str
-    :type fact_cache_type: str
-    :type omit_event_data: bool
-    :type only_failed_event_data: bool
-    :type check_job_event_data: bool
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing ``rc`` if run remotely
     '''
@@ -309,88 +260,54 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     '''
     Run an (Ansible) commands in the foreground and return a Runner object when complete.
 
-    :param executable_cmd: The command to be executed.
-    :param cmdline_args: A list of arguments to be passed to the executable command.
-    :param input_fd: This parameter is applicable when ``runner_mode`` is set to ``subprocess``, it provides the
+    :param str executable_cmd: The command to be executed.
+    :param list cmdline_args: A list of arguments to be passed to the executable command.
+    :param int input_fd: This parameter is applicable when ``runner_mode`` is set to ``subprocess``, it provides the
                      input file descrption to interact with the sub-process running the command.
-    :param output_fd: The output file descriptor to stream the output of command execution.
-    :param error_fd: This parameter is applicable when ``runner_mode`` is set to ``subprocess``, it provides the
+    :param int output_fd: The output file descriptor to stream the output of command execution.
+    :param int error_fd: This parameter is applicable when ``runner_mode`` is set to ``subprocess``, it provides the
                      error file descrption to read the error received while executing the command.
-    :param runner_mode: The applicable values are ``pexpect`` and ``subprocess``. If the value of ``input_fd`` parameter
+    :param str runner_mode: The applicable values are ``pexpect`` and ``subprocess``. If the value of ``input_fd`` parameter
                         is set or the executable command is one of ``ansible-config``, ``ansible-doc`` or ``ansible-galaxy``
                         the default value is set to ``subprocess`` else in other cases it is set to ``pexpect``.
-    :param host_cwd: The host current working directory to be mounted within the container (if enabled) and will be
+    :param str host_cwd: The host current working directory to be mounted within the container (if enabled) and will be
                      the work directory within container.
-    :param envvars: Environment variables to be used when running Ansible. Environment variables will also be
+    :param dict envvars: Environment variables to be used when running Ansible. Environment variables will also be
                     read from ``env/envvars`` in ``private_data_dir``
-    :param passwords: A dictionary containing password prompt patterns and response values used when processing output from
+    :param dict passwords: A dictionary containing password prompt patterns and response values used when processing output from
                       Ansible. Passwords will also be read from ``env/passwords`` in ``private_data_dir``.
-    :param settings: A dictionary containing settings values for the ``ansible-runner`` runtime environment. These will also
+    :param dict settings: A dictionary containing settings values for the ``ansible-runner`` runtime environment. These will also
                      be read from ``env/settings`` in ``private_data_dir``.
-    :param ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
-    :param quiet: Disable all output
-    :param json_mode: Store event data in place of stdout on the console and in the stdout file
-    :param artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
-    :param project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
-    :param rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
-    :param timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
+    :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
+    :param bool quiet: Disable all output
+    :param bool json_mode: Store event data in place of stdout on the console and in the stdout file
+    :param str artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
+    :param str project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
+    :param int rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
+    :param int timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
                     (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
                     execution.
-    :param process_isolation: Enable process isolation, using a container engine (e.g. podman).
-    :param process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
-    :param container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
-    :param container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir:labels. (default: None)
-    :param container_options: List of container options to pass to execution engine.
-    :param container_workdir: The working directory within the container.
-    :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
+    :param bool process_isolation: Enable process isolation, using a container engine (e.g. podman).
+    :param str process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
+    :param str container_image: Container image to use when running an ansible task (default: quay.io/ansible/ansible-runner:devel)
+    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir:labels. (default: None)
+    :param list container_options: List of container options to pass to execution engine.
+    :param str container_workdir: The working directory within the container.
+    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
                        This is only used for 'jsonfile' type fact caches.
-    :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
-    :param private_data_dir: The directory containing all runner metadata needed to invoke the runner
+    :param str fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
+    :param str private_data_dir: The directory containing all runner metadata needed to invoke the runner
                              module. Output artifacts will also be stored here for later consumption.
-    :param ident: The run identifier for this invocation of Runner. Will be used to create and name
+    :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
                   the artifact directory holding the results of the invocation.
-    :param event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
-    :param cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
-    :param finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
-    :param status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
-    :param artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
-    :param check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
+    :param Callable event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
+    :param Callable cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
+    :param Callable finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
+    :param Callable status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
+    :param Callable artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
+    :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
                                  value is set to 'True' it will raise 'AnsibleRunnerException' exception,
                                  if set to 'False' it log a debug message and continue execution. Default value is 'False'
-
-    :type executable_cmd: str
-    :type cmdline_args: list
-    :type input_fd: int
-    :type output_fd: int
-    :type error_fd: int
-    :type runner_mode: str
-    :type host_cwd: str
-    :type envvars: dict
-    :type passwords: dict
-    :type settings: dict
-    :type private_data_dir: str
-    :type project_dir: str
-    :type artifact_dir: str
-    :type fact_cache_type: str
-    :type fact_cache: str
-    :type process_isolation: bool
-    :type process_isolation_executable: str
-    :type container_image: str
-    :type container_volume_mounts: list
-    :type container_options: list
-    :type container_workdir: str
-    :type ident: str
-    :type rotate_artifacts: int
-    :type timeout: int
-    :type ssh_key: str
-    :type quiet: bool
-    :type json_mode: bool
-    :type event_handler: Callable
-    :type cancel_callback: Callable
-    :type finished_callback: Callable
-    :type status_handler: Callable
-    :type artifacts_handler: Callable
-    :type check_job_event_data: bool
 
     :returns: Returns a tuple of response, error string and return code.
               In case if ``runner_mode`` is set to ``pexpect`` the error value is empty as

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -546,7 +546,7 @@ class Runner(object):
     @classmethod
     def handle_termination(cls, pid, pidfile=None, is_cancel=True):
         '''
-        Internal method to terminate a subprocess spawned by `pexpect` representing an invocation of runner.
+        Internal method to terminate a subprocess spawned by ``pexpect`` representing an invocation of runner.
 
         :param pid:       the process id of the running the job.
         :param pidfile:   the daemon's PID file

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -428,7 +428,10 @@ def sanitize_container_name(original_name):
     Docker and podman will only accept certain characters in container names
     This takes a given name from user-specified values and replaces the
     invalid characters so it can be used in docker/podman CLI commands
+
+    :param str original_name: Container name containing potentially invalid characters
     """
+
     return re.sub('[^a-zA-Z0-9_-]', '_', text_type(original_name))
 
 
@@ -456,10 +459,10 @@ def cli_mounts():
 
 def sanitize_json_response(data):
     '''
-    Removes warning message from response message emitted by ansible
+    Removes warning message from response message emitted by Ansible
     command line utilities.
-    :param action: The string data to be santizied
-    :type action: str
+
+    :param str data: The string data to be sanitized
     '''
     start_re = re.compile("{(.|\n)*", re.MULTILINE)
     data = start_re.search(data).group().strip()

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -402,17 +402,17 @@ def ensure_str(s, encoding='utf-8', errors='strict'):
     """
     Copied from six==1.12
 
-    Coerce *s* to `str`.
+    Coerce *s* to ``str``.
 
     For Python 2:
 
-      - `unicode` -> encoded to `str`
-      - `str` -> `str`
+      - ``unicode`` -> encoded to ``str``
+      - ``str`` -> ``str``
 
     For Python 3:
 
-      - `str` -> `str`
-      - `bytes` -> decoded to `str`
+      - ``str`` -> ``str``
+      - ``bytes`` -> decoded to ``str``
     """
     if not isinstance(s, (text_type, binary_type)):
         raise TypeError("not expecting type '%s'" % type(s))

--- a/ansible_runner/utils/base64io.py
+++ b/ansible_runner/utils/base64io.py
@@ -306,7 +306,7 @@ class Base64IO(io.IOBase):
             Because the source that this reads from may not contain any OEL characters, we
             read "lines" in chunks of length ``io.DEFAULT_BUFFER_SIZE``.
 
-        :type limit: int
+        :param int limit: Maximum number of bytes to read
         :rtype: bytes
         """
         return self.read(limit if limit > 0 else io.DEFAULT_BUFFER_SIZE)
@@ -318,7 +318,7 @@ class Base64IO(io.IOBase):
         ``hint`` can be specified to control the number of lines read: no more lines will
         be read if the total size (in bytes/characters) of all lines so far exceeds hint.
 
-        :type hint: int
+        :param int hint: Number of lines to read
         :returns: Lines of data
         :rtype: list of bytes
         """

--- a/docs/ansible_runner.callbacks.rst
+++ b/docs/ansible_runner.callbacks.rst
@@ -10,7 +10,6 @@ ansible_runner.callbacks.awx_display module
 .. automodule:: ansible_runner.callbacks.awx_display
     :members:
     :undoc-members:
-    :show-inheritance:
 
 ansible_runner.callbacks.minimal module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,4 +17,3 @@ ansible_runner.callbacks.minimal module
 .. automodule:: ansible_runner.callbacks.minimal
     :members:
     :undoc-members:
-    :show-inheritance:

--- a/docs/ansible_runner.config.rst
+++ b/docs/ansible_runner.config.rst
@@ -1,0 +1,10 @@
+ansible_runner.config package
+================================
+
+Submodules
+----------
+
+ansible_runner.config.runner module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: ansible_runner.config.runner.RunnerConfig

--- a/docs/ansible_runner.display_callback.rst
+++ b/docs/ansible_runner.display_callback.rst
@@ -26,7 +26,6 @@ ansible_runner.display_callback.minimal module
 .. automodule:: ansible_runner.display_callback.minimal
     :members:
     :undoc-members:
-    :show-inheritance:
 
 ansible_runner.display_callback.module module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,7 +33,6 @@ ansible_runner.display_callback.module module
 .. automodule:: ansible_runner.display_callback.module
     :members:
     :undoc-members:
-    :show-inheritance:
 
 
 Module contents
@@ -43,4 +41,3 @@ Module contents
 .. automodule:: ansible_runner.display_callback
     :members:
     :undoc-members:
-    :show-inheritance:

--- a/docs/ansible_runner.rst
+++ b/docs/ansible_runner.rst
@@ -7,6 +7,7 @@ Subpackages
 .. toctree::
 
     ansible_runner.callbacks
+    ansible_runner.config
     ansible_runner.display_callback
 
 Submodules

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,7 +182,4 @@ nitpick_ignore = [
     ('py:class', 'ansible.plugins.callback.default.CallbackModule'),
     ('py:class', 'display_callback.module.AWXDefaultCallbackModule'),
     ('py:class', 'display_callback.module.AWXMinimalCallbackModule'),
-
-    # FIXME: Undocumented classes referenced explicitly in the RST documents:
-    ('py:class', 'ansible_runner.runner_config.RunnerConfig'),
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,17 +176,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-# Strictness settings
-nitpicky = True
 nitpick_ignore = [
-    # FIXME: The following entries are used incorrectly in multiple docstrings:
-    ('py:class', 'export: bool'),
-    ('py:class', 'file'),
-    ('py:class', 'file descriptor'),
-    ('py:class', 'filename'),
-    ('py:class', 'function'),
-    ('py:class', 'json_mode: bool'),
-
     # FIXME: Undocumented classes picked up by autodoc as via inheritance:
     ('py:class', 'ansible.plugins.callback.CallbackBase'),
     ('py:class', 'ansible.plugins.callback.default.CallbackModule'),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,8 @@ def _get_version():
     return '.'.join(version_parts)
 
 
+nitpicky = True
+default_role = 'any'  # This catches single backticks (incorrectly) used for inline code formatting
 project = 'ansible-runner'
 copyright = f'2018-{datetime.datetime.today().year}, Red Hat, Inc'
 author = 'Red Hat, Inc.'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,11 +175,3 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
-nitpick_ignore = [
-    # FIXME: Undocumented classes picked up by autodoc as via inheritance:
-    ('py:class', 'ansible.plugins.callback.CallbackBase'),
-    ('py:class', 'ansible.plugins.callback.default.CallbackModule'),
-    ('py:class', 'display_callback.module.AWXDefaultCallbackModule'),
-    ('py:class', 'display_callback.module.AWXMinimalCallbackModule'),
-]

--- a/docs/execution_environments.rst
+++ b/docs/execution_environments.rst
@@ -34,17 +34,17 @@ Using Execution Environments from Protected Registries
 When a job is run that uses an execution environment container image from a private/protected registry,
 you will first need to authenticate to the registry.
 
-If you are running the job manually via `ansible-runner run`, logging in on the command line via
-`podman login` first is a method of authentication. Alternatively, creating a `container_auth_data`
-dictionary with the keys `host`, `username`, and `password` and putting that in the job's `env/settings`
+If you are running the job manually via ``ansible-runner run``, logging in on the command line via
+``podman login`` first is a method of authentication. Alternatively, creating a ``container_auth_data``
+dictionary with the keys ``host``, ``username``, and ``password`` and putting that in the job's ``env/settings``
 file is another way to ensure a successful pull of a protected execution environment container image.
 Note that this involves listing sensitive information in a file which will not automatically get cleaned
 up after the job run is complete.
 
 When running a job remotely via AWX or Ansible Tower, Ansible Runner can pick up the authentication
-information from the Container Registry Credential that was provided by the user. The `host`,
-`username`, `password`, and `verify_ssl` inputs from the credential are passed into Ansible Runner via the `container_auth_data`
-dictionary as key word arguments into a `json` file which gets deleted at the end of the job run (even if
+information from the Container Registry Credential that was provided by the user. The ``host``,
+``username``, ``password``, and ``verify_ssl`` inputs from the credential are passed into Ansible Runner via the ``container_auth_data``
+dictionary as key word arguments into a ``json`` file which gets deleted at the end of the job run (even if
 the job was canceled/interrupted), enabling the bypassing of sensitive information from any potentially
 persistent job-related files.
 

--- a/docs/external_interface.rst
+++ b/docs/external_interface.rst
@@ -40,13 +40,13 @@ pip::
 
 In order to configure it, you can provide details in the Runner Settings file (see :ref:`runnersettings`):
 
-* `runner_http_url`: The url to receive the ``POST``
-* `runner_http_headers`: Headers to send along with the request.
+* ``runner_http_url``: The url to receive the ``POST``
+* ``runner_http_headers``: Headers to send along with the request.
 
 The plugin also supports unix file-based sockets with:
 
-* `runner_http_url`: The path to the unix socket
-* `runner_http_path`: The path that will be included as part of the request to the socket
+* ``runner_http_url``: The path to the unix socket
+* ``runner_http_path``: The path that will be included as part of the request to the socket
 
 Some of these settings are also available as environment variables:
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -111,7 +111,7 @@ by providing a yaml or json formatted file with a regular expression and a value
 .. warning::
 
     Current **Ansible Runner** does not validate the command line arguments passed using this method so it is up to the playbook writer to provide a valid set of options
-    The command line options provided by this method are lower priority than the ones set by **Ansible Runner**.  For instance, this will not override `inventory` or `limit` values.
+    The command line options provided by this method are lower priority than the ones set by **Ansible Runner**.  For instance, this will not override ``inventory`` or ``limit`` values.
 
 **Ansible Runner** gathers command line options provided here as a string and supplies them to the **Ansible Process** itself. This file should contain the arguments to be added, for example::
 

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -84,8 +84,8 @@ response when finished. While running the command within the container the curre
 :meth:`ansible_runner.interface.get_inventory`
 
 When called, this function will take the inputs, and execute the ansible-inventory command to return the inventory releated information based on the action.
-If `action` is `list` it will return all the applicable configuration options for ansible, for `host` action it will return information
-of a single host andf for `graph` action it will return the inventory. The exectuin will be in the foreground and return a tuple of output and error
+If ``action`` is ``list`` it will return all the applicable configuration options for ansible, for ``host`` action it will return information
+of a single host andf for ``graph`` action it will return the inventory. The exectuin will be in the foreground and return a tuple of output and error
 response when finished. While running the command within the container the current local working diretory will be volume mounted within the container.
 
 ``get_ansible_config()`` helper function
@@ -94,8 +94,8 @@ response when finished. While running the command within the container the curre
 :meth:`ansible_runner.interface.get_ansible_config`
 
 When called, this function will take the inputs, and execute the ansible-config command to return the Ansible configuration releated information based on the action.
-If `action` is `list` it will return all the hosts related information including the host and group variables, for `dump` action it will return the enitre active configuration
-and it can be customized to return only the changed configuration value by settingg the `only_changed` boolean parameter to `True`. For `view` action it will return the
+If ``action`` is ``list`` it will return all the hosts related information including the host and group variables, for ``dump`` action it will return the enitre active configuration
+and it can be customized to return only the changed configuration value by settingg the ``only_changed`` boolean parameter to ``True``. For ``view`` action it will return the
 view of the active configuration file. The exectuin will be in the foreground and return a tuple of output and error response when finished.
 While running the command within the container the current local working diretory will be volume mounted within the container.
 
@@ -143,7 +143,7 @@ properties:
 -----------------
 
 The :class:`Runner <ansible_runner.runner.Runner>` object contains a property :attr:`ansible_runner.runner.Runner.stdout` which will return an open file
-handle containing the ``stdout`` of the **Ansible** process.
+handle containing the `stdout` of the **Ansible** process.
 
 ``Runner.stderr``
 -----------------
@@ -173,8 +173,8 @@ will return an open file handle containing the ``stderr`` of the **Ansible** pro
 ``Runner.event_handler``
 ------------------------
 
-A function passed to `__init__` of :class:`Runner <ansible_runner.runner.Runner>`, this is invoked every time an Ansible event is received. You can use this to
-inspect/process/handle events as they come out of Ansible. This function should return `True` to keep the event, otherwise it will be discarded.
+A function passed to ``__init__`` of :class:``Runner <ansible_runner.runner.Runner>``, this is invoked every time an Ansible event is received. You can use this to
+inspect/process/handle events as they come out of Ansible. This function should return ``True`` to keep the event, otherwise it will be discarded.
 
 ``Runner.cancel_callback``
 --------------------------
@@ -197,12 +197,12 @@ This function will be called immediately before the **Runner** event loop finish
 A function passed to ``__init__`` of :class:`Runner <ansible_runner.runner.Runner>` and to the :meth:`ansible_runner.interface.run` interface functions.
 This function will be called any time the ``status`` changes, expected values are:
 
-* `starting`: Preparing to start but hasn't started running yet
-* `running`: The **Ansible** task is running
-* `canceled`: The task was manually canceled either via callback or the cli
-* `timeout`: The timeout configured in Runner Settings was reached (see :ref:`runnersettings`)
-* `failed`: The **Ansible** process failed
-* `successful`: The **Ansible** process succeeded
+* ``starting``: Preparing to start but hasn't started running yet
+* ``running``: The **Ansible** task is running
+* ``canceled``: The task was manually canceled either via callback or the cli
+* ``timeout``: The timeout configured in Runner Settings was reached (see :ref:`runnersettings`)
+* ``failed``: The **Ansible** process failed
+* ``successful``: The **Ansible** process succeeded
 
 Usage examples
 --------------

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -365,5 +365,5 @@ The helper methods are just one possible entrypoint, extending the classes used 
 
 Show:
 
-* How :class:`Runner Config <ansible_runner.runner_config.RunnerConfig>` is used and how overriding the methods and behavior can work
+* How :class:`Runner Config <ansible_runner.config.runner.RunnerConfig>` is used and how overriding the methods and behavior can work
 * Show how custom cancel and status callbacks can be supplied.

--- a/docs/remote_jobs.rst
+++ b/docs/remote_jobs.rst
@@ -16,19 +16,19 @@ The following command illustrates how the three phases work together::
 
   $ ansible-runner transmit ./demo -p test.yml | ansible-runner worker | ansible-runner process ./demo
 
-In this example, the `ansible-runner transmit` command is given a private data directory of `./demo` and told to select
-the `test.yml` playbook from it.  Instead of executing the playbook as `ansible-runner run` would do, the data dir
-and command line parameters are converted to a compressed binary stream that is emitted as stdout.  The `transmit`
-command generally takes the same command line parameters as the `run` command.
+In this example, the ``ansible-runner transmit`` command is given a private data directory of ``./demo`` and told to select
+the ``test.yml`` playbook from it.  Instead of executing the playbook as ``ansible-runner run`` would do, the data dir
+and command line parameters are converted to a compressed binary stream that is emitted as stdout.  The ``transmit``
+command generally takes the same command line parameters as the ``run`` command.
 
-The `ansible-runner worker` command accepts this stream, runs the playbook, and generates a new compressed binary
+The ``ansible-runner worker`` command accepts this stream, runs the playbook, and generates a new compressed binary
 stream of the resulting job events and artifacts.
-This command optionally accepts the `--private-data-dir` option.
-If provided, it will extract the contents sent from `ansible-runner transmit` into that directory.
+This command optionally accepts the ``--private-data-dir`` option.
+If provided, it will extract the contents sent from ``ansible-runner transmit`` into that directory.
 
-The `ansible-runner process` command accepts the result stream from the worker, and fires all the normal callbacks
+The ``ansible-runner process`` command accepts the result stream from the worker, and fires all the normal callbacks
 and does job event processing.  In the command above, this results in printing the playbook output and saving
-artifacts to the data dir.  The `process` command takes a data dir as a parameter, to know where to save artifacts.
+artifacts to the data dir.  The ``process`` command takes a data dir as a parameter, to know where to save artifacts.
 
 Cleanup of Resources Used by Jobs
 ---------------------------------
@@ -36,7 +36,7 @@ Cleanup of Resources Used by Jobs
 The transmit and process commands do not offer any automatic deletion of the
 private data directory or artifacts, because these are how the user interacts with runner.
 
-When running `ansible-runner worker`, if no `--private-data-dir` is given,
+When running ``ansible-runner worker``, if no ``--private-data-dir`` is given,
 it will extract the contents to a temporary directory which is deleted at the end of execution.
 If the ``--private-data-dir`` option is given, then the directory will persist after the run finishes
 unless the ``--delete`` flag is also set. In that case, the private data directory will be deleted before execution if it exists and also removed after execution.
@@ -47,17 +47,17 @@ The following command offers out-of-band cleanup.
 
 This would assure that old directories that fit the file glob "/tmp/foo_*" are deleted,
 which would could be used to assure cleanup of paths created by commands like
-`ansible-runner worker --private_data_dir=/tmp/foo_3`, for example.
-NOTE: see the `--grace-period` option, which sets the time window.
+``ansible-runner worker --private_data_dir=/tmp/foo_3``, for example.
+NOTE: see the ``--grace-period`` option, which sets the time window.
 
-This command also takes a `--remove-images` option to run the podman or docker `rmi` command.
+This command also takes a ``--remove-images`` option to run the podman or docker ``rmi`` command.
 There is otherwise no automatic cleanup of images used by a run,
-even if `container_auth_data` is used to pull from a private container registry.
-To be sure that layers are deleted as well, the `--image-prune` flag is necessary.
+even if ``container_auth_data`` is used to pull from a private container registry.
+To be sure that layers are deleted as well, the ``--image-prune`` flag is necessary.
 
 Python API
 ----------
 
-Python code importing Ansible Runner can make use of these facilities by setting the `streamer` parameter to
-`ansible_runner.interface.run`.  This parameter can be set to `transmit`, `worker` or `process` to invoke
+Python code importing Ansible Runner can make use of these facilities by setting the ``streamer`` parameter to
+``ansible_runner.interface.run``.  This parameter can be set to ``transmit``, ``worker`` or ``process`` to invoke
 each of the three stages.  Other parameters are as normal in the CLI.


### PR DESCRIPTION
RST uses double backticks to indicate verbatim formatting but there were many places that used only a single backtick, which is correct for Markdown.

Also change the documentation config to catch these errors in CI.