### PR TITLE
Silence Ansible devel warning, again

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -36,7 +36,7 @@ if [[ -d ${AWX_ISOLATED_DATA_DIR} ]]; then
     if output=$(ansible-galaxy collection list --format json 2> /dev/null); then
         echo $output > ${AWX_ISOLATED_DATA_DIR}/collections.json
     fi
-    ansible --version | head -n 1 > ${AWX_ISOLATED_DATA_DIR}/ansible_version.txt
+    ansible --version 2> /dev/null | head -n 1 > ${AWX_ISOLATED_DATA_DIR}/ansible_version.txt
 fi
 
 SCRIPT=/usr/local/bin/dumb-init


### PR DESCRIPTION
I rebuilt the image fresh and was very annoyed by getting this error running _completely unrelated_ commands in the image

```
[WARNING]: You are running the development version of Ansible. You should only run Ansible from
"devel" if you are modifying the Ansible engine, or trying out features under development. This
is a rapidly changing source of code and can become unstable at any point.
```

It turns out that this is silenced in the `ansible-galaxy` command in the entrypoint.sh script, but the same problem happens again just a few lines down doing `ansible --version`, and this case is not silenced.

This applies the same method to the second case, so that this will run quiet:

```
(env) [alancoding@alan-red-hat ansible-runner]$ podman run --rm --tty --interactive --env AWX_ISOLATED_DATA_DIR=/runner/ quay.io/ansible/ansible-runner:devel whoami
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
root
```