### PR TITLE
[backport][release_2.1] Remove Zuul linters and docs jobs (#968)

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -9,10 +9,6 @@
         - ansible-runner-build-container-image-stable-2.11
         - ansible-runner-build-container-image-stable-2.12
         - ansible-runner-integration
-        - ansible-runner-tox-linters
-        - ansible-tox-docs:
-            vars:
-              sphinx_build_dir: docs/build
     gate:
       jobs: *id001
     post:


### PR DESCRIPTION
Remove Zuul linters and docs jobs

These are handled in GitHub Actions now.

Backport of PR #968 

(cherry picked from commit b4e2bc1d60c82907f380b6fb17384af0ab29d488)