### PR TITLE
Remove latest tag from images from devel

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -80,7 +80,6 @@
             - github.com/ansible/ansible
           tags:
             - stable-2.12-devel
-            - latest
       docker_images: *container_images_stable_2_12
 
 - job:
@@ -173,7 +172,8 @@
           repository: quay.io/ansible/ansible-runner
           siblings:
             - github.com/ansible/ansible
-          tags: ['stable-2.10-devel']
+          tags:
+            - stable-2.10-devel
       docker_images: *container_images_stable_2_10
 
 - job:
@@ -220,7 +220,8 @@
           repository: quay.io/ansible/ansible-runner
           siblings:
             - github.com/ansible/ansible
-          tags: ['stable-2.9-devel']
+          tags:
+            - stable-2.9-devel
       docker_images: *container_images_stable_2_9
 
 - job:


### PR DESCRIPTION
The `latest` tag should come from the `release_2.1` branch, not `devel`.