### PR TITLE
Disable 2.1 quay image jobs

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,17 +7,4 @@
     post:
       jobs: []
     periodic:
-      jobs:
-        - ansible-buildset-registry
-        - ansible-runner-upload-container-image-stable-2.9:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.10:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.11:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.12:
-            vars:
-              upload_container_image_promote: false
+      jobs: []


### PR DESCRIPTION
Expecting a newer `2.2` release.