### PR TITLE
Use `get_option` api from callback plugins

### DIFF
--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -72,7 +72,7 @@ elif IS_ADHOC:
 else:
     default_stdout_callback = 'default'
 
-DefaultCallbackModule: CallbackBase = callback_loader.get(default_stdout_callback).__class__
+DefaultCallbackModule: CallbackBase = callback_loader.get(default_stdout_callback, class_only=True)
 
 CENSORED = "the output has been hidden due to the fact that 'no_log: true' was specified for this result"
 
@@ -386,6 +386,12 @@ class CallbackModule(DefaultCallbackModule):
 
         # NOTE: Ansible doesn't generate a UUID for playbook_on_start so do it for them.
         self.playbook_uuid = str(uuid.uuid4())
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        base_config = C.config.get_configuration_definition(DefaultCallbackModule._load_name, plugin_type='callback')
+        my_config = C.config.get_configuration_definition(self._load_name, plugin_type='callback')
+        C.config.initialize_plugin_configuration_definitions('callback', self._load_name, base_config | my_config)
+        return super().set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
     @contextlib.contextmanager
     def capture_event_data(self, event, **event_data):

--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -387,11 +387,11 @@ class CallbackModule(DefaultCallbackModule):
         # NOTE: Ansible doesn't generate a UUID for playbook_on_start so do it for them.
         self.playbook_uuid = str(uuid.uuid4())
 
-    def set_options(self, task_keys=None, var_options=None, direct=None):
+    def set_options(self, *args, **kwargs):
         base_config = C.config.get_configuration_definition(DefaultCallbackModule._load_name, plugin_type='callback')
         my_config = C.config.get_configuration_definition(self._load_name, plugin_type='callback')
         C.config.initialize_plugin_configuration_definitions('callback', self._load_name, base_config | my_config)
-        return super().set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+        return super().set_options(*args, **kwargs)
 
     @contextlib.contextmanager
     def capture_event_data(self, event, **event_data):

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -439,3 +439,79 @@ def test_large_stdout_parsing_when_using_json_output(executor, playbook):  # pyl
     with executor.stdout as f:
         text = f.read()
     assert text.count('"F"') == 150
+
+
+@pytest.mark.parametrize('playbook', [
+    {'test_callback_with_options.yml': '''
+- name: Test callback plugins that use get_option
+  connection: local
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: Simple debug task
+      debug:
+        msg: "Testing callback with options"
+'''},  # noqa
+])
+@pytest.mark.parametrize('callback_config', [
+    {
+        'callback_name': 'tree',
+        'env_vars': {
+            'ANSIBLE_CALLBACKS_ENABLED': 'tree',
+            'ANSIBLE_STDOUT_CALLBACK': 'tree',
+            'ANSIBLE_CALLBACK_TREE_DIR': None,  # Will be set to tmp_path in test
+        },
+        'check_artifacts': True  # Verify tree creates artifacts
+    },
+], ids=['tree-callback'])
+def test_callback_plugins_with_get_option(tmp_path, playbook, callback_config):
+    """
+    Test that callback plugins using get_option() work correctly with awx_display.
+    """
+    private_data_dir = tmp_path / 'runner_test'
+    private_data_dir.mkdir()
+
+    inventory = 'localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"'
+
+    # Set up environment variables for the callback
+    envvars = {
+        "ANSIBLE_DEPRECATION_WARNINGS": "False",
+        "ANSIBLE_PYTHON_INTERPRETER": "auto_silent",
+    }
+
+    # Add callback-specific environment variables
+    for key, value in callback_config['env_vars'].items():
+        if value is None and key == 'ANSIBLE_CALLBACK_TREE_DIR':
+            # Set tree directory to a temp location
+            tree_dir = tmp_path / 'tree_output'
+            tree_dir.mkdir()
+            envvars[key] = str(tree_dir)
+        elif value is not None:
+            envvars[key] = value
+
+    playbook = list(playbook.values())[0]
+
+    r = init_runner(
+        private_data_dir=private_data_dir,
+        inventory=inventory,
+        envvars=envvars,
+        playbook=yaml.safe_load(playbook)
+    )
+
+    # Run the playbook
+    r.run()
+
+    # Verify the run was successful
+    assert r.status == 'successful', f"Playbook run failed with status: {r.status}"
+
+    # Verify events were captured (awx_display still works)
+    events = list(r.events)
+    assert len(events) > 0, "No events were captured"
+    assert 'playbook_on_start' in [e['event'] for e in events]
+    assert 'playbook_on_stats' in [e['event'] for e in events]
+
+    if callback_config.get('check_artifacts'):
+        # For tree callback, verify it created output files
+        tree_dir = tmp_path / 'tree_output'
+        tree_files = list(tree_dir.glob('localhost'))
+        assert len(tree_files) > 0, "Tree callback did not create expected output files"


### PR DESCRIPTION
##### SUMMARY

To load options, callback plugins can use `get_option` api.
Allow this functionality for other callback plugin.

Fixes: #1077

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_runner/display_callback/callback/awx_display.py
