### PR TITLE
Disable non-periodic zuul jobs

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -1,17 +1,13 @@
 ---
 - project:
     check:
-      jobs: &id001
-        - ansible-buildset-registry
-        - ansible-runner-build-container-image
-        - ansible-runner-build-container-image-stable-2.9
-        - ansible-runner-build-container-image-stable-2.10
-        - ansible-runner-build-container-image-stable-2.11
-        - ansible-runner-build-container-image-stable-2.12
+      jobs: []
     gate:
-      jobs: *id001
+      jobs: []
     post:
-      jobs: &id002
+      jobs: []
+    periodic:
+      jobs:
         - ansible-buildset-registry
         - ansible-runner-upload-container-image:
             vars:
@@ -28,5 +24,3 @@
         - ansible-runner-upload-container-image-stable-2.12:
             vars:
               upload_container_image_promote: false
-    periodic:
-      jobs: *id002


### PR DESCRIPTION
SoftwareFactory zuul apparently cannot run these jobs, so it leaves comments about the errors it encounters. The old ansible Zuul apparently still runs the periodic jobs, so we leave those in place. This will disable building the quay runner images for each PR so SF zuul won't complain, but since they'll still get published by the periodic job each night, that's ok.