### PR TITLE
[release_2.1] Make 2.1 based container images 'latest'

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -32,8 +32,8 @@
             - github.com/ansible/ansible
           tags:
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
-            # Otherwise: ['devel']
-            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['devel']) }}"
+            # Otherwise: ['latest']
+            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['latest']) }}"
       docker_images: *container_images
 
 - job:
@@ -78,7 +78,9 @@
           repository: quay.io/ansible/ansible-runner
           siblings:
             - github.com/ansible/ansible
-          tags: ['stable-2.12-devel']
+          tags:
+            - stable-2.12-latest
+            - latest
       docker_images: *container_images_stable_2_12
 
 - job:
@@ -125,8 +127,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.11-devel
-            - latest
+            - stable-2.11-latest
       docker_images: *container_images_stable_2_11
 
 - job:
@@ -172,7 +173,8 @@
           repository: quay.io/ansible/ansible-runner
           siblings:
             - github.com/ansible/ansible
-          tags: ['stable-2.10-devel']
+          tags:
+            - stable-2.10-latest
       docker_images: *container_images_stable_2_10
 
 - job:
@@ -219,7 +221,8 @@
           repository: quay.io/ansible/ansible-runner
           siblings:
             - github.com/ansible/ansible
-          tags: ['stable-2.9-devel']
+          tags:
+            - stable-2.9-latest
       docker_images: *container_images_stable_2_9
 
 - job:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -3,7 +3,6 @@
     check:
       jobs: &id001
         - ansible-buildset-registry
-        - ansible-runner-build-container-image
         - ansible-runner-build-container-image-stable-2.9
         - ansible-runner-build-container-image-stable-2.10
         - ansible-runner-build-container-image-stable-2.11
@@ -13,9 +12,6 @@
     post:
       jobs: &id002
         - ansible-buildset-registry
-        - ansible-runner-upload-container-image:
-            vars:
-              upload_container_image_promote: false
         - ansible-runner-upload-container-image-stable-2.9:
             vars:
               upload_container_image_promote: false


### PR DESCRIPTION
We should merge PR #992 before merging this one.

Currently conflicting with the container images published from `devel` branch. `2.1` based images should be named with the `latest` tagging scheme.
