### PR TITLE
[backport][release_2.3] Add `python_requires = >= 3.8` (#1206)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ description_file = README.md
 description_content_type = text/markdown
 license_file = LICENSE.md
 
+[options]
+python_requires = >=3.8
+
 [entry_points]
 console_scripts =
     ansible-runner = ansible_runner.__main__:main


### PR DESCRIPTION
Backport of PR #1206 

(cherry picked from commit 69e8c1ae5a5660294b7cb8aea63e05c470fdb244)