### PR TITLE
[backport][2.2] skip process isolation check for transmit and process

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -83,12 +83,6 @@ def init_runner(**kwargs):
         if logfile:
             output.set_logfile(logfile)
 
-    if kwargs.get("process_isolation", False):
-        pi_executable = kwargs.get("process_isolation_executable", "podman")
-        if not check_isolation_executable_installed(pi_executable):
-            print(f'Unable to find process isolation executable: {pi_executable}')
-            sys.exit(1)
-
     event_callback_handler = kwargs.pop('event_handler', None)
     status_callback_handler = kwargs.pop('status_handler', None)
     artifacts_handler = kwargs.pop('artifacts_handler', None)
@@ -117,6 +111,12 @@ def init_runner(**kwargs):
                                          finished_callback=finished_callback,
                                          **kwargs)
             return stream_processor
+
+    if kwargs.get("process_isolation", False):
+        pi_executable = kwargs.get("process_isolation_executable", "podman")
+        if not check_isolation_executable_installed(pi_executable):
+            print(f'Unable to find process isolation executable: {pi_executable}')
+            sys.exit(1)
 
     kwargs.pop('_input', None)
     kwargs.pop('_output', None)


### PR DESCRIPTION
backport of https://github.com/ansible/ansible-runner/pull/1084

skip process isolation check for transmit and process

moving down the process isolation executable so that transmit and
process no longer checks for its existance

ansible-runner worker will still run the check since it will invoke
ansible-runner run with process-isolation-executable and it will still
be checked properly

Co-Authored-By: Jeff Bradberry <685957+jbradberry@users.noreply.github.com>
Signed-off-by: Hao Liu <haoli@redhat.com>