### PR TITLE
Add example for RunnerConfig

### DIFF
--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -264,6 +264,21 @@ Usage examples
 
 .. code-block:: python
 
+  from ansible_runner import Runner, RunnerConfig
+
+  # Using tag using RunnerConfig
+  rc = RunnerConfig(
+      private_data_dir="project",
+      playbook="main.yml",
+      tags='my_tag',
+  )
+
+  rc.prepare()
+  r = Runner(config=rc)
+  r.run()
+
+.. code-block:: python
+
   # run the role named 'myrole' contained in the '<private_data_dir>/project/roles' directory
   r = ansible_runner.run(private_data_dir='/tmp/demo', role='myrole')
   print("{}: {}".format(r.status, r.rc))


### PR DESCRIPTION
##### SUMMARY

* Added an example for RunnerConfig to show tags usages

Fixes: #1131

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/python_interface.rst
