### PR TITLE
Make yamllint rule compatible with prettier

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -10,6 +10,8 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
+  comments:
+    min-spaces-from-content: 1 # prettier compatibility
   line-length: disable
   document-start: disable
   truthy:


### PR DESCRIPTION
Adapts yamllint config to not require two char indentation for inline comments as that is in conflict with prettier formatting.

Ansible-lint also does the same override for compatibility issues, especially as many users use format-on-save.

Reference: https://github.com/ansible/ansible-lint/blob/679ffc04c8ab84ee417cf6eec10868b06fc246eb/src/ansiblelint/yaml_utils.py#L52-L54
