### PR TITLE
Add 'skip_ipc_opt' API parameter to avoid --ipc=host option on podman run command

### DIFF
--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -203,7 +203,7 @@ def run(**kwargs):
     :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
                                  value is set to 'True' it will raise 'AnsibleRunnerException' exception,
                                  if set to 'False' it log a debug message and continue execution. Default value is 'False'
-    :param bool skip_ipc_opt: Disables the --ipc=host option to podman run command.
+    :param bool skip_ipc_opt: Disables the --ipc=host option to podman run command. Default value is 'False'.
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing ``rc`` if run remotely
     '''

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -203,6 +203,7 @@ def run(**kwargs):
     :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
                                  value is set to 'True' it will raise 'AnsibleRunnerException' exception,
                                  if set to 'False' it log a debug message and continue execution. Default value is 'False'
+    :param bool skip_ipc_opt: Disables the --ipc=host option to podman run command.
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing ``rc`` if run remotely
     '''

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -53,7 +53,8 @@ def test_prepare_config_invalid_action():
 
 
 @pytest.mark.test_all_runtimes
-def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker):
+@pytest.mark.parametrize("skip_ipc_opt", (False, True))
+def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker, skip_ipc_opt):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
 
@@ -61,7 +62,8 @@ def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker)
         'private_data_dir': tmp_path,
         'process_isolation': True,
         'container_image': 'my_container',
-        'process_isolation_executable': runtime
+        'process_isolation_executable': runtime,
+        'skip_ipc_opt': skip_ipc_opt,
     }
     rc = AnsibleCfgConfig(**kwargs)
     rc.ident = 'foo'
@@ -86,7 +88,9 @@ def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker)
     ]
 
     if runtime == 'podman':
-        expected_command_start.extend(['--group-add=root', '--ipc=host'])
+        expected_command_start.append('--group-add=root')
+        if not skip_ipc_opt:
+            expected_command_start.append('--ipc=host')
 
     expected_command_start.extend([
         '-v', '{}/artifacts/:/runner/artifacts/:Z'.format(rc.private_data_dir),


### PR DESCRIPTION
The `--ipc=host` option to `podman run` is added to bypass some issues accessing SSH_AUTH_SOCK on systems running SELinux. This can cause issues on systems without a `/dev/mqueue` device. We add a new API parameter called `skip_ipc_opt` that can be set to `True` to avoid using the `--ipc` option.

Fixes #984