### PR TITLE
Omit the callback plugin from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,8 @@ branch = True
 data_file = test/coverage/data/coverage
 source =
     ansible_runner
+omit =
+    ansible_runner/display_callback/callback/awx_display.py
 
 [report]
 skip_covered = True


### PR DESCRIPTION
Making some changes to the standard out callback plugin, I realized that it's not giving good information about code coverage.

Fundamentally, this will only be used inside of a subprocess, because `ansible-playbook` itself is ran as a subprocess. There is nothing we can do (short of implementing a new run option where we import Ansible) to get it loaded in the same process as what we're testing. Should we add unit test coverage specifically for this plugin in the future (which we should) then the options are more like `ansible-test` than the usual pytest.