### PR TITLE
Emit periodic keepalive events from `Worker`

### DIFF
--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -614,7 +614,7 @@ def main(sys_args=None):
     worker_subparser.add_argument(
         "--keepalive-seconds",
         dest="keepalive_seconds",
-        default=0,
+        default=None,
         type=int,
         help=(
             "Emit a synthetic keepalive event every N seconds of idle. (default=0, disabled)"

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -897,3 +897,7 @@ def main(sys_args=None):
             return 0
         except OSError:
             return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -611,6 +611,15 @@ def main(sys_args=None):
             "Using this will also assure that the directory is deleted when the job finishes."
         )
     )
+    worker_subparser.add_argument(
+        "--keepalive-seconds",
+        dest="keepalive_seconds",
+        default=0,
+        type=int,
+        help=(
+            "Emit a synthetic keepalive event every N seconds of idle. (default=0, disabled)"
+        )
+    )
     process_subparser = subparser.add_parser(
         'process',
         help="Receive the output of remote ansible-runner work and distribute the results"
@@ -859,6 +868,7 @@ def main(sys_args=None):
                                    limit=vargs.get('limit'),
                                    streamer=streamer,
                                    suppress_env_files=vargs.get("suppress_env_files"),
+                                   keepalive_seconds=vargs.get("keepalive_seconds"),
                                    )
                 try:
                     res = run(**run_options)

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -67,7 +67,7 @@ class BaseConfig(object):
                  process_isolation=False, process_isolation_executable=None,
                  container_image=None, container_volume_mounts=None, container_options=None, container_workdir=None, container_auth_data=None,
                  ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False,
-                 check_job_event_data=False, suppress_env_files=False):
+                 check_job_event_data=False, suppress_env_files=False, keepalive_seconds=None):
         # common params
         self.host_cwd = host_cwd
         self.envvars = envvars
@@ -95,6 +95,8 @@ class BaseConfig(object):
         self.timeout = timeout
         self.check_job_event_data = check_job_event_data
         self.suppress_env_files = suppress_env_files
+        # ignore this for now since it's worker-specific and would just trip up old runners
+        # self.keepalive_seconds = keepalive_seconds
 
         # setup initial environment
         if private_data_dir:

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -67,7 +67,7 @@ class BaseConfig(object):
                  process_isolation=False, process_isolation_executable=None,
                  container_image=None, container_volume_mounts=None, container_options=None, container_workdir=None, container_auth_data=None,
                  ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False,
-                 check_job_event_data=False, suppress_env_files=False):
+                 check_job_event_data=False, suppress_env_files=False, keepalive_seconds=0):
         # common params
         self.host_cwd = host_cwd
         self.envvars = envvars
@@ -95,6 +95,7 @@ class BaseConfig(object):
         self.timeout = timeout
         self.check_job_event_data = check_job_event_data
         self.suppress_env_files = suppress_env_files
+        self.keepalive_seconds = keepalive_seconds
 
         # setup initial environment
         if private_data_dir:

--- a/ansible_runner/config/_base.py
+++ b/ansible_runner/config/_base.py
@@ -67,7 +67,7 @@ class BaseConfig(object):
                  process_isolation=False, process_isolation_executable=None,
                  container_image=None, container_volume_mounts=None, container_options=None, container_workdir=None, container_auth_data=None,
                  ident=None, rotate_artifacts=0, timeout=None, ssh_key=None, quiet=False, json_mode=False,
-                 check_job_event_data=False, suppress_env_files=False, keepalive_seconds=0):
+                 check_job_event_data=False, suppress_env_files=False):
         # common params
         self.host_cwd = host_cwd
         self.envvars = envvars
@@ -95,7 +95,6 @@ class BaseConfig(object):
         self.timeout = timeout
         self.check_job_event_data = check_job_event_data
         self.suppress_env_files = suppress_env_files
-        self.keepalive_seconds = keepalive_seconds
 
         # setup initial environment
         if private_data_dir:

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 import uuid
 import traceback
-from builtins import ValueError
 
 import ansible_runner
 from ansible_runner.exceptions import ConfigurationError

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -65,7 +65,7 @@ class Transmitter(object):
 
 
 class Worker:
-    def __init__(self, _input=None, _output=None, keepalive_seconds: int | None = None, **kwargs):
+    def __init__(self, _input=None, _output=None, keepalive_seconds: float | None = None, **kwargs):
         if _input is None:
             _input = sys.stdin.buffer
         if _output is None:
@@ -73,7 +73,7 @@ class Worker:
 
         if keepalive_seconds is None:  # if we didn't get an explicit int value, fall back to envvar
             # FIXME: emit/log a warning and silently continue if this value won't parse
-            keepalive_seconds = int(os.environ.get('ANSIBLE_RUNNER_KEEPALIVE_SECONDS', 0))
+            keepalive_seconds = float(os.environ.get('ANSIBLE_RUNNER_KEEPALIVE_SECONDS', 0))
 
         self._keepalive_interval_sec = keepalive_seconds
         self._keepalive_thread: Thread | None = None

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -337,9 +337,9 @@ class Processor(object):
                 self.artifacts_callback(data)
             elif 'eof' in data:
                 break
-            # FIXME: add a short-circuit here to minimize the overhead of keepalives?
-            # elif data.get('event') == 'keepalive':
-            #     continue
+            elif data.get('event') == 'keepalive':
+                # just ignore keepalives
+                continue
             else:
                 self.event_callback(data)
 

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -92,7 +92,7 @@ class Worker:
     def _begin_keepalive(self):
         """Starts a keepalive thread at most once"""
         if not self._keepalive_thread:
-            self._keepalive_thread = Thread(target=self._keepalive_loop)
+            self._keepalive_thread = Thread(target=self._keepalive_loop, daemon=True)
             self._keepalive_thread.start()
 
     def _end_keepalive(self):

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -293,10 +293,17 @@ class Processor(object):
 
     def event_callback(self, event_data):
         # FIXME: this needs to be more defensive to not blow up on "malformed" events or new values it doesn't recognize
+        counter = event_data.get('counter')
+        uuid = event_data.get('uuid')
+
+        if not counter or not uuid:
+            # FIXME: log a warning about a malformed event?
+            return
+
         full_filename = os.path.join(self.artifact_dir,
                                      'job_events',
-                                     '{}-{}.json'.format(event_data['counter'],
-                                                         event_data['uuid']))
+                                     f'{counter}-{uuid}.json')
+
         if not self.quiet and 'stdout' in event_data:
             print(event_data['stdout'])
 

--- a/ansible_runner/streaming.py
+++ b/ansible_runner/streaming.py
@@ -224,6 +224,7 @@ class Worker:
 
     @_synchronize_output_reset_keepalive
     def finished_callback(self, runner_obj):
+        self._end_keepalive()  # ensure that we can't splat a keepalive event after the eof event
         self._output.write(json.dumps({'eof': True}).encode('utf-8'))
         self._output.write(b'\n')
         self._output.flush()

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -178,7 +178,7 @@ class TestStreamingUsage:
                     if pending_payload_length:
                         # decode and check length to validate that we didn't trash the payload
                         # zap the mashed eof message from the end if present
-                        line = line.removesuffix('{"eof": true}')
+                        line = line.rsplit('{"eof": true}', 1)[0]  # FUTURE: change this to removesuffix for 3.9+
                         assert pending_payload_length == len(base64.b64decode(line))
                         pending_payload_length = 0  # back to normal
                         continue

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -107,10 +107,10 @@ class TestStreamingUsage:
         self.check_artifacts(str(process_dir), job_type)
 
     @pytest.mark.parametrize("keepalive_setting", [
-        0, # keepalive explicitly disabled, default
-        1, # emit keepalives every 1s
-        0.000000001, # emit keepalives on a ridiculously small interval to test for output corruption
-        None, # default disable, test sets envvar for keepalives
+        0,  # keepalive explicitly disabled, default
+        1,  # emit keepalives every 1s
+        0.000000001,  # emit keepalives on a ridiculously small interval to test for output corruption
+        None,  # default disable, test sets envvar for keepalives
     ])
     def test_keepalive_setting(self, tmp_path, project_fixtures, keepalive_setting):
         verbosity = None

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -158,7 +158,8 @@ class TestStreamingUsage:
         if keepalive_setting == 0:
             assert incoming_data.count('"event": "keepalive"') == 0
         else:
-            assert incoming_data.count('"event": "keepalive"') in (1, 2)
+            # account for some wobble in the number of keepalives for artifact gather, etc
+            assert 1 <= incoming_data.count('"event": "keepalive"') < 5
 
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
     def test_remote_job_by_sockets(self, tmp_path, project_fixtures, job_type):

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -177,6 +177,8 @@ class TestStreamingUsage:
                 for line in incoming_data.splitlines():
                     if pending_payload_length:
                         # decode and check length to validate that we didn't trash the payload
+                        # zap the mashed eof message from the end if present
+                        line = line.removesuffix('{"eof": true}')
                         assert pending_payload_length == len(base64.b64decode(line))
                         pending_payload_length = 0  # back to normal
                         continue


### PR DESCRIPTION
fixes #1187

This approach is less "fancy" than some others, but also doesn't require yet another interposing output handle.

Open issues:
- [x] short-circuit handling: Ideally there'd be a short-circuit in the `Process` layer for this, or any other "malformed"/bogus event, but as-is, `Process` will bomb out with a KeyError on any dictionary missing `uuid` or `counter`. Ideally, these keepalives could be as simple as a newline, dot, or `{}`, but unless/until we can be sure that an older `Process` isn't going to barf on them, we have to have a larger payload to keep it happy.

- [x] other consumers: In cases where the event actually gets persisted by `Process`, will anything else be upset by the empty `0-0.json` event it writes as? (_EDIT_: consensus was to go for a "fail-fast" approach instead)

- [x] unit tests: there are a number of potential output corruption races this attempts to prevent, but simulating them with unit tests to ensure they stay "prevented" would probably be a Good Thing. (_EDIT_: added crazy way-subsecond keepalive tests to try and flush out problems and races here)

- [x] tests: Don't want to gold-plate this until  we're sure we like this approach. Also, the transmit/worker/process tests need some refactoring to be able to introduce delays so the keepalives have a chance to fire, and also to ensure that they don't fire when they're not supposed to. 

This specifically is *not* trying to solve the generic "I want to do periodic random stuff in runner" issue- it seems like that would be better handled in a future asyncio layer where such things are trivial to do without extra threading overhead. 