### PR TITLE
Fix Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create tox environment
         run: tox --notest
@@ -61,17 +61,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Python ${{ matrix.py_version.name }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.py_version.name }}
 
       - name: Install tox
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install tox
+          python3 -m pip install "tox<4.0.0"
 
       - name: Create tox environment
         run: |
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create tox environment
         run: tox --notest


### PR DESCRIPTION
- Limits the version of `tox` to `<4.0.0`. Recent major update of tox is breaking our CI, so this limits it to a working version until we can adjust for a newer tox later.
- Updates the `checkout` action to `v3`: This doesn't fix the breakage, but is an update to the CI that has been needed for a while to eliminate warnings about deprecated actions.
- Updates the `setup-python` action to `v4`.