### PR TITLE
Make sure we close stdout/stderr in Runner.run()

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -276,9 +276,7 @@ class Runner(object):
                     stderr_response = stderr_response.decode()
                 stderr_handle.write(stderr_response)
 
-            stdout_handle.flush()
             stdout_handle.close()
-            stderr_handle.flush()
             stderr_handle.close()
         else:
             try:
@@ -341,9 +339,7 @@ class Runner(object):
                     Runner.handle_termination(child.pid, is_cancel=False)
                     self.timed_out = True
 
-            stdout_handle.flush()
             stdout_handle.close()
-            stderr_handle.flush()
             stderr_handle.close()
             child.close()
             self.rc = child.exitstatus if not (self.timed_out or self.canceled) else 254

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -275,6 +275,11 @@ class Runner(object):
                 if isinstance(stderr_response, bytes):
                     stderr_response = stderr_response.decode()
                 stderr_handle.write(stderr_response)
+
+            stdout_handle.flush()
+            stdout_handle.close()
+            stderr_handle.flush()
+            stderr_handle.close()
         else:
             try:
                 child = pexpect.spawn(
@@ -338,6 +343,8 @@ class Runner(object):
 
             stdout_handle.flush()
             stdout_handle.close()
+            stderr_handle.flush()
+            stderr_handle.close()
             child.close()
             self.rc = child.exitstatus if not (self.timed_out or self.canceled) else 254
 

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -188,3 +188,19 @@ def test_multiline_blank_write(rc, runner_mode):
     assert status == 'successful'
     stdout_path = Path(rc.artifact_dir) / 'stdout'
     assert stdout_path.read_text() == 'hello_world_marker\n\n\n\n'  # one extra newline okay
+
+
+@pytest.mark.parametrize('runner_mode', ['subprocess'])
+@pytest.mark.filterwarnings("error")
+def test_no_ResourceWarning_error(rc, runner_mode):
+    """
+    Test that no ResourceWarning error is propogated up with warnings-as-errors enabled.
+
+    Not properly closing stdout/stderr in Runner.run() will cause a ResourceWarning
+    error that is only seen when we treat warnings as an error.
+    """
+    rc.command = ['echo', 'Hello World']
+    rc.runner_mode = runner_mode
+    runner = Runner(config=rc)
+    status, exitcode = runner.run()
+    assert status == 'successful'


### PR DESCRIPTION
If we treat warnings as errors with pytest (via `-Werror` or config file change), tests using `subprocess` code path will fail because we get a warning about an unclosed file on `stderr`.

Ultimately, the entire `Runner.run()` method probably needs reworked so that it is not so complex, and we can use better/safer coding methods, such as context managers on the open file handles. As it is now, using context managers on these file handles is a major pain since there is so much code between opening them and where we need to guarantee they are closed.

Provided test will fail without the code changes to close `stdout`/`stderr`.