### PR TITLE
test: generate SSH private key

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,3 +5,4 @@ pytest-timeout
 pytest-xdist
 flake8==4.0.1
 yamllint
+cryptography

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -13,6 +13,7 @@ from pexpect import TIMEOUT, EOF
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.exceptions import ConfigurationError
+from test.utils.common import RSAKey
 
 try:
     Pattern = re._pattern_type
@@ -170,12 +171,13 @@ def test_prepare_env_sshkey_defaults():
 def test_prepare_env_sshkey(mocker):
     rc = BaseConfig()
 
-    value = '01234567890'
-    sshkey_side_effect = partial(load_file_side_effect, 'env/ssh_key', value)
+    rsa_key = RSAKey()
+    rsa_private_key_value = rsa_key.private
+    sshkey_side_effect = partial(load_file_side_effect, 'env/ssh_key', rsa_private_key_value)
 
     mocker.patch.object(rc.loader, 'load_file', side_effect=sshkey_side_effect)
     rc._prepare_env()
-    assert rc.ssh_key_data == value
+    assert rc.ssh_key_data == rsa_private_key_value
 
 
 def test_prepare_env_defaults():
@@ -218,7 +220,8 @@ def test_prepare_with_ssh_key(mocker, tmp_path):
     rc.artifact_dir = custom_artifacts.as_posix()
     rc.env = {}
     rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
-    rc.ssh_key_data = '01234567890'
+    rsa_key = RSAKey()
+    rc.ssh_key_data = rsa_key.private
     rc.command = 'ansible-playbook'
     rc.cmdline_args = []
     rc._prepare_env()

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -14,6 +14,7 @@ from ansible_runner.config.runner import RunnerConfig, ExecutionMode
 from ansible_runner.interface import init_runner
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.exceptions import ConfigurationError
+from test.utils.common import RSAKey
 
 try:
     Pattern = re._pattern_type
@@ -184,13 +185,14 @@ def test_prepare_env_sshkey(mocker):
     mocker.patch('os.makedirs', return_value=True)
     rc = RunnerConfig('/')
 
-    value = '01234567890'
-    sshkey_side_effect = partial(load_file_side_effect, 'env/ssh_key', value)
+    rsa_key = RSAKey()
+    rsa_private_key_value = rsa_key.private
+    sshkey_side_effect = partial(load_file_side_effect, 'env/ssh_key', rsa_private_key_value)
 
     mocker.patch.object(rc.loader, 'load_file', side_effect=sshkey_side_effect)
 
     rc.prepare_env()
-    assert rc.ssh_key_data == value
+    assert rc.ssh_key_data == rsa_private_key_value
 
 
 def test_prepare_env_defaults(mocker):
@@ -478,7 +480,8 @@ def test_prepare_with_ssh_key(mocker):
     rc.env = {}
     rc.execution_mode = ExecutionMode.ANSIBLE_PLAYBOOK
     rc.playbook = 'main.yaml'
-    rc.ssh_key_data = '01234567890'
+    rsa_key = RSAKey()
+    rc.ssh_key_data = rsa_key.private
     rc.command = 'ansible-playbook'
 
     mocker.patch.dict('os.environ', {'AWX_LIB_DIRECTORY': '/'})

--- a/test/utils/common.py
+++ b/test/utils/common.py
@@ -1,11 +1,40 @@
 import time
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
 
 
 def iterate_timeout(max_seconds, purpose, interval=2):
     start = time.time()
     count = 0
-    while (time.time() < start + max_seconds):
+    while time.time() < start + max_seconds:
         count += 1
         yield count
         time.sleep(interval)
     raise Exception("Timeout waiting for %s" % purpose)
+
+
+class RSAKey:
+    """In-memory RSA key generation and management utils."""
+
+    def __init__(self):
+        _rsa_key_obj = generate_private_key(
+            public_exponent=65537,
+            key_size=1024,
+            backend=default_backend(),
+        )
+
+        _private_rsa_key_repr = _rsa_key_obj.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.TraditionalOpenSSL,  # A.K.A. PKCS#1
+            encryption_algorithm=NoEncryption(),
+        )
+        self._private_rsa_key_repr = _private_rsa_key_repr.decode()
+
+    @property
+    def private(self) -> str:
+        return self._private_rsa_key_repr


### PR DESCRIPTION
##### SUMMARY

Instead of hardcoded value generate SSH Private key in tests

Fixes: #823

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
test/requirements.txt
test/unit/config/test__base.py
test/unit/config/test_runner.py
test/utils/common.py
