### PR TITLE
Consolidate how we run linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,9 @@ repos:
     rev: v2.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.27.1
+    hooks:
+      - id: yamllint
+        args:
+          - --strict

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,10 @@ commands = pytest {posargs}
 [testenv:linters]
 description = Run code linters
 basepython = python3.8
+deps =
+    pre-commit
 commands=
-    flake8 --version
-    flake8 docs ansible_runner test
-    yamllint --version
-    yamllint -s .
+    pre-commit run -a
 
 [testenv:unit{,-py38,-py39,-py310}]
 description = Run unit tests


### PR DESCRIPTION
Ensure we use pre-commit as linter orchestrator as this ensures that
we always use the same linter version.
