### PR TITLE
Ensure that UTC ISO8601 datetimes include timezone info

### DIFF
--- a/ansible_runner/display_callback/callback/awx_display.py
+++ b/ansible_runner/display_callback/callback/awx_display.py
@@ -67,7 +67,7 @@ CENSORED = "the output has been hidden due to the fact that 'no_log: true' was s
 
 
 def current_time():
-    return datetime.datetime.utcnow()
+    return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
 
 
 # use a custom JSON serializer so we can properly handle !unsafe and !vault
@@ -198,7 +198,7 @@ class EventContext(object):
             event_dict['project_update_id'] = int(os.getenv('PROJECT_UPDATE_ID', '0'))
         event_dict['pid'] = event_data.get('pid', os.getpid())
         event_dict['uuid'] = event_data.get('uuid', str(uuid.uuid4()))
-        event_dict['created'] = event_data.get('created', datetime.datetime.utcnow().isoformat())
+        event_dict['created'] = event_data.get('created', current_time().isoformat())
         if not event_data.get('parent_uuid', None):
             for key in ('task_uuid', 'play_uuid', 'playbook_uuid'):
                 parent_uuid = event_data.get(key, None)

--- a/ansible_runner/runner.py
+++ b/ansible_runner/runner.py
@@ -80,7 +80,7 @@ class Runner(object):
 
                 # prefer 'created' from partial data, but verbose events set time here
                 if 'created' not in event_data:
-                    event_data['created'] = datetime.datetime.utcnow().isoformat()
+                    event_data['created'] = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
 
                 if self.event_handler is not None:
                     should_write = self.event_handler(event_data)

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import codecs
+import datetime
 import os
 
 import json
@@ -80,6 +81,7 @@ def test_verbose_event_created_time(rc):
     assert exitcode == 0
     for event in runner.events:
         assert 'created' in event, event
+        assert datetime.datetime.fromisoformat(event['created']).tzinfo == datetime.timezone.utc
 
 
 @pytest.mark.parametrize('value', ['abc123', six.u('Iñtërnâtiônàlizætiøn')])


### PR DESCRIPTION
This PR modifies UTC datetime generation to always include a `datetime.timezone.utc` `tzinfo`, which ensures that datetimes emitted by runner are correctly indicated to be UTC.

ISO8601 states that missing timezone info indicates localtime, and not UTC.

This should not impact AWX, as the code already defensively corrects this issue:

https://github.com/ansible/awx/blob/2ce9440bab6f14c0eb2f1b85206f1f92dc88fe0d/awx/main/models/events.py#L416-L427