### PR TITLE
Docs: Use the Ansible Sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    "sphinx_ansible_theme",
     'pbr.sphinxext',
 ]
 
@@ -83,13 +84,18 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_ansible_theme'
+html_title = "Ansible Runner Documentation"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'display_version': False,
+    'titles_only': False,
+    'documentation_home_url': 'https://ansible-runner.readthedocs.io/en/stable/',
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer==2.0.7
 cryptography==35.0.0
 docutils==0.17.1
 idna==3.3
-imagesize==1.2.0
+imagesize==1.3.0
 Jinja2==3.0.2
 MarkupSafe==2.0.1
 packaging==21.0
@@ -15,7 +15,7 @@ pbr==5.6.0
 pexpect==4.8.0
 ptyprocess==0.7.0
 pycparser==2.20
-Pygments==2.10.0
+Pygments==2.12.0
 pyparsing==3.0.1
 pytz==2021.3
 PyYAML==6.0
@@ -23,11 +23,12 @@ requests==2.26.0
 resolvelib==0.5.5
 six==1.16.0
 snowballstemmer==2.1.0
-Sphinx==4.2.0
+Sphinx==5.3.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
+sphinx-ansible-theme == 0.10.1
 urllib3==1.26.7


### PR DESCRIPTION
This PR updates the Sphinx configuration to use the Ansible theme.

The Ansible community team recently updated the docsite and included Runner on the new [ecosystem](https://docs.ansible.com/ecosystem.html) page. We're working to create a more cohesive user experience for the Ansible community and noticed that this project could start using the Ansible Sphinx theme with a pretty straightforward change.

I did bump some of the other requirements and the Sphinx version. Everything seems fine when I build locally, including the API docs.