### PR TITLE
[2.2 backport] remove any pipe files before zip/unzipping (#1133)

### DIFF
--- a/ansible_runner/utils/streaming.py
+++ b/ansible_runner/utils/streaming.py
@@ -32,6 +32,11 @@ def stream_dir(source_directory, stream):
                             permissions |= 0xA000
                             zip_info.external_attr = permissions << 16
                             archive.writestr(zip_info, os.readlink(full_path))
+                        elif stat.S_ISFIFO(os.stat(full_path).st_mode):
+                            # skip any pipes, as python hangs when attempting
+                            # to open them.
+                            # i.e. ssh_key_data that was never cleaned up
+                            continue
                         else:
                             archive.write(
                                 os.path.join(dirpath, fname), arcname=os.path.join(relpath, fname)
@@ -81,6 +86,12 @@ def unstream_dir(stream, length, target_directory):
                 if os.path.exists(out_path):
                     if is_symlink:
                         os.remove(out_path)
+                    elif stat.S_ISFIFO(os.stat(out_path).st_mode):
+                        # remove any pipes, as python hangs when attempting
+                        # to open them.
+                        # i.e. ssh_key_data that was never cleaned up
+                        os.remove(out_path)
+                        continue
                     elif os.path.isdir(out_path):
                         # Special case, the important dirs were pre-created so don't try to chmod them
                         continue


### PR DESCRIPTION
* Write test to demonstrate job hang on pipes

* Remove any pipe files before zip/unzipping

- Prevents hangs when zipping, unzipping artifacts dir. If python attempts to open a fifo pipe, it will block indefinitely until it can read data from the pipe.

* move fifo check below symlink

Co-authored-by: Alan Rominger <arominge@redhat.com>
(cherry picked from commit 8f39752dc7e6d271bb3e3b11d507050489a9ad02)