### PR TITLE
[release_2.1] Write auto-created private data dirs to pytest dir instead of /tmp (#916)

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -100,7 +100,7 @@ class BaseConfig(object):
             # attempt to compromise the directories via a race.
             os.makedirs(self.private_data_dir, exist_ok=True, mode=0o700)
         else:
-            self.private_data_dir = tempfile.mkdtemp(prefix=".ansible-runner-")
+            self.private_data_dir = tempfile.mkdtemp(prefix=defaults.AUTO_CREATE_NAMING, dir=defaults.AUTO_CREATE_DIR)
 
         if artifact_dir is None:
             artifact_dir = os.path.join(self.private_data_dir, 'artifacts')

--- a/ansible_runner/defaults.py
+++ b/ansible_runner/defaults.py
@@ -4,3 +4,8 @@ registry_auth_prefix = 'ansible_runner_registry_'
 
 # for ansible-runner worker cleanup command
 GRACE_PERIOD_DEFAULT = 60  # minutes
+
+# values passed to tempfile.mkdtemp to generate a private data dir
+# when user did not provide one
+AUTO_CREATE_NAMING = '.ansible-runner-'
+AUTO_CREATE_DIR = None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,8 @@ import shutil
 
 from distutils.version import LooseVersion
 
+from ansible_runner import defaults
+
 import pkg_resources
 import pytest
 
@@ -15,6 +17,11 @@ CONTAINER_RUNTIMES = (
 @pytest.fixture(autouse=True)
 def mock_env_user(monkeypatch):
     monkeypatch.setenv("ANSIBLE_DEVEL_WARNING", "False")
+
+
+@pytest.fixture(autouse=True)
+def change_save_path(tmp_path, mocker):
+    mocker.patch.object(defaults, 'AUTO_CREATE_DIR', str(tmp_path))
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
Backport of #916 for Ansible Runner 2.1.