### PR TITLE
[bp/2.1] Linting fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN if [ "$ANSIBLE_BRANCH" != "" ] ; then \
 # NOTE(pabelanger): For downstream builds, we compile everything from source
 # over using existing wheels. Do this upstream too so we can better catch
 # issues.
-ENV PIP_OPTS=--no-build-isolation
+
+# Commenting due to failures in CI
+# ENV PIP_OPTS=--no-build-isolation
 RUN assemble
 
 FROM $PYTHON_BASE_IMAGE

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -915,21 +915,21 @@ def main(sys_args=None):
                     else:
                         sys.stderr.write(exc)
                     return 1
-            return(res.rc)
+            return res.rc
 
     try:
         with open(pidfile, 'r') as f:
             pid = int(f.readline())
     except IOError:
-        return(1)
+        return 1
 
     if vargs.get('command') == 'stop':
         Runner.handle_termination(pid, pidfile=pidfile)
-        return (0)
+        return 0
 
     elif vargs.get('command') == 'is-alive':
         try:
             os.kill(pid, signal.SIG_DFL)
-            return(0)
+            return 0
         except OSError:
-            return(1)
+            return 1

--- a/ansible_runner/cleanup.py
+++ b/ansible_runner/cleanup.py
@@ -79,9 +79,9 @@ def is_alive(dir):
 
     try:
         os.kill(pid, signal.SIG_DFL)
-        return(0)
+        return 0
     except OSError:
-        return(1)
+        return 1
 
 
 def project_idents(dir):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,5 +2,5 @@ pytest
 pytest-mock
 pytest-timeout
 pytest-xdist
-flake8
+flake8==4.0.1
 yamllint


### PR DESCRIPTION
##### SUMMARY

* Added whitespace after the keyword
* Pinned `flake8` to 4.0.1 for now
* Commented `ENV PIP_OPTS=--no-build-isolation`

(cherry picked from commit 2d240e09937131de5ef76cdb9a5621b1fe272789)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Dockerfile
ansible_runner/__main__.py
ansible_runner/cleanup.py
test/requirements.txt
