### PR TITLE
Honor inventory filepath

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -148,7 +148,8 @@ def run(**kwargs):
     :param str or dict or list inventory: Overrides the inventory directory/file (supplied at ``private_data_dir/inventory``) with
         a specific host or list of hosts. This can take the form of:
 
-            - Path to the inventory file in the ``private_data_dir``
+            - Path to the inventory file in the ``private_data_dir/inventory`` directory or
+              an absolute path to the inventory file
             - Native python dict supporting the YAML/json inventory structure
             - A text INI formatted string
             - A list of inventory sources, or an empty list to disable passing inventory

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -255,8 +255,12 @@ def dump_artifacts(kwargs):
         if isinstance(obj, MutableMapping):
             kwargs['inventory'] = dump_artifact(json.dumps(obj), path, 'hosts.json')
         elif isinstance(obj, string_types):
-            if not os.path.exists(obj):
+            if not os.path.exists(os.path.join(path, obj)):
                 kwargs['inventory'] = dump_artifact(obj, path, 'hosts')
+            elif os.path.isabs(obj):
+                kwargs['inventory'] = obj
+            else:
+                kwargs['inventory'] = os.path.join(path, obj)
 
     if not kwargs.get('suppress_env_files', False):
         for key in ('envvars', 'extravars', 'passwords', 'settings'):

--- a/test/unit/utils/test_dump_artifacts.py
+++ b/test/unit/utils/test_dump_artifacts.py
@@ -147,6 +147,26 @@ def test_dump_artifacts_inventory_object(mocker):
     assert mock_dump_artifact.called_once_with(inv_string, '/tmp/inventory', 'hosts.json')
 
 
+def test_dump_artifacts_inventory_string_path(mocker):
+    mocker.patch('ansible_runner.utils.os.path.exists', return_value=True)
+
+    inv_string = 'site1'
+    kwargs = {'private_data_dir': '/tmp', 'inventory': inv_string}
+    dump_artifacts(kwargs)
+
+    assert kwargs['inventory'] == '/tmp/inventory/site1'
+
+
+def test_dump_artifacts_inventory_string_abs_path(mocker):
+    mocker.patch('ansible_runner.utils.os.path.exists', return_value=True)
+
+    inv_string = '/tmp/site1'
+    kwargs = {'private_data_dir': '/tmp', 'inventory': inv_string}
+    dump_artifacts(kwargs)
+
+    assert kwargs['inventory'] == '/tmp/site1'
+
+
 def test_dump_artifacts_passwords(mocker):
     mock_dump_artifact = mocker.patch('ansible_runner.utils.dump_artifact')
 


### PR DESCRIPTION
##### SUMMARY

inventory parameter in `run` method, accepts inventory filepath
relative to the `private_data_dir`. Check added to honor this path.

Fixes: #351

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible_runner/interface.py
ansible_runner/utils/__init__.py
test/unit/utils/test_dump_artifacts.py
