### PR TITLE
Test both runtimes in unit tests

### DIFF
--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -288,7 +288,7 @@ def test_container_volume_mounting_with_Z(tmp_path, mocker):
         raise Exception('Could not find expected mount, args: {}'.format(new_args))
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_containerization_settings(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
@@ -346,7 +346,7 @@ def test_containerization_settings(tmp_path, runtime, mocker):
     assert expected_command_start == rc.command
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
     mock_containerized = mocker.patch('ansible_runner.config._base.BaseConfig.containerized', new_callable=mocker.PropertyMock)
 

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -52,7 +52,7 @@ def test_prepare_config_invalid_action():
     assert "Invalid action test, valid value is one of either list, dump, view" == exc.value.args[0]
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -61,7 +61,7 @@ def test_prepare_run_command_generic():
     assert rc.execution_mode == BaseExecutionMode.GENERIC_COMMANDS
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_prepare_run_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -58,7 +58,7 @@ def test_prepare_plugin_docs_command():
     assert rc.execution_mode == BaseExecutionMode.ANSIBLE_COMMANDS
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_prepare_plugin_docs_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()
@@ -129,7 +129,7 @@ def test_prepare_plugin_list_command():
     assert rc.execution_mode == BaseExecutionMode.ANSIBLE_COMMANDS
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_prepare_plugin_list_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -84,7 +84,7 @@ def test_prepare_inventory_invalid_graph_response_format():
     assert "'graph' action supports only 'json' response format" == exc.value.args[0]
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_prepare_inventory_command_with_containerization(tmp_path, runtime, mocker):
     mocker.patch.dict('os.environ', {'HOME': str(tmp_path)}, clear=True)
     tmp_path.joinpath('.ssh').mkdir()

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -710,7 +710,7 @@ def test_container_volume_mounting_with_Z(mocker, tmp_path):
         raise Exception('Could not find expected mount, args: {}'.format(new_args))
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_containerization_settings(tmp_path, runtime, mocker):
     mocker.patch('os.path.isdir', return_value=True)
     mocker.patch('os.path.exists', return_value=True)

--- a/test/unit/test_cleanup.py
+++ b/test/unit/test_cleanup.py
@@ -47,7 +47,7 @@ def test_cleanup_command_grace_period(tmp_path):
     assert os.path.exists(new_dir)
 
 
-@pytest.mark.test_all_runtimes
+@pytest.mark.parametrize('runtime', ('docker', 'podman'))
 def test_registry_auth_cleanup(tmp_path, runtime):
     pdd_path = tmp_path / 'private_data_dir'
     pdd_path.mkdir()


### PR DESCRIPTION
Unit tests do not need a runtime (docker or podman) actually installed to test code paths that depend on the runtime. The `@pytest.mark.test_all_runtimes` fixture checks for installed runtimes. Change this to just parametrize the runtime name.

Fixes #1153 