### PR TITLE
[bp/2.1] Make sure we close stdout/stderr in Runner.run()

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -294,6 +294,9 @@ class Runner(object):
                 if isinstance(stderr_response, bytes):
                     stderr_response = stderr_response.decode()
                 stderr_handle.write(stderr_response)
+
+            stdout_handle.close()
+            stderr_handle.close()
         else:
             try:
                 child = pexpect.spawn(
@@ -355,8 +358,8 @@ class Runner(object):
                     Runner.handle_termination(child.pid, is_cancel=False)
                     self.timed_out = True
 
-            stdout_handle.flush()
             stdout_handle.close()
+            stderr_handle.close()
             child.close()
             self.rc = child.exitstatus if not (self.timed_out or self.canceled) else 254
 

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -152,3 +152,19 @@ def test_status_callback_interface(rc, mocker):
     assert runner.status_handler.call_count == 1
     runner.status_handler.assert_called_with(dict(status='running', runner_ident=str(rc.ident)), runner_config=runner.config)
     assert runner.status == 'running'
+
+
+@pytest.mark.parametrize('runner_mode', ['subprocess'])
+@pytest.mark.filterwarnings("error")
+def test_no_ResourceWarning_error(rc, runner_mode):
+    """
+    Test that no ResourceWarning error is propogated up with warnings-as-errors enabled.
+
+    Not properly closing stdout/stderr in Runner.run() will cause a ResourceWarning
+    error that is only seen when we treat warnings as an error.
+    """
+    rc.command = ['echo', 'Hello World']
+    rc.runner_mode = runner_mode
+    runner = Runner(config=rc)
+    status, exitcode = runner.run()
+    assert status == 'successful'


### PR DESCRIPTION
* Make sure we close stdout/stderr
* Remove unnecessary flush() calls

(cherry picked from commit 2eab20131bf66ad6ca32f330f87534506ebab120)