### PR TITLE
Fix bugs in streaming code you hit if using more than 1 inventory

### DIFF
--- a/ansible_runner/config/runner.py
+++ b/ansible_runner/config/runner.py
@@ -31,7 +31,7 @@ from ansible_runner import output
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.output import debug
-from ansible_runner.utils import register_for_cleanup
+from ansible_runner.utils import register_for_cleanup, get_relative_inventory_path
 
 
 logger = logging.getLogger('ansible-runner')
@@ -160,13 +160,12 @@ class RunnerConfig(BaseConfig):
         """
         Prepares the inventory default under ``private_data_dir`` if it's not overridden by the constructor.
         """
-        if self.containerized:
-            self.inventory = '/runner/inventory/hosts'
-            return
-
         if self.inventory is None:
             if os.path.exists(os.path.join(self.private_data_dir, "inventory")):
                 self.inventory = os.path.join(self.private_data_dir, "inventory")
+
+        if self.containerized:
+            self.inventory = get_relative_inventory_path(self.inventory, self.private_data_dir, new_base='/runner')
 
     def prepare_env(self):
         """

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -64,9 +64,16 @@ def init_runner(**kwargs):
         if os.path.isabs(playbook_path) and playbook_path.startswith(project_dir):
             kwargs['playbook'] = os.path.relpath(playbook_path, project_dir)
 
-        inventory_path = kwargs.get('inventory') or ''
-        if os.path.isabs(inventory_path) and inventory_path.startswith(private_data_dir):
-            kwargs['inventory'] = os.path.relpath(inventory_path, private_data_dir)
+        inventory = kwargs.get('inventory') or ''
+        if isinstance(inventory, list):
+            new_inventory = []
+            for inventory_path in inventory:
+                if os.path.isabs(inventory_path) and inventory_path.startswith(private_data_dir):
+                    new_inventory.append(os.path.relpath(inventory_path, private_data_dir))
+            kwargs['inventory'] = new_inventory
+        else:
+            if os.path.isabs(inventory) and inventory.startswith(private_data_dir):
+                kwargs['inventory'] = os.path.relpath(inventory_path, private_data_dir)
 
         roles_path = kwargs.get('envvars', {}).get('ANSIBLE_ROLES_PATH') or ''
         if os.path.isabs(roles_path) and roles_path.startswith(private_data_dir):

--- a/ansible_runner/interface.py
+++ b/ansible_runner/interface.py
@@ -36,6 +36,7 @@ from ansible_runner.utils import (
     check_isolation_executable_installed,
     sanitize_json_response,
     signal_handler,
+    get_relative_inventory_path
 )
 
 logging.getLogger('ansible-runner').addHandler(logging.NullHandler())
@@ -64,16 +65,8 @@ def init_runner(**kwargs):
         if os.path.isabs(playbook_path) and playbook_path.startswith(project_dir):
             kwargs['playbook'] = os.path.relpath(playbook_path, project_dir)
 
-        inventory = kwargs.get('inventory') or ''
-        if isinstance(inventory, list):
-            new_inventory = []
-            for inventory_path in inventory:
-                if os.path.isabs(inventory_path) and inventory_path.startswith(private_data_dir):
-                    new_inventory.append(os.path.relpath(inventory_path, private_data_dir))
-            kwargs['inventory'] = new_inventory
-        else:
-            if os.path.isabs(inventory) and inventory.startswith(private_data_dir):
-                kwargs['inventory'] = os.path.relpath(inventory_path, private_data_dir)
+        if kwargs.get('inventory'):
+            kwargs['inventory'] = get_relative_inventory_path(kwargs['inventory'], private_data_dir)
 
         roles_path = kwargs.get('envvars', {}).get('ANSIBLE_ROLES_PATH') or ''
         if os.path.isabs(roles_path) and roles_path.startswith(private_data_dir):

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -88,7 +88,12 @@ class Worker(object):
                 roles_dir = os.path.join(self.private_data_dir, 'roles')
                 kwargs['envvars']['ANSIBLE_ROLES_PATH'] = os.path.join(roles_dir, roles_path)
         if kwargs.get('inventory'):
-            kwargs['inventory'] = os.path.join(self.private_data_dir, kwargs['inventory'])
+            if isinstance(kwargs['inventory'], list):
+                kwargs['inventory'] = [
+                    os.path.join(self.private_data_dir, inventory_path) for inventory_path in kwargs['inventory']
+                ]
+            else:
+                kwargs['inventory'] = os.path.join(self.private_data_dir, kwargs['inventory'])
 
         return kwargs
 

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -474,7 +474,7 @@ def get_relative_inventory_path(inventory, private_data_dir, new_base=''):
             else:
                 new_inventory.append(inventory_path)
         return new_inventory
-    else:
+    elif isinstance(inventory, string_types):
         if os.path.isabs(inventory) and inventory.startswith(private_data_dir):
             return os.path.join(new_base, os.path.relpath(inventory, private_data_dir))
     return inventory

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -463,6 +463,23 @@ def sanitize_container_name(original_name):
     return re.sub('[^a-zA-Z0-9_-]', '_', text_type(original_name))
 
 
+def get_relative_inventory_path(inventory, private_data_dir, new_base=''):
+    if isinstance(inventory, list):
+        new_inventory = []
+        for inventory_path in inventory:
+            if os.path.isabs(inventory_path) and inventory_path.startswith(private_data_dir):
+                new_inventory.append(
+                    os.path.join(new_base, os.path.relpath(inventory_path, private_data_dir))
+                )
+            else:
+                new_inventory.append(inventory_path)
+        return new_inventory
+    else:
+        if os.path.isabs(inventory) and inventory.startswith(private_data_dir):
+            return os.path.join(new_base, os.path.relpath(inventory_path, private_data_dir))
+    return inventory
+
+
 def cli_mounts():
     return [
         {

--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -476,7 +476,7 @@ def get_relative_inventory_path(inventory, private_data_dir, new_base=''):
         return new_inventory
     else:
         if os.path.isabs(inventory) and inventory.startswith(private_data_dir):
-            return os.path.join(new_base, os.path.relpath(inventory_path, private_data_dir))
+            return os.path.join(new_base, os.path.relpath(inventory, private_data_dir))
     return inventory
 
 


### PR DESCRIPTION
Generally, ansible-runner will take a lot of different things from the `inventory` parameter.

 - A dict, which is the outright definition of an inventory
 - A list of strings that don't exist as files or folders, being an alternative definition of an inventory
 - A list of paths to inventory sources
 - A single string that is a path to an inventory source

If you look at what we're doing in several of this places, we obviously abandon support for all but the last of these formats. In containerized jobs, we don't support that either, less the inventory file is named "hosts" in the inventory folder... which may be the same as not providing the parameter in the first place.

This adds just enough support for those other cases to allow me to get it working with a list of inventory files.