### PR TITLE
Added more information about tasks to event_data #1227

### DIFF
--- a/ansible_runner/display_callback/callback/awx_display.py
+++ b/ansible_runner/display_callback/callback/awx_display.py
@@ -409,6 +409,7 @@ class CallbackModule(DefaultCallbackModule):
             task=(task.name or task.action),
             task_uuid=str(task._uuid),
             task_action=task.action,
+            task_check_mode=task.check_mode,
             resolved_action=getattr(task, 'resolved_action', task.action),
             task_args='',
         )


### PR DESCRIPTION
Hi!! I have updated /ansible_runner/display_callback/callback/awx_display.py. Added more information about tasks to event_data as you have mentioned. 

`        task_ctx = dict(
            task=(task.name or task.action),
            task_uuid=str(task._uuid),
            task_action=task.action,
            task_check_mode=task.check_mode,
            resolved_action=getattr(task, 'resolved_action', task.action),
            task_args='',
        )
`

Please review this PR and merge it. If any changes still required please do let me know.

Thanks!
#1227 