### PR TITLE
[backport][release_2.0] Remove zuul integration job (#970)

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -193,27 +193,3 @@
 - job:
     name: ansible-runner-upload-container-image-stable-2.9
     parent: ansible-runner-container-image-base
-
-# =============================================================================
-- job:
-    name: ansible-runner-integration
-    parent: ansible-buildset-registry-consumer
-    requires:
-      - ansible-runner-container-image
-    dependencies:
-      - ansible-runner-build-container-image
-    vars:
-      container_command: docker
-
-- job:
-    name: ansible-runner-integration
-    parent: ansible-tox-py38
-
-
-# =============================================================================
-
-- job:
-    name: ansible-runner-tox-linters
-    parent: ansible-tox-linters
-    pre-run: .zuul.d/playbooks/ansible-runner-tox-linters/pre.yaml
-    nodeset: centos-8-stream

--- a/.zuul.d/playbooks/ansible-runner-tox-linters/pre.yaml
+++ b/.zuul.d/playbooks/ansible-runner-tox-linters/pre.yaml
@@ -1,8 +1,0 @@
----
-- hosts: all
-  tasks:
-    - name: Ensure python3.8 is present
-      become: true
-      package:
-        name: python38-devel
-        state: present

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,7 +7,6 @@
         - ansible-runner-build-container-image-stable-2.9
         - ansible-runner-build-container-image-stable-2.10
         - ansible-runner-build-container-image-stable-2.11
-        - ansible-runner-integration
     gate:
       jobs: *id001
     post:


### PR DESCRIPTION
Remove zuul integration job

This job is handled through GHA now.
Also remove remnants of linter job.

Backport of PR #970 

(cherry picked from commit 1db262e84ebb22aea9736e6634d06ad7f42122b7)