### PR TITLE
Give more detail when we cannot process a non-JSON streamed line

### DIFF
--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -244,8 +244,13 @@ class Processor(object):
             try:
                 line = self._input.readline()
                 data = json.loads(line)
-            except (json.decoder.JSONDecodeError, IOError):
-                self.status_callback({'status': 'error', 'job_explanation': 'Failed to JSON parse a line from worker stream.'})
+            except (json.decoder.JSONDecodeError, IOError) as exc:
+                self.status_callback({
+                    'status': 'error',
+                    'job_explanation': (
+                        f'Failed to JSON parse a line from worker stream. Error: {exc} Line with invalid JSON data: {line[:1000]}'
+                    )
+                })
                 break
 
             if 'status' in data:


### PR DESCRIPTION
The error handling for this in AWX has been really unforgivably bad. This abuses `result_traceback` somewhat, but this practice already existed in AWX. More information is better than less, is the main idea I'm following here.