### PR TITLE
Add option to disable streaming to stdout file

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -244,6 +244,7 @@ class BaseConfig(object):
             self.ssh_key_path = os.path.join(self.artifact_dir, 'ssh_key_data')
             open_fifo_write(self.ssh_key_path, self.ssh_key_data)
 
+        self.suppress_output_file = self.settings.get('suppress_output_file', False)
         self.suppress_ansible_output = self.settings.get('suppress_ansible_output', self.quiet)
 
         if 'fact_cache' in self.settings:

--- a/ansible_runner/config/runner.py
+++ b/ansible_runner/config/runner.py
@@ -65,7 +65,7 @@ class RunnerConfig(BaseConfig):
     def __init__(self,
                  private_data_dir, playbook=None, inventory=None, roles_path=None, limit=None,
                  module=None, module_args=None, verbosity=None, host_pattern=None, binary=None,
-                 extravars=None, suppress_ansible_output=False, process_isolation_path=None,
+                 extravars=None, suppress_output_file=False, suppress_ansible_output=False, process_isolation_path=None,
                  process_isolation_hide_paths=None, process_isolation_show_paths=None,
                  process_isolation_ro_paths=None, resource_profiling=False,
                  resource_profiling_base_cgroup='ansible-runner', resource_profiling_cpu_poll_interval=0.25,
@@ -101,6 +101,7 @@ class RunnerConfig(BaseConfig):
 
         self.directory_isolation_path = directory_isolation_base_path
         self.verbosity = verbosity
+        self.suppress_output_file = suppress_output_file
         self.suppress_ansible_output = suppress_ansible_output
         self.tags = tags
         self.skip_tags = skip_tags

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -139,7 +139,8 @@ The **settings** file is a little different than the other files provided in thi
 * ``pexpect_timeout``: ``10`` Number of seconds for the internal pexpect command to wait to block on input before continuing
 * ``pexpect_use_poll``: ``True`` Use ``poll()`` function for communication with child processes instead of ``select()``. ``select()`` is used when the value is set to ``False``. ``select()`` has a known limitation of using only up to 1024 file descriptors.
 
-* ``suppress_ansible_output``: ``False`` Allow output from ansible to not be printed to the screen
+* ``suppress_output_file``: ``False`` Allow output from ansible to not be streamed to the ``stdout`` or ``stderr`` files inside of the artifacts directory.
+* ``suppress_ansible_output``: ``False`` Allow output from ansible to not be printed to the screen.
 * ``fact_cache``: ``'fact_cache'`` The directory relative to ``artifacts`` where ``jsonfile`` fact caching will be stored.  Defaults to ``fact_cache``.  This is ignored if ``fact_cache_type`` is different than ``jsonfile``.
 * ``fact_cache_type``: ``'jsonfile'`` The type of fact cache to use.  Defaults to ``jsonfile``.
 


### PR DESCRIPTION
This addresses https://github.com/ansible/ansible-runner/issues/926

My current intention is to make use of the setting (set it to True) in AWX, unconditionally. We don't want the additional disk writes this incurs. If the executor team is okay with the looks of this, I may ask @amolgautam25 to make that PR.

This use case is only concerned with the `pexpect` runner mode. I only messed with `subprocess` here for completeness. The subprocess mode also appears to somehow be connected with the introduction of this behavior. Maybe @ganeshrn has more history to share about this.

