### PR TITLE
Adding --omit-env-files option

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -218,11 +218,11 @@ DEFAULT_CLI_ARGS = {
             ),
         ),
         (
-            ("--no-store-env",),
+            ("--omit-env-files",),
             dict(
-                action="store_false",
-                dest='store_env',
-                help="Set to false to prevent the writing of the env directory"
+                action="store_true",
+                dest='suppress_env_files',
+                help="Add flag to prevent the writing of the env directory"
             ),
         ),
         (
@@ -858,7 +858,7 @@ def main(sys_args=None):
                                    cmdline=vargs.get('cmdline'),
                                    limit=vargs.get('limit'),
                                    streamer=streamer,
-                                   store_env=vargs.get("store_env"),
+                                   suppress_env_files=vargs.get("suppress_env_files"),
                                    )
                 try:
                     res = run(**run_options)

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -218,6 +218,14 @@ DEFAULT_CLI_ARGS = {
             ),
         ),
         (
+            ("--no-store-env",),
+            dict(
+                action="store_false",
+                dest='store_env',
+                help="Set to false to prevent the writing of the env directory"
+            ),
+        ),
+        (
             ("-q", "--quiet",),
             dict(
                 action="store_true",
@@ -849,7 +857,8 @@ def main(sys_args=None):
                                    directory_isolation_base_path=vargs.get('directory_isolation_base_path'),
                                    cmdline=vargs.get('cmdline'),
                                    limit=vargs.get('limit'),
-                                   streamer=streamer
+                                   streamer=streamer,
+                                   store_env=vargs.get("store_env"),
                                    )
                 try:
                     res = run(**run_options)

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -65,8 +65,8 @@ class BaseConfig(object):
                  private_data_dir=None, host_cwd=None, envvars=None, passwords=None, settings=None,
                  project_dir=None, artifact_dir=None, fact_cache_type='jsonfile', fact_cache=None,
                  process_isolation=False, process_isolation_executable=None,
-                 container_image=None, container_volume_mounts=None, container_options=None, container_workdir=None, container_auth_data=None,
-                 ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False, check_job_event_data=False):
+                 ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False,
+                 check_job_event_data=False, store_passwords=True):
         # common params
         self.host_cwd = host_cwd
         self.envvars = envvars
@@ -93,6 +93,7 @@ class BaseConfig(object):
         self.settings = settings
         self.timeout = timeout
         self.check_job_event_data = check_job_event_data
+        self.store_passwords = store_passwords
 
         # setup initial environment
         if private_data_dir:
@@ -162,13 +163,17 @@ class BaseConfig(object):
                     self.passwords.update(self.loader.load_file('env/passwords', Mapping))
                 else:
                     self.passwords = self.passwords or self.loader.load_file('env/passwords', Mapping)
-                self.expect_passwords = {
-                    re.compile(pattern, re.M): password
-                    for pattern, password in iteritems(self.passwords)
-                }
             except ConfigurationError:
                 debug('Not loading passwords')
                 self.expect_passwords = dict()
+            finally:
+                if self.passwords:
+                    self.expect_passwords = {
+                        re.compile(pattern, re.M): password
+                        for pattern, password in iteritems(self.passwords)
+                    }
+                else:
+                    self.expect_passwords = dict()
 
             self.expect_passwords[pexpect.TIMEOUT] = None
             self.expect_passwords[pexpect.EOF] = None

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -67,7 +67,7 @@ class BaseConfig(object):
                  process_isolation=False, process_isolation_executable=None,
                  container_image=None, container_volume_mounts=None, container_options=None, container_workdir=None, container_auth_data=None,
                  ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False,
-                 check_job_event_data=False, store_env=True):
+                 check_job_event_data=False, suppress_env_files=False):
         # common params
         self.host_cwd = host_cwd
         self.envvars = envvars
@@ -94,7 +94,7 @@ class BaseConfig(object):
         self.settings = settings
         self.timeout = timeout
         self.check_job_event_data = check_job_event_data
-        self.store_env = store_env
+        self.suppress_env_files = suppress_env_files
 
         # setup initial environment
         if private_data_dir:

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -165,7 +165,7 @@ def run(**kwargs):
                      be read from ``env/settings`` in ``private_data_dir``.
     :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
-    :param bool store_env: Disable the writing of files into the ``env`` which may store sensitive information
+    :param bool suppress_env_files: Disable the writing of files into the ``env`` which may store sensitive information
     :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param int forks: Control Ansible parallel concurrency
     :param int verbosity: Control how verbose the output of ansible-playbook is

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -165,7 +165,7 @@ def run(**kwargs):
                      be read from ``env/settings`` in ``private_data_dir``.
     :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
-    :param bool store_passwords: Disable the file ``env/passwords`` creation which store passwords provided by a dictionary with ``passwords`` argument
+    :param bool store_env: Disable the writing of files into the ``env`` which may store sensitive information
     :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param int forks: Control Ansible parallel concurrency
     :param int verbosity: Control how verbose the output of ansible-playbook is

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -165,6 +165,7 @@ def run(**kwargs):
                      be read from ``env/settings`` in ``private_data_dir``.
     :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
+    :param bool store_passwords: Disable the file ``env/passwords`` creation which store passwords provided by a dictionary with ``passwords`` argument
     :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param int forks: Control Ansible parallel concurrency
     :param int verbosity: Control how verbose the output of ansible-playbook is

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -259,11 +259,12 @@ def dump_artifacts(kwargs):
                 kwargs['inventory'] = dump_artifact(obj, path, 'hosts')
 
     for key in ('envvars', 'extravars', 'passwords', 'settings'):
-        obj = kwargs.get(key)
-        if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
-            path = os.path.join(private_data_dir, 'env')
-            dump_artifact(json.dumps(obj), path, key)
-            kwargs.pop(key)
+        if key == 'passwords' and kwargs.get('store_passwords', True) or key != 'passwords':
+            obj = kwargs.get(key)
+            if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
+                path = os.path.join(private_data_dir, 'env')
+                print(dump_artifact(json.dumps(obj), path, key))
+                kwargs.pop(key)
 
     for key in ('ssh_key', 'cmdline'):
         obj = kwargs.get(key)

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -258,20 +258,20 @@ def dump_artifacts(kwargs):
             if not os.path.exists(obj):
                 kwargs['inventory'] = dump_artifact(obj, path, 'hosts')
 
-    for key in ('envvars', 'extravars', 'passwords', 'settings'):
-        if key == 'passwords' and kwargs.get('store_passwords', True) or key != 'passwords':
+    if kwargs.get('store_env', True):
+        for key in ('envvars', 'extravars', 'passwords', 'settings'):
             obj = kwargs.get(key)
             if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
                 path = os.path.join(private_data_dir, 'env')
-                print(dump_artifact(json.dumps(obj), path, key))
+                dump_artifact(json.dumps(obj), path, key)
                 kwargs.pop(key)
 
-    for key in ('ssh_key', 'cmdline'):
-        obj = kwargs.get(key)
-        if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
-            path = os.path.join(private_data_dir, 'env')
-            dump_artifact(str(kwargs[key]), path, key)
-            kwargs.pop(key)
+        for key in ('ssh_key', 'cmdline'):
+            obj = kwargs.get(key)
+            if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):
+                path = os.path.join(private_data_dir, 'env')
+                dump_artifact(str(kwargs[key]), path, key)
+                kwargs.pop(key)
 
 
 def collect_new_events(event_path, old_events):

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -258,7 +258,7 @@ def dump_artifacts(kwargs):
             if not os.path.exists(obj):
                 kwargs['inventory'] = dump_artifact(obj, path, 'hosts')
 
-    if kwargs.get('store_env', True):
+    if not kwargs.get('suppress_env_files', False):
         for key in ('envvars', 'extravars', 'passwords', 'settings'):
             obj = kwargs.get(key)
             if obj and not os.path.exists(os.path.join(private_data_dir, 'env', key)):

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -431,6 +431,9 @@ def open_fifo_write(path, data):
     reads data from the pipe.
     '''
     os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
+    # If the data is a string instead of bytes, convert it before writing the fifo
+    if type(data) == str:
+        data = data.encode()
     threading.Thread(target=lambda p, d: open(p, 'wb').write(d),
                      args=(path, data)).start()
 

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -101,7 +101,7 @@ def test_no_env_files(request, project_fixtures):
         playbook='get_environment.yml',
         inventory=None,
         envvars={'FROM_TEST': 'FOOBAR'},
-        store_env=False,
+        suppress_env_files=True,
     )
     assert res.rc == 0, res.stdout.read()
     # Assert that the env file was not created

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -58,6 +58,12 @@ def test_env_accuracy(request, project_fixtures):
     printenv_example = project_fixtures / 'printenv'
     os.environ['SET_BEFORE_TEST'] = 'MADE_UP_VALUE'
 
+    # Remove the envvars file if it exists
+    try:
+        os.remove(printenv_example / "env/envvars")
+    except FileNotFoundError:
+        pass
+
     def remove_test_env_var():
         if 'SET_BEFORE_TEST' in os.environ:
             del os.environ['SET_BEFORE_TEST']
@@ -75,6 +81,31 @@ def test_env_accuracy(request, project_fixtures):
     actual_env = get_env_data(res)['environment']
 
     assert actual_env == res.config.env
+
+    # Assert that the env file was properly created
+    assert os.path.exists(printenv_example / "env/envvars") == 1
+
+
+def test_no_env_files(request, project_fixtures):
+    printenv_example = project_fixtures / 'printenv'
+    os.environ['SET_BEFORE_TEST'] = 'MADE_UP_VALUE'
+
+    # Remove the envvars file if it exists
+    try:
+        os.remove(printenv_example / "env/envvars")
+    except FileNotFoundError:
+        pass
+
+    res = run(
+        private_data_dir=printenv_example,
+        playbook='get_environment.yml',
+        inventory=None,
+        envvars={'FROM_TEST': 'FOOBAR'},
+        store_env=False,
+    )
+    assert res.rc == 0, res.stdout.read()
+    # Assert that the env file was not created
+    assert os.path.exists(printenv_example / "env/envvars") == 0
 
 
 @pytest.mark.test_all_runtimes

--- a/test/unit/utils/test_dump_artifacts.py
+++ b/test/unit/utils/test_dump_artifacts.py
@@ -146,6 +146,7 @@ def test_dump_artifacts_inventory_object(mocker):
 
     assert mock_dump_artifact.called_once_with(inv_string, '/tmp/inventory', 'hosts.json')
 
+
 def test_dump_artifacts_passwords(mocker):
     mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
 
@@ -163,6 +164,7 @@ def test_dump_artifacts_passwords(mocker):
     mock_dump_artifact.assert_any_call('{"abc": "def"}', '/tmp/env', 'envvars')
     mock_dump_artifact.assert_called_with('asdfg1234', '/tmp/env', 'ssh_key')
 
+
 def test_dont_dump_artifacts_passwords(mocker):
     mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
 
@@ -177,6 +179,7 @@ def test_dont_dump_artifacts_passwords(mocker):
     dump_artifacts(kwargs)
 
     assert mock_dump_artifact.call_count == 0
+
 
 @pytest.mark.parametrize(
     ('key', 'value', 'value_str'), (

--- a/test/unit/utils/test_dump_artifacts.py
+++ b/test/unit/utils/test_dump_artifacts.py
@@ -146,6 +146,37 @@ def test_dump_artifacts_inventory_object(mocker):
 
     assert mock_dump_artifact.called_once_with(inv_string, '/tmp/inventory', 'hosts.json')
 
+def test_dump_artifacts_passwords(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
+
+    kwargs = {
+        'private_data_dir': '/tmp',
+        'passwords': {"a": "b"},
+        'envvars': {"abc": "def"},
+        'ssh_key': 'asdfg1234',
+    }
+
+    dump_artifacts(kwargs)
+
+    assert mock_dump_artifact.call_count == 3
+    mock_dump_artifact.assert_any_call('{"a": "b"}', '/tmp/env', 'passwords')
+    mock_dump_artifact.assert_any_call('{"abc": "def"}', '/tmp/env', 'envvars')
+    mock_dump_artifact.assert_called_with('asdfg1234', '/tmp/env', 'ssh_key')
+
+def test_dont_dump_artifacts_passwords(mocker):
+    mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
+
+    kwargs = {
+        'private_data_dir': '/tmp',
+        'passwords': {"a": "b"},
+        'envvars': {"abd": "def"},
+        'ssh_key': 'asdfg1234',
+        'store_env': False
+    }
+
+    dump_artifacts(kwargs)
+
+    assert mock_dump_artifact.call_count == 0
 
 @pytest.mark.parametrize(
     ('key', 'value', 'value_str'), (

--- a/test/unit/utils/test_dump_artifacts.py
+++ b/test/unit/utils/test_dump_artifacts.py
@@ -173,7 +173,7 @@ def test_dont_dump_artifacts_passwords(mocker):
         'passwords': {"a": "b"},
         'envvars': {"abd": "def"},
         'ssh_key': 'asdfg1234',
-        'store_env': False
+        'suppress_env_files': True
     }
 
     dump_artifacts(kwargs)

--- a/test/unit/utils/test_fifo_pipe.py
+++ b/test/unit/utils/test_fifo_pipe.py
@@ -1,0 +1,26 @@
+from ansible_runner.utils import open_fifo_write
+from os import remove
+
+
+def test_fifo_write_bytes(tmp_path):
+    path = tmp_path / "bytes_test"
+    data = "bytes"
+    try:
+        open_fifo_write(path, data.encode())
+        with open(path, 'r') as f:
+            results = f.read()
+        assert results == data
+    finally:
+        remove(path)
+
+
+def test_fifo_write_string(tmp_path):
+    path = tmp_path / "string_test"
+    data = "string"
+    try:
+        open_fifo_write(path, data)
+        with open(path, 'r') as f:
+            results = f.read()
+        assert results == data
+    finally:
+        remove(path)


### PR DESCRIPTION
Adding an option to not write out files into the env folder as these can contain sensitive information. 
Changing write fifo to take either bytes or a string.

Initially based off of https://github.com/ansible/ansible-runner/pull/812