### PR TITLE
[release_2.0] Disable quay image jobs

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,28 +1,10 @@
 ---
 - project:
     check:
-      jobs: &id001
-        - ansible-buildset-registry
-        - ansible-runner-build-container-image
-        - ansible-runner-build-container-image-stable-2.9
-        - ansible-runner-build-container-image-stable-2.10
-        - ansible-runner-build-container-image-stable-2.11
+      jobs: []
     gate:
-      jobs: *id001
+      jobs: []
     post:
-      jobs: &id002
-        - ansible-buildset-registry
-        - ansible-runner-upload-container-image:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.9:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.10:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.11:
-            vars:
-              upload_container_image_promote: false
+      jobs: []
     periodic:
-      jobs: *id002
+      jobs: []


### PR DESCRIPTION
These were being run via the `periodic` pipeline and interfering with image publishing.