### PR TITLE
[backport][release_2.2] Fix artifact file permissions

### DIFF
--- a/ansible_runner/utils/__init__.py
+++ b/ansible_runner/utils/__init__.py
@@ -162,7 +162,7 @@ def dump_artifact(obj, path, filename=None):
 
         try:
             with open(fn, 'w') as f:
-                os.chmod(fn, stat.S_IRUSR)
+                os.chmod(fn, stat.S_IRUSR | stat.S_IWUSR)
                 f.write(str(obj))
         finally:
             fcntl.lockf(lock_fd, fcntl.LOCK_UN)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,12 @@
+import os
+import stat
+
+from ansible_runner.utils import dump_artifact
+
+
+def test_artifact_permissions(tmp_path):
+    """Artifacts should allow user read/write"""
+    filename = dump_artifact("artifact content", str(tmp_path))
+    file_mode = stat.S_IMODE(os.stat(filename).st_mode)
+    user_rw = stat.S_IRUSR | stat.S_IWUSR
+    assert (user_rw & file_mode) == user_rw, "file mode is incorrect"


### PR DESCRIPTION
* Fix artifact file permissions (#702, #853)

Sets artifact file permissions to octal `600` in
`ansible_runner.utils.dump_artifact`

Backport of PR #1183 

(cherry picked from commit a4a981d67c7e4f4209381c6fedbb7f1fa4942098)