### PR TITLE
[backport][release_2.1] Stringify all env vars, not just those from file (#1039)

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -234,7 +234,7 @@ class BaseConfig(object):
         try:
             envvars = self.loader.load_file('env/envvars', Mapping)
             if envvars:
-                self.env.update({str(k): str(v) for k, v in envvars.items()})
+                self.env.update(envvars)
         except ConfigurationError:
             debug("Not loading environment vars")
             # Still need to pass default environment to pexpect
@@ -285,6 +285,9 @@ class BaseConfig(object):
             self.env['ANSIBLE_CACHE_PLUGIN'] = 'jsonfile'
             if not self.containerized:
                 self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = self.fact_cache
+
+        # Pexpect will error with non-string envvars types, so we ensure string types
+        self.env = {str(k): str(v) for k, v in self.env.items()}
 
         debug('env:')
         for k, v in sorted(self.env.items()):

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -72,7 +72,7 @@ def test_base_config_project_dir(tmp_path):
     assert rc.project_dir == tmp_path.joinpath('project').as_posix()
 
 
-def test_prepare_environment_vars_only_strings(mocker):
+def test_prepare_environment_vars_only_strings_from_file(mocker):
     rc = BaseConfig(envvars=dict(D='D'))
 
     value = dict(A=1, B=True, C="foo")
@@ -81,6 +81,20 @@ def test_prepare_environment_vars_only_strings(mocker):
     mocker.patch.object(rc.loader, 'load_file', side_effect=envvar_side_effect)
 
     rc._prepare_env()
+    assert 'A' in rc.env
+    assert isinstance(rc.env['A'], six.string_types)
+    assert 'B' in rc.env
+    assert isinstance(rc.env['B'], six.string_types)
+    assert 'C' in rc.env
+    assert isinstance(rc.env['C'], six.string_types)
+    assert 'D' in rc.env
+    assert rc.env['D'] == 'D'
+
+
+def test_prepare_environment_vars_only_strings_from_interface():
+    rc = BaseConfig(envvars=dict(D='D', A=1, B=True, C="foo"))
+    rc._prepare_env()
+
     assert 'A' in rc.env
     assert isinstance(rc.env['A'], six.string_types)
     assert 'B' in rc.env


### PR DESCRIPTION
Backport of PR #1039 

(cherry picked from commit c143c07a9355cf4f598717ad853bb4fd008dbca7)