### PR TITLE
remove redundant/conflicting test requirement

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,4 +6,3 @@ pytest-xdist
 flake8==4.0.1
 yamllint
 cryptography
-importlib-metadata >= 4.6, < 4.7; python_version < '3.10'


### PR DESCRIPTION
(noticed during #1230 on release_2.3, which already contains this change)