### PR TITLE
Preserve timestamps when unstreaming dirs

### DIFF
--- a/ansible_runner/utils/streaming.py
+++ b/ansible_runner/utils/streaming.py
@@ -69,6 +69,7 @@ def unstream_dir(stream, length, target_directory):
 
         with zipfile.ZipFile(tmp.name, "r") as archive:
             # Fancy extraction in order to preserve permissions
+            # AWX relies on the execution bit, in particular, for inventory
             # https://www.burgundywall.com/post/preserving-file-perms-with-python-zipfile-module
             for info in archive.infolist():
                 out_path = os.path.join(target_directory, info.filename)
@@ -87,6 +88,7 @@ def unstream_dir(stream, length, target_directory):
                 archive.extract(info.filename, path=target_directory)
 
                 # Fancy logic to preserve modification times
+                # AWX uses modification times to determine if new facts were written for a host
                 # https://stackoverflow.com/questions/9813243/extract-files-from-zip-file-and-retain-mod-date
                 date_time = time.mktime(info.date_time + (0, 0, -1))
                 os.utime(out_path, times=(date_time, date_time))

--- a/ansible_runner/utils/streaming.py
+++ b/ansible_runner/utils/streaming.py
@@ -1,3 +1,4 @@
+import time
 import tempfile
 import zipfile
 import os
@@ -84,6 +85,11 @@ def unstream_dir(stream, length, target_directory):
                         continue
 
                 archive.extract(info.filename, path=target_directory)
+
+                # Fancy logic to preserve modification times
+                # https://stackoverflow.com/questions/9813243/extract-files-from-zip-file-and-retain-mod-date
+                date_time = time.mktime(info.date_time + (0, 0, -1))
+                os.utime(out_path, times=(date_time, date_time))
 
                 if is_symlink:
                     link = open(out_path).read()

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -1,7 +1,9 @@
+import datetime
 import io
 import json
 import os
 import signal
+import time
 
 from pathlib import Path
 
@@ -145,6 +147,48 @@ def test_transmit_permissions(tmp_path, fperm):
     # Assure the new file is the same permissions
     new_file_path = dest_dir / 'ordinary_file.txt'
     assert oct(new_file_path.stat().st_mode) == oct(old_file_path.stat().st_mode)
+
+
+def test_transmit_modtimes(tmp_path):
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+
+    (source_dir / 'b.txt').touch()
+    time.sleep(2.0)  # flaky for anything less because of integer math
+    (source_dir / 'a.txt').touch()
+
+    very_old_file = source_dir / 'very_old.txt'
+    very_old_file.touch()
+    old_datetime = os.path.getmtime(source_dir / 'a.txt') - datetime.timedelta(days=1).total_seconds()
+    os.utime(very_old_file, (old_datetime, old_datetime))
+
+    # sanity, verify assertions pass for source dir
+    mod_delta = os.path.getmtime(source_dir / 'a.txt') - os.path.getmtime(source_dir / 'b.txt')
+    assert mod_delta >= 1.0
+
+    outgoing_buffer = io.BytesIO()
+    outgoing_buffer.name = 'not_stdout'
+    stream_dir(source_dir, outgoing_buffer)
+
+    dest_dir = tmp_path / 'dest'
+    dest_dir.mkdir()
+
+    outgoing_buffer.seek(0)
+    first_line = outgoing_buffer.readline()
+    size_data = json.loads(first_line.strip())
+    unstream_dir(outgoing_buffer, size_data['zipfile'], dest_dir)
+
+    # Assure modification times are internally consistent
+    mod_delta = os.path.getmtime(dest_dir / 'a.txt') - os.path.getmtime(dest_dir / 'b.txt')
+    assert mod_delta >= 1.0
+
+    # Assure modification times are same as original
+    for filename in ('a.txt', 'b.txt'):
+        assert os.path.getmtime(dest_dir / filename) == os.path.getmtime(dest_dir / filename)
+
+    # Assure the very old timestamp is preserved
+    old_delta = os.path.getmtime(dest_dir / 'a.txt') - os.path.getmtime(dest_dir / 'very_old.txt')
+    assert old_delta >= datetime.timedelta(days=1).total_seconds() - 2.
 
 
 def test_signal_handler(mocker):


### PR DESCRIPTION
Connect https://github.com/ansible/ansible-runner/issues/964

That fixes the linked issue with the limitation (discovered by the test) that we might miss a 2 second delta or less. This assumes the computer clock is perfectly synced on the machines that do the compressing and extracting.

Nonetheless, I think this opens up an option for AWX to get the job done. I show a demo in the test with the `very_old.txt` file, where I artificially set the mod and access time to 1 day in the past. It seems like that would work for the AWX use case, assuming that the two computers agree on the day, which doesn't sound like an unreasonable demand.

Ping @jbradberry 