### PR TITLE
Add compatibility code to the entrypoint so new EEs work with old runner version

### DIFF
--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -24,6 +24,15 @@ EOF
 
 fi
 
+if [[ -n "${LAUNCHED_BY_RUNNER}" ]]; then
+    # Special actions to be compatible with old ansible-runner versions, 2.1.x specifically
+    RUNNER_CALLBACKS=$(python3 -c "import from ansible_runner.display_callback.callback import awx_display; print(awx_display.__file__)")
+    export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS)"
+
+    # old versions split the callback name between awx_display and minimal, but new version just uses awx_display
+    export ANSIBLE_STDOUT_CALLBACK=awx_display
+fi
+
 if [[ -d ${AWX_ISOLATED_DATA_DIR} ]]; then
     if output=$(ansible-galaxy collection list --format json 2> /dev/null); then
         echo $output > ${AWX_ISOLATED_DATA_DIR}/collections.json

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 if [[ -n "${LAUNCHED_BY_RUNNER}" ]]; then
     # Special actions to be compatible with old ansible-runner versions, 2.1.x specifically
-    RUNNER_CALLBACKS=$(python3 -c "import from ansible_runner.display_callback.callback import awx_display; print(awx_display.__file__)")
+    RUNNER_CALLBACKS=$(python3 -c "from ansible_runner.display_callback.callback import awx_display; print(awx_display.__file__)")
     export ANSIBLE_CALLBACK_PLUGINS="$(dirname $RUNNER_CALLBACKS)"
 
     # old versions split the callback name between awx_display and minimal, but new version just uses awx_display


### PR DESCRIPTION
In https://github.com/ansible/ansible-runner/pull/957 we combined 2 callback names (awx_display, minimal) into just 1, awx_display. Fundamentally, this makes it hard for the containers to work with ansible-runner versions before/after, and vice versa. Ping review by @shanemcd 

In that PR, I paid attention to the ability for current ansible-runner to work with _old_ images.

I was failing to fully appreciate the implications of _old_ ansible-runner not working with current images.

This PR adds a shim to the entrypoint so that the image with work even if used by old versions of ansible-runner. In the PR 957 I removed the use of the `LAUNCHED_BY_RUNNER` environment variable. This allows using that as a poor proxy for the version of ansible-runner that is starting the container.

@rebeccahhh pointed out to me that our tests for AAP controller 4.1.x were failing due to these problems. I've re-tested those with a custom image built from this branch, `quay.io/alancoding/ansible-runner:marty_youve_got_to_come_back_with_me`, and this gets them to pass.

There's no reasonable way to ever get test coverage, because the whole idea is compatibility with old versions. So I am working on running `make test` with that custom image tagged as `quay.io/ansible/ansible-runner:devel` while I have the commit f1b6c3a5c084e9c3c9e5797648b6905dd1287698 checked out, which was the last commit before the PR landed.