### PR TITLE
Add stable-2.13 container builds

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -59,6 +59,53 @@
 # =============================================================================
 
 - job:
+    name: ansible-runner-build-container-image-stable-2.13
+    parent: ansible-build-container-image
+    provides:
+      - ansible-runner-stable-2.13-container-image
+    requires:
+      - python-base-container-image
+      - python-builder-container-image
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.13
+    vars: &ansible_runner_image_vars_stable_2_13
+      container_images: &container_images_stable_2_13
+        - context: .
+          build_args:
+            - ANSIBLE_BRANCH=stable-2.13
+          registry: quay.io
+          repository: quay.io/ansible/ansible-runner
+          siblings:
+            - github.com/ansible/ansible
+          tags:
+            - stable-2.13-devel
+      docker_images: *container_images_stable_2_13
+
+- job:
+    name: ansible-runner-build-container-image-stable-2.13
+    parent: ansible-runner-container-image-base
+
+- job:
+    name: ansible-runner-upload-container-image-stable-2.13
+    parent: ansible-upload-container-image
+    provides:
+      - ansible-runner-stable-2.13-container-image
+    requires:
+      - python-base-container-image
+      - python-builder-container-image
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.13
+    vars: *ansible_runner_image_vars_stable_2_13
+
+- job:
+    name: ansible-runner-upload-container-image-stable-2.13
+    parent: ansible-runner-container-image-base
+
+# =============================================================================
+
+- job:
     name: ansible-runner-build-container-image-stable-2.12
     parent: ansible-build-container-image
     provides:

--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -24,3 +24,6 @@
         - ansible-runner-upload-container-image-stable-2.12:
             vars:
               upload_container_image_promote: false
+        - ansible-runner-upload-container-image-stable-2.13:
+            vars:
+              upload_container_image_promote: false

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE_NAME ?= quay.io/ansible/ansible-runner
 IMAGE_NAME_STRIPPED := $(word 1,$(subst :, ,$(IMAGE_NAME)))
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 ANSIBLE_BRANCH ?=
-ANSIBLE_VERSIONS ?= stable-2.9 stable-2.10 stable-2.11
+ANSIBLE_VERSIONS ?= stable-2.9 stable-2.10 stable-2.11 stable-2.12 stable-2.13
 PIP_NAME = ansible_runner
 VERSION := $(shell $(PYTHON) setup.py --version)
 ifeq ($(OFFICIAL),yes)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -71,6 +71,29 @@ def skipif_pre_ansible212(is_pre_ansible212):
     if is_pre_ansible212:
         pytest.skip("Valid only on Ansible 2.12+")
 
+@pytest.fixture(scope="session")
+def is_pre_ansible213():
+    try:
+        base_version = (
+            subprocess.run(
+                "python -c 'import ansible; print(ansible.__version__)'",
+                capture_output=True,
+                shell=True,
+            )
+            .stdout.strip()
+            .decode()
+        )
+        if Version(base_version) < Version("2.13"):
+            return True
+    except pkg_resources.DistributionNotFound:
+        pass
+
+
+@pytest.fixture(scope="session")
+def skipif_pre_ansible213(is_pre_ansible213):
+    if is_pre_ansible213:
+        pytest.skip("Valid only on Ansible 2.13+")
+
 
 # TODO: determine if we want to add docker / podman
 # to zuul instances in order to run these tests

--- a/tools/requirements-stable-2.13.txt
+++ b/tools/requirements-stable-2.13.txt
@@ -1,0 +1,11 @@
+ansible-core
+ncclient
+paramiko
+pyOpenSSL<20.0.0  # Transient dependency for credssp support.
+pypsrp[kerberos,credssp]
+pywinrm[kerberos,credssp]
+toml
+pexpect>=4.5
+python-daemon
+pyyaml
+six

--- a/tools/upper-constraints-stable-2.12.txt
+++ b/tools/upper-constraints-stable-2.12.txt
@@ -1,1 +1,1 @@
-ansible-core
+ansible-core<2.13

--- a/tools/upper-constraints-stable-2.13.txt
+++ b/tools/upper-constraints-stable-2.13.txt
@@ -1,0 +1,1 @@
+ansible-core<2.14


### PR DESCRIPTION
I just copied 2.12 stuff and changed it to 2.13 and verified with the changes to enable stable-2.12 so this isn't actually tested.

There's another pull request but it appears abandoned.

I'll prepare a PR for 2.14 too in case this one gets accepted.