### PR TITLE
[backport] [release_2.0] Create GitHub Actions workflow for running tests (#944)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+
+jobs:
+  sanity:
+    name: ${{ matrix.test.name }}
+    runs-on: ubuntu-20.04
+    container:
+      image: quay.io/ansible/ansible-runner-test-container:2.0.0
+      env:
+        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
+        PY_COLORS: 1
+        TOXENV: ${{ matrix.test.tox_env }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: Lint
+            tox_env: linters
+
+          - name: Docs
+            tox_env: docs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create tox environment
+        run: tox --notest
+
+      - name: Run tests
+        run: tox
+
+
+  integration:
+    runs-on: ubuntu-20.04
+    name: Integration - ${{ matrix.py_version.name }}
+
+    env:
+      TOXENV: ${{ matrix.py_version.tox_env }}
+      PY_COLORS: 1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - name: '3.8'
+            tox_env: integration-py38
+
+          - name: '3.9'
+            tox_env: integration-py39
+
+          - name: '3.10'
+            tox_env: integration-py310
+
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Python ${{ matrix.py_version.name }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.py_version.name }}
+
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install tox
+
+      - name: Create tox environment
+        run: |
+          tox --notest
+
+      - name: Run integration tests
+        run: |
+          docker build --rm=true -t quay.io/ansible/ansible-runner:devel -t quay.io/ansible/ansible-runner:latest .
+          podman build --rm=true -t quay.io/ansible/ansible-runner:devel -t quay.io/ansible/ansible-runner:latest .
+          tox
+
+      - name: Upload coverage report
+        run: |
+          curl --silent --show-error --output codecov https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/linux/codecov
+          chmod +x codecov
+          ./codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
+
+
+  unit:
+    name: Unit - ${{ matrix.py_version.name}}
+    runs-on: ubuntu-20.04
+    container:
+      image: quay.io/ansible/ansible-runner-test-container:2.0.0
+      env:
+        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
+        TOXENV: ${{ matrix.py_version.tox_env }}
+        PY_COLORS: 1
+
+    strategy:
+      fail-fast: false
+      matrix:
+        py_version:
+          - name: '3.8'
+            tox_env: unit-py38
+
+          - name: '3.9'
+            tox_env: unit-py39
+
+          - name: '3.10'
+            tox_env: unit-py310
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create tox environment
+        run: tox --notest
+
+      - name: Run tests
+        run: tox
+
+      - name: Upload coverage report
+        run: codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ansible Runner
 [![Documentation](https://readthedocs.org/projects/ansible-runner/badge/?version=stable)](https://ansible-runner.readthedocs.io/en/latest/)
 [![Code of Conduct](https://img.shields.io/badge/Code%20of%20Conduct-Ansible-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
 [![Ansible Mailing lists](https://img.shields.io/badge/Mailing%20lists-Ansible-orange.svg)](https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information)
-
+[![codecov](https://codecov.io/gh/ansible/ansible-runner/branch/devel/graph/badge.svg?token=CmCcjBz0pQ)](https://codecov.io/gh/ansible/ansible-runner)
 
 Ansible Runner is a tool and Python library that helps when interfacing with Ansible directly or as part of another system. Ansible Runner works as a standalone tool, a container image interface, or a Python module that can be imported. The goal is to provide a stable and consistent interface abstraction to Ansible.
 

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -12,6 +12,7 @@ from ansible_runner import Runner
 from ansible_runner.exceptions import AnsibleRunnerException
 
 
+@pytest.mark.xfail(reason='Test is unstable')
 def test_password_prompt(rc):
     rc.command = [sys.executable, '-c' 'import time; print(input("Password: "))']
     rc.expect_passwords[re.compile(r'Password:\s*?$', re.M)] = '1234'

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ deps = ansible27: ansible<2.8
        ansible28: ansible<2.9
        ansible29: ansible<2.10
        ansible-base: ansible-base
-       py{,3,38}: ansible-core
+       py{,3,38,39,310}: ansible-core
+       integration{,-py38,-py39,-py310}: ansible-core
        -r {toxinidir}/requirements.txt
        -r {toxinidir}/test/requirements.txt
 passenv = HOME
@@ -23,6 +24,14 @@ commands=
     flake8 docs ansible_runner test
     yamllint --version
     yamllint -s .
+
+[testenv:unit{,-py38,-py39,-py310}]
+description = Run unit tests
+commands = pytest {posargs:test/unit}
+
+[testenv:integration{,-py38,-py39,-py310}]
+description = Run integration tests
+commands = pytest {posargs:test/integration}
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
Add GHA CI workflow. Includes sanity, unit, and integration tests.

Backport of #944 

Co-authored-by: David Shrewsbury <dshrewsb@redhat.com>
(cherry picked from commit 16cc1fe965a2337177031b60cd7dd1133a76c39e)