### PR TITLE
Bump cryptography from 35.0.0 to 39.0.1 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ babel==2.9.1
 certifi==2022.12.7
 cffi==1.15.0
 charset-normalizer==2.0.7
-cryptography==35.0.0
+cryptography==39.0.1
 docutils==0.17.1
 idna==3.3
 imagesize==1.3.0


### PR DESCRIPTION
##### SUMMARY

Bumps cryptography from 35.0.0 to 39.0.1

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docs/requirements.txt
