### PR TITLE
Make 2.2 images latest

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -32,8 +32,8 @@
             - github.com/ansible/ansible
           tags:
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
-            # Otherwise: ['devel']
-            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['devel']) }}"
+            # Otherwise: ['latest']
+            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['latest']) }}"
       docker_images: *container_images
 
 - job:
@@ -79,7 +79,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.12-devel
+            - stable-2.12-latest
       docker_images: *container_images_stable_2_12
 
 - job:
@@ -126,7 +126,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.11-devel
+            - stable-2.11-latest
       docker_images: *container_images_stable_2_11
 
 - job:
@@ -173,7 +173,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.10-devel
+            - stable-2.10-latest
       docker_images: *container_images_stable_2_10
 
 - job:
@@ -221,7 +221,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.9-devel
+            - stable-2.9-latest
       docker_images: *container_images_stable_2_9
 
 - job:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,4 +7,17 @@
     post:
       jobs: []
     periodic:
-      jobs: []
+      jobs:
+        - ansible-buildset-registry
+        - ansible-runner-upload-container-image-stable-2.9:
+            vars:
+              upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.10:
+            vars:
+              upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.11:
+            vars:
+              upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.12:
+            vars:
+              upload_container_image_promote: false


### PR DESCRIPTION
DO NOT MERGE until 2.2 is released.

This also re-enables the image publication jobs (turned off until release).