### PR TITLE
Fix suppress_output_file bug where event_callback was not called

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -10,7 +10,6 @@ import codecs
 import collections
 import datetime
 import logging
-from io import StringIO
 
 import six
 import pexpect
@@ -156,8 +155,8 @@ class Runner(object):
             stdout_handle = codecs.open(stdout_filename, 'w', encoding='utf-8')
             stderr_handle = codecs.open(stderr_filename, 'w', encoding='utf-8')
         else:
-            stdout_handle = StringIO()
-            stderr_handle = StringIO()
+            stdout_handle = None
+            stderr_handle = None
 
         stdout_handle = OutputEventFilter(stdout_handle, self.event_callback, suppress_ansible_output, output_json=self.config.json_mode)
         stderr_handle = OutputEventFilter(stderr_handle, self.event_callback, suppress_ansible_output, output_json=self.config.json_mode)
@@ -313,8 +312,7 @@ class Runner(object):
                     echo=False,
                     use_poll=self.config.pexpect_use_poll,
                 )
-                if not self.config.suppress_output_file:
-                    child.logfile_read = stdout_handle
+                child.logfile_read = stdout_handle
             except pexpect.exceptions.ExceptionPexpect as e:
                 child = collections.namedtuple(
                     'MissingProcess', 'exitstatus isalive close'

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -279,7 +279,8 @@ class OutputEventFilter(object):
         self.suppress_ansible_output = suppress_ansible_output
 
     def flush(self):
-        self._handle.flush()
+        if self._handle:
+            self._handle.flush()
 
     def write(self, data):
         self._buffer.write(data)
@@ -318,8 +319,9 @@ class OutputEventFilter(object):
                     )
                     sys.stdout.write("\n")
                     sys.stdout.flush()
-                self._handle.write(stdout_actual + "\n")
-                self._handle.flush()
+                if self._handle:
+                    self._handle.write(stdout_actual + "\n")
+                    self._handle.flush()
 
             self._last_chunk = remainder
         else:
@@ -338,8 +340,9 @@ class OutputEventFilter(object):
                         sys.stdout.write(
                             line.encode('utf-8') if PY2 else line
                         )
-                    self._handle.write(line)
-                    self._handle.flush()
+                    if self._handle:
+                        self._handle.write(line)
+                        self._handle.flush()
                 self._buffer = StringIO()
                 # put final partial line back on buffer
                 if remainder:
@@ -351,7 +354,8 @@ class OutputEventFilter(object):
             self._emit_event(value)
             self._buffer = StringIO()
         self._event_callback(dict(event='EOF'))
-        self._handle.close()
+        if self._handle:
+            self._handle.close()
 
     def _emit_event(self, buffered_stdout, next_event_data=None):
         next_event_data = next_event_data or {}


### PR DESCRIPTION
Sorry, I had a major flaw with https://github.com/ansible/ansible-runner/pull/937 and I should have tested that better before it was merged.

The handle was not passed to pexpect, and that was wrong. The handle is the way that it dispatches events to the `event_callback`. Even if you do not intend to write to the stdout file, this is necessary.

Design-wise, if `suppress_output_file` is given, we _do_ want to use the stdout handle wrapper, but we do not want to use the stdout handle itself. I think this code structure articulates that about as best as possible. Alternatively, we could create a null handler and pass that to `OutputEventFilter`, instead of handling the `None` case.

----

Separately, I may have discovered a bug related to the test failures on the prior PR.

https://github.com/ansible/ansible-runner/blob/d01304455c3c25669fba70d9983487ffdb85f1c5/ansible_runner/utils/__init__.py#L373

This is assuming the `.splitlines(True)` leaves `\r\n` at the end of the line. This is... not universal. Because of that, the final character in the `echo` command gets truncated, because it has a `\n` without the `\r`. This looks completely fixable, but I wish to keep that separate.