### PR TITLE
Fix two runtime warnings

### DIFF
--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -13,7 +13,7 @@ import base64
 import threading
 from pathlib import Path
 import pwd
-import pipes
+from shlex import quote
 import uuid
 import codecs
 import atexit
@@ -413,12 +413,18 @@ def open_fifo_write(path, data):
     # If the data is a string instead of bytes, convert it before writing the fifo
     if isinstance(data, string_types):
         data = data.encode()
-    threading.Thread(target=lambda p, d: open(p, 'wb').write(d),
+
+    def worker(path, data):
+        with open(path, 'wb') as fh:
+            fh.write(data)
+        fh.close()
+
+    threading.Thread(target=worker,
                      args=(path, data)).start()
 
 
 def args2cmdline(*args):
-    return ' '.join([pipes.quote(a) for a in args])
+    return ' '.join([quote(a) for a in args])
 
 
 def ensure_str(s, encoding='utf-8', errors='strict'):

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -417,7 +417,6 @@ def open_fifo_write(path, data):
     def worker(path, data):
         with open(path, 'wb') as fh:
             fh.write(data)
-        fh.close()
 
     threading.Thread(target=worker,
                      args=(path, data)).start()


### PR DESCRIPTION
- Replace deprecated pipes.quote with shlex.quote
- Fix file handle not being closed

Both were observed as affecting ansible-navigator testing, which is configured to run with warnings as errors. Ideally we should be able to do the here with runner at some point.

Fixes #1101 