### PR TITLE
expand importlib-metadata version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ packaging
 python-daemon
 pyyaml
 six
-importlib-metadata >= 4.6, < 4.7; python_version < '3.10'
+importlib-metadata >= 4.6, < 6.3; python_version < '3.10' # enable `groups` arg to entry_points missing in 3.9 stdlib importlib.metadata


### PR DESCRIPTION
* only applicable to Python 3.9; minimizes downstream packaging conflicts
* verified compatible behavior through 6.2.0
* will need a backport to `release_2.3` branch