### PR TITLE
Remove Zuul linters and docs jobs

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -9,10 +9,6 @@
         - ansible-runner-build-container-image-stable-2.11
         - ansible-runner-build-container-image-stable-2.12
         - ansible-runner-integration
-        - ansible-runner-tox-linters
-        - ansible-tox-docs:
-            vars:
-              sphinx_build_dir: docs/build
     gate:
       jobs: *id001
     post:


### PR DESCRIPTION
These are handled in GitHub Actions now.