### PR TITLE
[release_2.3] Add `python_requires = >= 3.8`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ description_file = README.md
 description_content_type = text/markdown
 license_file = LICENSE.md
 
+[options]
+python_requires = >=3.8
+
 [entry_points]
 console_scripts =
     ansible-runner = ansible_runner.__main__:main


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible-runner/issues/1205