### PR TITLE
Remove pkg_resources use

### DIFF
--- a/ansible_runner/__init__.py
+++ b/ansible_runner/__init__.py
@@ -1,5 +1,4 @@
-import pkg_resources
-
+from .utils.importlib_compat import importlib_metadata
 from .interface import run, run_async, \
                         run_command, run_command_async, \
                         get_plugin_docs, get_plugin_docs_async, get_plugin_list, \
@@ -13,5 +12,5 @@ from .runner import Runner # noqa
 plugins = {
     entry_point.name: entry_point.load()
     for entry_point
-    in pkg_resources.iter_entry_points('ansible_runner.plugins')
+    in importlib_metadata.entry_points(group='ansible_runner.plugins')
 }

--- a/ansible_runner/__main__.py
+++ b/ansible_runner/__main__.py
@@ -17,7 +17,6 @@
 # under the License.
 #
 import ast
-import pkg_resources
 import threading
 import traceback
 import argparse
@@ -42,10 +41,11 @@ from ansible_runner import output
 from ansible_runner import cleanup
 from ansible_runner.utils import dump_artifact, Bunch, register_for_cleanup
 from ansible_runner.utils.capacity import get_cpu_count, get_mem_in_bytes, ensure_uuid
+from ansible_runner.utils.importlib_compat import importlib_metadata
 from ansible_runner.runner import Runner
 from ansible_runner.exceptions import AnsibleRunnerException
 
-VERSION = pkg_resources.require("ansible_runner")[0].version
+VERSION = importlib_metadata.version("ansible_runner")
 
 DEFAULT_ROLES_PATH = os.getenv('ANSIBLE_ROLES_PATH', None)
 DEFAULT_RUNNER_BINARY = os.getenv('RUNNER_BINARY', None)

--- a/ansible_runner/utils/importlib_compat.py
+++ b/ansible_runner/utils/importlib_compat.py
@@ -1,0 +1,6 @@
+import sys
+
+if sys.version_info < (3, 10):
+    import importlib_metadata  # noqa: F401
+else:
+    import importlib.metadata as importlib_metadata  # noqa: F401

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ packaging
 python-daemon
 pyyaml
 six
+importlib-metadata; python_version < "3.10.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ packaging
 python-daemon
 pyyaml
 six
-importlib-metadata; python_version < "3.10.0"
+importlib-metadata >= 4.6, < 4.7; python_version < '3.10'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,11 +2,10 @@ import shutil
 
 from pathlib import Path
 from packaging.version import Version
-import subprocess
 
 from ansible_runner import defaults
+from ansible_runner.utils.importlib_compat import importlib_metadata
 
-import pkg_resources
 import pytest
 
 
@@ -35,9 +34,9 @@ def is_pre_ansible211():
     """
 
     try:
-        if pkg_resources.get_distribution('ansible-core').version:
+        if importlib_metadata.version("ansible-core"):
             return False
-    except pkg_resources.DistributionNotFound:
+    except importlib_metadata.PackageNotFoundError:
         # Must be ansible-base or ansible
         return True
 
@@ -51,18 +50,10 @@ def skipif_pre_ansible211(is_pre_ansible211):
 @pytest.fixture(scope="session")
 def is_pre_ansible212():
     try:
-        base_version = (
-            subprocess.run(
-                "python -c 'import ansible; print(ansible.__version__)'",
-                capture_output=True,
-                shell=True,
-            )
-            .stdout.strip()
-            .decode()
-        )
+        base_version = importlib_metadata.version("ansible")
         if Version(base_version) < Version("2.12"):
             return True
-    except pkg_resources.DistributionNotFound:
+    except importlib_metadata.PackageNotFoundError:
         pass
 
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,3 +6,4 @@ pytest-xdist
 flake8==4.0.1
 yamllint
 cryptography
+importlib-metadata >= 4.6, < 4.7; python_version < '3.10'


### PR DESCRIPTION
##### SUMMARY

* pkg_resources is deprecated in favor of importlib.metadata

Fixes: #1223

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_runner/__init__.py
ansible_runner/__main__.py
ansible_runner/utils/importlib_compat.py
