### PR TITLE
[backport][release_2.1] Preserve timestamps when unstreaming dirs (#966)

### DIFF
--- a/ansible_runner/utils/streaming.py
+++ b/ansible_runner/utils/streaming.py
@@ -1,3 +1,4 @@
+import time
 import tempfile
 import zipfile
 import os
@@ -68,6 +69,7 @@ def unstream_dir(stream, length, target_directory):
 
         with zipfile.ZipFile(tmp.name, "r") as archive:
             # Fancy extraction in order to preserve permissions
+            # AWX relies on the execution bit, in particular, for inventory
             # https://www.burgundywall.com/post/preserving-file-perms-with-python-zipfile-module
             for info in archive.infolist():
                 out_path = os.path.join(target_directory, info.filename)
@@ -84,6 +86,12 @@ def unstream_dir(stream, length, target_directory):
                         continue
 
                 archive.extract(info.filename, path=target_directory)
+
+                # Fancy logic to preserve modification times
+                # AWX uses modification times to determine if new facts were written for a host
+                # https://stackoverflow.com/questions/9813243/extract-files-from-zip-file-and-retain-mod-date
+                date_time = time.mktime(info.date_time + (0, 0, -1))
+                os.utime(out_path, times=(date_time, date_time))
 
                 if is_symlink:
                     link = open(out_path).read()


### PR DESCRIPTION
Backport of PR #966 

(cherry picked from commit 203ef4314f00cc331c6f68d9c099f3707e78d891)