### PR TITLE
[backport][2.2]update how callback plugin gets copied and added to job container

### DIFF
--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -61,27 +61,6 @@ def is_dir_owner(directory):
     return bool(current_user == callback_owner)
 
 
-def callback_mount(copy_if_needed=False):
-    '''
-    Return a tuple that gives mount points for the standard out callback
-    in the form of (<host location>, <location in container>)
-    if copy_if_needed is set, and the install is owned by another user,
-    it will copy the plugin to a tmpdir for the mount in anticipation of SELinux problems
-    '''
-    container_dot_ansible = '/home/runner/.ansible'
-    rel_path = ('callback', '',)
-    host_path = os.path.join(get_plugin_dir(), *rel_path)
-    if copy_if_needed:
-        callback_dir = get_callback_dir()
-        if not is_dir_owner(callback_dir):
-            tmp_path = tempfile.mkdtemp(prefix='ansible_runner_plugins_')
-            register_for_cleanup(tmp_path)
-            host_path = os.path.join(tmp_path, 'callback')
-            shutil.copytree(callback_dir, host_path)
-    container_path = os.path.join(container_dot_ansible, 'plugins', *rel_path)
-    return (host_path, container_path)
-
-
 class Bunch(object):
 
     '''

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -13,7 +13,6 @@ from pexpect import TIMEOUT, EOF
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import callback_mount
 
 try:
     Pattern = re._pattern_type
@@ -331,7 +330,6 @@ def test_containerization_settings(tmp_path, runtime, mocker):
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -6,7 +6,7 @@ import pytest
 from ansible_runner.config.ansible_cfg import AnsibleCfgConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import get_executable_path, callback_mount
+from ansible_runner.utils import get_executable_path
 
 
 def test_ansible_cfg_init_defaults(tmp_path, patch_private_data_dir):
@@ -91,7 +91,6 @@ def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker)
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -6,7 +6,6 @@ import pytest
 from ansible_runner.config.command import CommandConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import callback_mount
 
 
 def test_ansible_config_defaults(tmp_path, patch_private_data_dir):
@@ -106,7 +105,6 @@ def test_prepare_run_command_with_containerization(tmp_path, runtime, mocker):
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -6,7 +6,7 @@ import pytest
 from ansible_runner.config.doc import DocConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import get_executable_path, callback_mount
+from ansible_runner.utils import get_executable_path
 
 
 def test_ansible_doc_defaults(tmp_path, patch_private_data_dir):
@@ -101,7 +101,6 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, runtime, mo
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 
@@ -170,7 +169,6 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, runtime, mo
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -6,7 +6,7 @@ import pytest
 from ansible_runner.config.inventory import InventoryConfig
 from ansible_runner.config._base import BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
-from ansible_runner.utils import get_executable_path, callback_mount
+from ansible_runner.utils import get_executable_path
 
 
 def test_ansible_inventory_init_defaults(tmp_path, patch_private_data_dir):
@@ -126,7 +126,6 @@ def test_prepare_inventory_command_with_containerization(tmp_path, runtime, mock
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
         '-v', '{}/:/runner/:Z'.format(rc.private_data_dir),
-        '-v', '{0}:{1}:Z'.format(*callback_mount()),
         '--env-file', '{}/env.list'.format(rc.artifact_dir),
     ])
 


### PR DESCRIPTION
back port of https://github.com/ansible/ansible-runner/pull/1093 to release_2.2

when in containerized environment
- always copy callback plugin to private_data_dir/artifacts/{job_id}/callback
- appending to ANSIBLE_CALLBACK_PLUGINS with the runner callback plugin location (from private_data/artifacts)
- unused method utils.callback_mount
- update unit tests

Co-Authored-By: Alan Rominger [arominge@redhat.com](mailto:arominge@redhat.com)
Signed-off-by: Hao Liu [the.real.hao.liu@gmail.com](mailto:the.real.hao.liu@gmail.com)