### PR TITLE
Differentiate timeout vs idle timeout

### DIFF
--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -35,6 +35,7 @@ class Runner(object):
         self.status_handler = status_handler
         self.canceled = False
         self.timed_out = False
+        self.idle_timed_out = False
         self.errored = False
         self.status = "unstarted"
         self.rc = None
@@ -337,7 +338,7 @@ class Runner(object):
                 if self.config.idle_timeout and (time.time() - self.last_stdout_update) > self.config.idle_timeout:
                     self.kill_container()
                     Runner.handle_termination(child.pid, is_cancel=False)
-                    self.timed_out = True
+                    self.idle_timed_out = True
 
             stdout_handle.close()
             stderr_handle.close()
@@ -350,6 +351,8 @@ class Runner(object):
             self.status_callback('successful')
         elif self.timed_out:
             self.status_callback('timeout')
+        elif self.idle_timed_out:
+            self.status_callback('idle_timeout')
         else:
             self.status_callback('failed')
 

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -110,7 +110,7 @@ def test_run_command_idle_timeout(rc):
     rc.idle_timeout = 0.0000001
     runner = Runner(config=rc)
     status, exitcode = runner.run()
-    assert status == 'timeout'
+    assert status == 'idle_timeout'
     assert exitcode == 254
 
 


### PR DESCRIPTION
currently idle timeout and timeout result in the same status call back this result in the AWX not being able to parse the differences between the two failure condition and make it confusing to debug

