### PR TITLE
Remove --ipc=host podman option

### DIFF
--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -490,7 +490,6 @@ class BaseConfig(object):
             if 'podman' in self.process_isolation_executable:
                 # container namespace stuff
                 new_args.extend(["--group-add=root"])
-                new_args.extend(["--ipc=host"])
 
             self._ensure_path_safe_to_mount(self.private_data_dir)
             # Relative paths are mounted relative to /runner/project

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -328,7 +328,7 @@ def test_containerization_settings(tmp_path, runtime, mocker):
     ]
 
     if runtime == 'podman':
-        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+        expected_command_start.extend(['--group-add=root'])
 
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -86,7 +86,7 @@ def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker)
     ]
 
     if runtime == 'podman':
-        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+        expected_command_start.extend(['--group-add=root'])
 
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -100,7 +100,7 @@ def test_prepare_run_command_with_containerization(tmp_path, runtime, mocker):
     ]
 
     if runtime == 'podman':
-        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+        expected_command_start.extend(['--group-add=root'])
 
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -96,7 +96,7 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, runtime, mo
     ]
 
     if runtime == 'podman':
-        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+        expected_command_start.extend(['--group-add=root'])
 
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),
@@ -164,7 +164,7 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, runtime, mo
     ]
 
     if runtime == 'podman':
-        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+        expected_command_start.extend(['--group-add=root'])
 
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -121,7 +121,7 @@ def test_prepare_inventory_command_with_containerization(tmp_path, runtime, mock
     ]
 
     if runtime == 'podman':
-        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+        expected_command_start.extend(['--group-add=root'])
 
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),


### PR DESCRIPTION
Fixes #984

This removes the `--ipc=host` option from the `podman` command line. This does not seem to be needed, possibly an artifact of a long-removed feature, and adds an unnecessary requirement of having an existing `/dev/mqueue`.