### PR TITLE
Checking for string input in fifo write

### DIFF
--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -430,6 +430,9 @@ def open_fifo_write(path, data):
     reads data from the pipe.
     '''
     os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
+    # If the data is a string instead of bytes, convert it before writing the fifo
+    if type(data) == str:
+        data = data.encode()
     threading.Thread(target=lambda p, d: open(p, 'wb').write(d),
                      args=(path, data)).start()
 


### PR DESCRIPTION
When passing ssh_key through receptor the argument to ssh_key needs to be a string for JSON encoding. But in the write to the fifo we need a byte array. This will do a list minute check and change the string to bytes for the write (if a string was given). 