### PR TITLE
Remove ``containerized`` docs

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -156,10 +156,10 @@ The process isolation settings are meant to control the process isolation featur
 * ``process_isolation_show_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run.
 * ``process_isolation_ro_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run as read-only.
 
-These settings instructs **Ansible Runner** to execute **Ansible** tasks inside a container environment.
+These settings instruct **Runner** to execute **Ansible** tasks inside a container environment.
 A default execution environment is provided on Quay.io at `ansible/ansible-runner <https://quay.io/repository/ansible/ansible-runner>`_.
 
-To run Ansible Runner with execution environment:
+To execute **Runner** with an execution environment:
 
 ``ansible-runner run --container-image quay.io/ansible/ansible-runner:devel --process-isolation -p playbook.yml .``
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -156,22 +156,12 @@ The process isolation settings are meant to control the process isolation featur
 * ``process_isolation_show_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run.
 * ``process_isolation_ro_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run as read-only.
 
-Container-based Execution
-^^^^^^^^^^^^^^^^^^^^^^^^^
+These settings instructs **Ansible Runner** to execute **Ansible** tasks inside a container environment.
+A default execution environment is provided on Quay.io at `ansible/ansible-runner <https://quay.io/repository/ansible/ansible-runner>`_.
 
-The ``--containerized`` setting instructs **Ansible Runner** to execute **Ansible** tasks inside a container environment. A default execution environment is provided on Quay.io at `ansible/ansible-runner <https://quay.io/repository/ansible/ansible-runner>`_. Users also have the option of building their own container for executing playbooks, however.
+To run Ansible Runner with execution environment:
 
-To build an execution environment locally, run:
-
-``docker build --rm=true -t custom-container -f Dockerfile .``
-
-or, using `podman <https://podman.io/releases/>`_:
-
-``podman build --rm=true -t custom-container -f Dockerfile .``
-
-To run Ansible Runner with your custom container:
-
-``ansible-runner run --container-image custom-container -p playbook.yml``
+``ansible-runner run --container-image quay.io/ansible/ansible-runner:devel --process-isolation -p playbook.yml .``
 
 See ``ansible-runner -h`` for other container-related options.
 


### PR DESCRIPTION
##### SUMMARY

* Correct process isolation documentation with an example
* Remove reference of deprecated parameter ``containerized``

Fixes: #1008

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/intro.rst
