### PR TITLE
fix rpm-builder build

### DIFF
--- a/packaging/rpm/Dockerfile.epel-8-x86_64
+++ b/packaging/rpm/Dockerfile.epel-8-x86_64
@@ -1,6 +1,6 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 RUN dnf install -y epel-release
 RUN yum install -y make mock python3-pip which git gcc python3-devel
-
+RUN pip3 install -IU pip>=21.0.1
 RUN pip3 install -IU ansible


### PR DESCRIPTION
This fixes the rpm-builder build...
the "make rpm" target it still not working for other reasons

would be great to get that fixed + add a PR check so https://github.com/ansible/ansible-runner/pull/985 wouldn't happen