### PR TITLE
Switch to using `pull_request_target` for labeler

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -9,10 +9,13 @@ on:
   issues:
     types:
       - opened
+      - reopened
 
   pull_request:
     types:
       - opened
+      - reopened
+      - synchronize
 
 jobs:
   triage:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,7 +11,7 @@ on:
       - opened
       - reopened
 
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -12,10 +12,6 @@ on:
       - reopened
 
   pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 jobs:
   triage:


### PR DESCRIPTION
This allows PRs opened from forks to edit the PR.

https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target