### PR TITLE
Fix image build to override root homedir in /etc/passwd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN /output/install-from-bindep \
 
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
-RUN sed -i 's/:root:\/root:/:root:\/home\/runner:/g' /etc/passwd \
- && for dir in \
+RUN for dir in \
       /home/runner \
       /home/runner/.ansible \
       /home/runner/.ansible/tmp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN /output/install-from-bindep \
 
 # In OpenShift, container will run as a random uid number and gid 0. Make sure things
 # are writeable by the root group.
-RUN for dir in \
+RUN sed -i 's/:root:\/root:/:root:\/home\/runner:/g' /etc/passwd \
+ && for dir in \
       /home/runner \
       /home/runner/.ansible \
       /home/runner/.ansible/tmp \
@@ -53,8 +54,6 @@ RUN for dir in \
     do touch $file ; chmod g+rw $file ; chgrp root $file ; done
 
 WORKDIR /runner
-
-ENV HOME=/home/runner
 
 ADD utils/entrypoint.sh /bin/entrypoint
 RUN chmod +x /bin/entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,12 @@ RUN for dir in \
 
 WORKDIR /runner
 
+# NB: this appears to be necessary for container builds based on this container, since we can't rely on the entrypoint
+# script to run during a build to fix up /etc/passwd. This envvar value, and the fact that all user homedirs are
+# set to /home/runner is an implementation detail that may change with future versions of runner and should not be
+# assumed by other code or tools.
+ENV HOME=/home/runner
+
 ADD utils/entrypoint.sh /bin/entrypoint
 RUN chmod +x /bin/entrypoint
 

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# We need to fix a number of problems here that manifest under different container runtimes, as well as paper over some
+# We need to fix a number of problems here that manifest under different container runtimes, as well as tweak some
 # things to simplify runner's containerized launch behavior. Since runner currently always expects to bind-mount its
 # callback plugins under ~/.ansible, it must have prior knowledge of the user's homedir before the container is launched
 # in order to know where to mount in the callback dir. In all cases, we must get a consistent answer from $HOME

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -1,28 +1,54 @@
 #!/usr/bin/env bash
 
-# In OpenShift, containers are run as a random high number uid
-# that doesn't exist in /etc/passwd, but Ansible module utils
-# require a named user. So if we're in OpenShift, we need to make
-# one before Ansible runs.
-if [[ (`id -u` -ge 500 || -z "${CURRENT_UID}") ]]; then
+# We need to fix a number of problems here that manifest under different container runtimes. If we're running
+# as a legit default user that has an entry in /etc/passwd and a valid homedir that's not `/`, we're all good.
+# If the username/uid we're running under is not represented in /etc/passwd and/or doesn't have a homedir that's not
+# `/` (eg, the container was run with --user and some dynamic unmapped UID from the host with primary GID 0), we need to
+# correct that. Some things (eg podman/cri-o today) already create an /etc/passwd entry on the fly in this case, but
+# they set the homedir to `/`, which causes potential collisions with mounted/mapped volumes. For consistency, we'll
+# just always set every dynamically-created user's homedir to `/home/runner`, which we've already configured in a way
+# that should always work (eg, ug+rwx and all dirs owned by the root group).
 
-    # Only needed for RHEL 8. Try deleting this conditional (not the code)
-    # sometime in the future. Seems to be fixed on Fedora 32
-    # If we are running in rootless podman, this file cannot be overwritten
-    ROOTLESS_MODE=$(cat /proc/self/uid_map | head -n1 | awk '{ print $2; }')
-    if [[ "$ROOTLESS_MODE" -eq "0" ]]; then
-cat << EOF > /etc/passwd
-root:x:0:0:root:/root:/bin/bash
-runner:x:`id -u`:`id -g`:,,,:/home/runner:/bin/bash
-EOF
-    fi
+# if current user is not listed in /etc/passwd, add an entry with username==uid, primary gid 0, and homedir /home/runner
 
-cat <<EOF > /etc/group
-root:x:0:runner
-runner:x:`id -g`:
-EOF
+# if current user is in /etc/passwd but $HOME == `/`, rewrite that user's homedir in /etc/passwd to /home/runner and
+# export HOME=/home/runner for this session only- all new sessions, eg created by exec, should set HOME to match the
+# current value in /etc/passwd going forward.
 
+# if any of this business fails, we probably want to fail fast
+if [ -n "$EP_DEBUG" ]; then
+  set -eux
+  echo 'hello from entrypoint'
+else
+  set -e
 fi
+
+# FIXME junk output
+if ! getent passwd $(whoami || id -u) ; then
+  if [ -n "$EP_DEBUG" ]; then
+    echo "hacking missing uid $(id -u) into /etc/passwd"
+  fi
+  echo "$(id -u):x:$(id -u):0:container user $(id -u):/home/runner:/bin/bash" >> /etc/passwd
+  export HOME=/home/runner
+fi
+
+# FIXME junk output
+MYHOME=`getent passwd $(whoami) | cut -d: -f6`
+
+# FIXME: we also want to check the case of a generated user who podman set their homedir to WORKDIR; maybe anything with a high UID, or ?
+if [ "$MYHOME" != "$HOME" ] || [ $(id -u) -ge 500 ] && [ "$MYHOME" != "/home/runner" ]; then
+  if [ -n "$EP_DEBUG" ]; then
+    echo "replacing homedir for user $(whoami)"
+  fi
+  # sed -i wants to create a tempfile next to the original, which won't work with /etc permissions in many cases,
+  # so just do it in memory and overwrite the existing file if we succeeded
+  NEWPW=$(sed -r "s/(^$(whoami):(.*:){4})(.*:)/\1\/home\/runner:/g" /etc/passwd)
+  echo "$NEWPW" > /etc/passwd
+  # ensure the envvar matches what we just set in /etc/passwd for this session; future sessions set automatically
+  export HOME=/home/runner
+fi
+
+# FIXME: validate group entries?
 
 if [[ -n "${LAUNCHED_BY_RUNNER}" ]]; then
     # Special actions to be compatible with old ansible-runner versions, 2.1.x specifically


### PR DESCRIPTION
fixes #1024 

* using only `HOME` envvar to override homedir causes mismatches with anything that asks for it a different way (eg, `echo ~root`)
* kicking the can down the road on "why are we overriding /root as root's homedir anyway?"
