### PR TITLE
[backport][2.2] update how callback plugin gets copied and added to job container

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -32,8 +32,8 @@
             - github.com/ansible/ansible
           tags:
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
-            # Otherwise: ['devel']
-            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['devel']) }}"
+            # Otherwise: ['latest']
+            "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['latest']) }}"
       docker_images: *container_images
 
 - job:
@@ -79,7 +79,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.12-devel
+            - stable-2.12-latest
       docker_images: *container_images_stable_2_12
 
 - job:
@@ -126,7 +126,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.11-devel
+            - stable-2.11-latest
       docker_images: *container_images_stable_2_11
 
 - job:
@@ -173,7 +173,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.10-devel
+            - stable-2.10-latest
       docker_images: *container_images_stable_2_10
 
 - job:
@@ -221,7 +221,7 @@
           siblings:
             - github.com/ansible/ansible
           tags:
-            - stable-2.9-devel
+            - stable-2.9-latest
       docker_images: *container_images_stable_2_9
 
 - job:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,4 +7,17 @@
     post:
       jobs: []
     periodic:
-      jobs: []
+      jobs:
+        - ansible-buildset-registry
+        - ansible-runner-upload-container-image-stable-2.9:
+            vars:
+              upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.10:
+            vars:
+              upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.11:
+            vars:
+              upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.12:
+            vars:
+              upload_container_image_promote: false

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -7,20 +7,4 @@
     post:
       jobs: []
     periodic:
-      jobs:
-        - ansible-buildset-registry
-        - ansible-runner-upload-container-image:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.9:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.10:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.11:
-            vars:
-              upload_container_image_promote: false
-        - ansible-runner-upload-container-image-stable-2.12:
-            vars:
-              upload_container_image_promote: false
+      jobs: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,10 @@ RUN for dir in \
 
 WORKDIR /runner
 
+# NB: this appears to be necessary for container builds based on this container, since we can't rely on the entrypoint
+# script to run during a build to fix up /etc/passwd. This envvar value, and the fact that all user homedirs are
+# set to /home/runner is an implementation detail that may change with future versions of runner and should not be
+# assumed by other code or tools.
 ENV HOME=/home/runner
 
 ADD utils/entrypoint.sh /bin/entrypoint

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -234,7 +234,7 @@ class BaseConfig(object):
         try:
             envvars = self.loader.load_file('env/envvars', Mapping)
             if envvars:
-                self.env.update({str(k): str(v) for k, v in envvars.items()})
+                self.env.update(envvars)
         except ConfigurationError:
             debug("Not loading environment vars")
             # Still need to pass default environment to pexpect
@@ -292,6 +292,9 @@ class BaseConfig(object):
             self.env['ANSIBLE_CACHE_PLUGIN'] = 'jsonfile'
             if not self.containerized:
                 self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = self.fact_cache
+
+        # Pexpect will error with non-string envvars types, so we ensure string types
+        self.env = {str(k): str(v) for k, v in self.env.items()}
 
         debug('env:')
         for k, v in sorted(self.env.items()):

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -61,27 +61,6 @@ def is_dir_owner(directory):
     return bool(current_user == callback_owner)
 
 
-def callback_mount(copy_if_needed=False):
-    '''
-    Return a tuple that gives mount points for the standard out callback
-    in the form of (<host location>, <location in container>)
-    if copy_if_needed is set, and the install is owned by another user,
-    it will copy the plugin to a tmpdir for the mount in anticipation of SELinux problems
-    '''
-    container_dot_ansible = '/home/runner/.ansible'
-    rel_path = ('callback', '',)
-    host_path = os.path.join(get_plugin_dir(), *rel_path)
-    if copy_if_needed:
-        callback_dir = get_callback_dir()
-        if not is_dir_owner(callback_dir):
-            tmp_path = tempfile.mkdtemp(prefix='ansible_runner_plugins_')
-            register_for_cleanup(tmp_path)
-            host_path = os.path.join(tmp_path, 'callback')
-            shutil.copytree(callback_dir, host_path)
-    container_path = os.path.join(container_dot_ansible, 'plugins', *rel_path)
-    return (host_path, container_path)
-
-
 class Bunch(object):
 
     '''

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -432,7 +432,7 @@ def open_fifo_write(path, data):
     '''
     os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
     # If the data is a string instead of bytes, convert it before writing the fifo
-    if type(data) == str:
+    if isinstance(data, string_types):
         data = data.encode()
     threading.Thread(target=lambda p, d: open(p, 'wb').write(d),
                      args=(path, data)).start()

--- a/ansible_runner/utils/streaming.py
+++ b/ansible_runner/utils/streaming.py
@@ -13,7 +13,7 @@ from pathlib import Path
 def stream_dir(source_directory, stream):
     with tempfile.NamedTemporaryFile() as tmp:
         with zipfile.ZipFile(
-            tmp.name, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True
+            tmp.name, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True, strict_timestamps=False
         ) as archive:
             if source_directory:
                 for dirpath, dirs, files in os.walk(source_directory):

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -217,6 +217,28 @@ Usage examples
   print("Final status:")
   print(r.stats)
 
+
+.. code-block:: python
+
+  import ansible_runner
+
+  def my_status_handler(data, runner_config):
+      # Do something here
+      print(data)
+
+  r = ansible_runner.run(private_data_dir='/tmp/demo', playbook='test.yml', status_handler=my_status_handler)
+
+
+.. code-block:: python
+
+  import ansible_runner
+
+  def my_event_handler(data):
+      # Do something here
+      print(data)
+
+  r = ansible_runner.run(private_data_dir='/tmp/demo', playbook='test.yml', event_handler=my_event_handler)
+
 .. code-block:: python
 
   import ansible_runner

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -73,7 +73,7 @@ def test_base_config_project_dir(tmp_path):
     assert rc.project_dir == tmp_path.joinpath('project').as_posix()
 
 
-def test_prepare_environment_vars_only_strings(mocker):
+def test_prepare_environment_vars_only_strings_from_file(mocker):
     rc = BaseConfig(envvars=dict(D='D'))
 
     value = dict(A=1, B=True, C="foo")
@@ -82,6 +82,20 @@ def test_prepare_environment_vars_only_strings(mocker):
     mocker.patch.object(rc.loader, 'load_file', side_effect=envvar_side_effect)
 
     rc._prepare_env()
+    assert 'A' in rc.env
+    assert isinstance(rc.env['A'], six.string_types)
+    assert 'B' in rc.env
+    assert isinstance(rc.env['B'], six.string_types)
+    assert 'C' in rc.env
+    assert isinstance(rc.env['C'], six.string_types)
+    assert 'D' in rc.env
+    assert rc.env['D'] == 'D'
+
+
+def test_prepare_environment_vars_only_strings_from_interface():
+    rc = BaseConfig(envvars=dict(D='D', A=1, B=True, C="foo"))
+    rc._prepare_env()
+
     assert 'A' in rc.env
     assert isinstance(rc.env['A'], six.string_types)
     assert 'B' in rc.env

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -13,7 +13,6 @@ from pexpect import TIMEOUT, EOF
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import callback_mount
 
 try:
     Pattern = re._pattern_type
@@ -331,7 +330,6 @@ def test_containerization_settings(tmp_path, runtime, mocker):
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -6,7 +6,7 @@ import pytest
 from ansible_runner.config.ansible_cfg import AnsibleCfgConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import get_executable_path, callback_mount
+from ansible_runner.utils import get_executable_path
 
 
 def test_ansible_cfg_init_defaults(tmp_path, patch_private_data_dir):
@@ -91,7 +91,6 @@ def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker)
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -6,7 +6,6 @@ import pytest
 from ansible_runner.config.command import CommandConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import callback_mount
 
 
 def test_ansible_config_defaults(tmp_path, patch_private_data_dir):
@@ -106,7 +105,6 @@ def test_prepare_run_command_with_containerization(tmp_path, runtime, mocker):
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -6,7 +6,7 @@ import pytest
 from ansible_runner.config.doc import DocConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import get_executable_path, callback_mount
+from ansible_runner.utils import get_executable_path
 
 
 def test_ansible_doc_defaults(tmp_path, patch_private_data_dir):
@@ -101,7 +101,6 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, runtime, mo
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 
@@ -170,7 +169,6 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, runtime, mo
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -6,7 +6,7 @@ import pytest
 from ansible_runner.config.inventory import InventoryConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import get_executable_path, callback_mount
+from ansible_runner.utils import get_executable_path
 
 
 def test_ansible_inventory_init_defaults(tmp_path, patch_private_data_dir):
@@ -126,7 +126,6 @@ def test_prepare_inventory_command_with_containerization(tmp_path, runtime, mock
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -194,6 +194,29 @@ def test_transmit_modtimes(tmp_path):
     assert old_delta >= datetime.timedelta(days=1).total_seconds() - 2.
 
 
+def test_transmit_file_from_before_1980s(tmp_path):
+    source_dir = tmp_path / 'source'
+    source_dir.mkdir()
+
+    old_file = source_dir / 'cassette_tape.txt'
+    old_file.touch()
+
+    old_timestamp = datetime.datetime(year=1978, month=7, day=28).timestamp()
+    os.utime(old_file, (old_timestamp, old_timestamp))
+
+    outgoing_buffer = io.BytesIO()
+    outgoing_buffer.name = 'not_stdout'
+    stream_dir(source_dir, outgoing_buffer)
+
+    dest_dir = tmp_path / 'dest'
+    dest_dir.mkdir()
+
+    outgoing_buffer.seek(0)
+    first_line = outgoing_buffer.readline()
+    size_data = json.loads(first_line.strip())
+    unstream_dir(outgoing_buffer, size_data['zipfile'], dest_dir)
+
+
 def test_signal_handler(mocker):
     """Test the default handler is set to handle the correct signals"""
 

--- a/utils/entrypoint.sh
+++ b/utils/entrypoint.sh
@@ -1,27 +1,60 @@
 #!/usr/bin/env bash
 
-# In OpenShift, containers are run as a random high number uid
-# that doesn't exist in /etc/passwd, but Ansible module utils
-# require a named user. So if we're in OpenShift, we need to make
-# one before Ansible runs.
-if [[ (`id -u` -ge 500 || -z "${CURRENT_UID}") ]]; then
+# We need to fix a number of problems here that manifest under different container runtimes, as well as tweak some
+# things to simplify runner's containerized launch behavior. Since runner currently always expects to bind-mount its
+# callback plugins under ~/.ansible, it must have prior knowledge of the user's homedir before the container is launched
+# in order to know where to mount in the callback dir. In all cases, we must get a consistent answer from $HOME
+# and anything that queries /etc/passwd for a homedir (eg, `~root`), or lots of things (including parts of Ansible
+# core itself) will be broken.
 
-    # Only needed for RHEL 8. Try deleting this conditional (not the code)
-    # sometime in the future. Seems to be fixed on Fedora 32
-    # If we are running in rootless podman, this file cannot be overwritten
-    ROOTLESS_MODE=$(cat /proc/self/uid_map | head -n1 | awk '{ print $2; }')
-    if [[ "$ROOTLESS_MODE" -eq "0" ]]; then
-cat << EOF > /etc/passwd
-root:x:0:0:root:/root:/bin/bash
-runner:x:`id -u`:`id -g`:,,,:/home/runner:/bin/bash
-EOF
-    fi
+# If we're running as a legit default user that has an entry in /etc/passwd and a valid homedir, we're all good.
 
-cat <<EOF > /etc/group
-root:x:0:runner
-runner:x:`id -g`:
-EOF
+# If the username/uid we're running under is not represented in /etc/passwd or the current user's homedir is something
+# other than /home/runner (eg, the container was run with --user and some dynamic unmapped UID from the host with
+# primary GID 0), we need to correct that in order for ansible-runner's callbacks to function properly. Some things
+# (eg podman/cri-o today) already create an /etc/passwd entry on the fly in this case, but they set the homedir to
+# WORKDIR, which causes potential collisions with mounted/mapped volumes. For consistency, we'll
+# just always set the current user's homedir to `/home/runner`, which we've already configured in a way
+# that should always work with known container runtimes (eg, ug+rwx and all dirs owned by the root group).
 
+# If current user is not listed in /etc/passwd, add an entry with username==uid, primary gid 0, and homedir /home/runner
+
+# If current user is in /etc/passwd but $HOME != `/home/runner`, rewrite that user's homedir in /etc/passwd to
+# /home/runner and export HOME=/home/runner for this session only. All new sessions (eg podman exec) should
+# automatically set HOME to the value in /etc/passwd going forward.
+
+# Ideally in the future, we can come up with a better way for the outer runner to dynamically inject its callbacks, or
+# rely on the inner runner's copy. This would allow us to restore the typical POSIX user homedir conventions.
+
+# if any of this business fails, we probably want to fail fast
+if [ -n "$EP_DEBUG" ]; then
+  set -eux
+  echo 'hello from entrypoint'
+else
+  set -e
+fi
+
+# current user might not exist in /etc/passwd at all
+if ! $(whoami &> /dev/null) || ! getent passwd $(whoami || id -u) &> /dev/null ; then
+  if [ -n "$EP_DEBUG" ]; then
+    echo "adding missing uid $(id -u) into /etc/passwd"
+  fi
+  echo "$(id -u):x:$(id -u):0:container user $(id -u):/home/runner:/bin/bash" >> /etc/passwd
+  export HOME=/home/runner
+fi
+
+MYHOME=`getent passwd $(whoami) | cut -d: -f6`
+
+if [ "$MYHOME" != "$HOME" ] || [ "$MYHOME" != "/home/runner" ]; then
+  if [ -n "$EP_DEBUG" ]; then
+    echo "replacing homedir for user $(whoami)"
+  fi
+  # sed -i wants to create a tempfile next to the original, which won't work with /etc permissions in many cases,
+  # so just do it in memory and overwrite the existing file if we succeeded
+  NEWPW=$(sed -r "s/(^$(whoami):(.*:){4})(.*:)/\1\/home\/runner:/g" /etc/passwd)
+  echo "$NEWPW" > /etc/passwd
+  # ensure the envvar matches what we just set in /etc/passwd for this session; future sessions set automatically
+  export HOME=/home/runner
 fi
 
 if [[ -n "${LAUNCHED_BY_RUNNER}" ]]; then


### PR DESCRIPTION
back port of #1093 to release_2.2

when in containerized environment
- always copy callback plugin to private_data_dir/artifacts/{job_id}/callback
- appending to `ANSIBLE_CALLBACK_PLUGINS` with the runner callback plugin location (from private_data/artifacts)
- unused method `utils.callback_mount`
- update unit tests

Co-Authored-By: Alan Rominger <arominge@redhat.com>
Signed-off-by: Hao Liu <the.real.hao.liu@gmail.com>

