### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,17 @@ on:
 jobs:
   sanity:
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-20.04
-    container:
-      image: quay.io/ansible/ansible-runner-test-container:2.0.0
-      env:
-        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
-        PY_COLORS: 1
-        TOXENV: ${{ matrix.test.tox_env }}
+    runs-on: ubuntu-22.04
+    env:
+      TOXENV: ${{ matrix.test.tox_env }}
+      PY_COLORS: 1
 
     strategy:
       fail-fast: false
       matrix:
         test:
           - name: Lint
-            tox_env: linters
+            tox_env: linters-py310
 
           - name: Docs
             tox_env: docs
@@ -29,6 +26,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "tox==4.5.0"
 
       - name: Create tox environment
         run: tox --notest
@@ -38,7 +40,7 @@ jobs:
 
 
   integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Integration - ${{ matrix.py_version.name }}
 
     env:
@@ -61,7 +63,6 @@ jobs:
           - name: '3.11'
             tox_env: integration-py311
 
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -74,7 +75,7 @@ jobs:
       - name: Install tox
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "tox<4.0.0" build
+          python3 -m pip install "tox==4.5.0" build
 
       - name: Prepare runner test container
         run: |
@@ -96,21 +97,18 @@ jobs:
           RUNNER_TEST_IMAGE_NAME=ansible-runner-gha${{ github.run_id }}-event-test tox
 
       - name: Upload coverage report
-        run: |
-          curl --silent --show-error --output codecov https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/linux/codecov
-          chmod +x codecov
-          ./codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: test/coverage/reports/coverage.xml
+          flags: ${{ matrix.py_version.tox_env }}
 
 
   unit:
     name: Unit - ${{ matrix.py_version.name}}
-    runs-on: ubuntu-20.04
-    container:
-      image: quay.io/ansible/ansible-runner-test-container:2.0.0
-      env:
-        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
-        TOXENV: ${{ matrix.py_version.tox_env }}
-        PY_COLORS: 1
+    runs-on: ubuntu-22.04
+    env:
+      TOXENV: ${{ matrix.py_version.tox_env }}
+      PY_COLORS: 1
 
     strategy:
       fail-fast: false
@@ -125,9 +123,22 @@ jobs:
           - name: '3.10'
             tox_env: unit-py310
 
+          - name: '3.11'
+            tox_env: unit-py311
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Install Python ${{ matrix.py_version.name }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.py_version.name }}
+
+      - name: Install tox
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install "tox==4.5.0"
 
       - name: Create tox environment
         run: tox --notest
@@ -136,4 +147,7 @@ jobs:
         run: tox
 
       - name: Upload coverage report
-        run: codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: test/coverage/reports/coverage.xml
+          flags: ${{ matrix.py_version.tox_env }}

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -327,6 +327,9 @@ def test_containerization_settings(tmp_path, runtime, mocker):
         '-v', '{}/.ssh/:/root/.ssh/'.format(str(tmp_path)),
     ]
 
+    if os.path.exists('/etc/ssh/ssh_known_hosts'):
+        expected_command_start.extend(['-v', '/etc/ssh/:/etc/ssh/'])
+
     if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 

--- a/test/unit/config/test_ansible_cfg.py
+++ b/test/unit/config/test_ansible_cfg.py
@@ -85,6 +85,9 @@ def test_prepare_config_command_with_containerization(tmp_path, runtime, mocker)
         '-v', '{}/.ssh/:/root/.ssh/'.format(str(tmp_path)),
     ]
 
+    if os.path.exists('/etc/ssh/ssh_known_hosts'):
+        expected_command_start.extend(['-v', '/etc/ssh/:/etc/ssh/'])
+
     if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 

--- a/test/unit/config/test_command.py
+++ b/test/unit/config/test_command.py
@@ -99,6 +99,9 @@ def test_prepare_run_command_with_containerization(tmp_path, runtime, mocker):
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
+    if os.path.exists('/etc/ssh/ssh_known_hosts'):
+        expected_command_start.extend(['-v', '/etc/ssh/:/etc/ssh/'])
+
     if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -95,6 +95,9 @@ def test_prepare_plugin_docs_command_with_containerization(tmp_path, runtime, mo
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
+    if os.path.exists('/etc/ssh/ssh_known_hosts'):
+        expected_command_start.extend(['-v', '/etc/ssh/:/etc/ssh/'])
+
     if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 
@@ -162,6 +165,9 @@ def test_prepare_plugin_list_command_with_containerization(tmp_path, runtime, mo
         '-v', '{}/.ssh/:/home/runner/.ssh/'.format(rc.private_data_dir),
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
+
+    if os.path.exists('/etc/ssh/ssh_known_hosts'):
+        expected_command_start.extend(['-v', '/etc/ssh/:/etc/ssh/'])
 
     if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])

--- a/test/unit/config/test_inventory.py
+++ b/test/unit/config/test_inventory.py
@@ -120,6 +120,9 @@ def test_prepare_inventory_command_with_containerization(tmp_path, runtime, mock
         '-v', '{}/.ssh/:/root/.ssh/'.format(rc.private_data_dir),
     ]
 
+    if os.path.exists('/etc/ssh/ssh_known_hosts'):
+        expected_command_start.extend(['-v', '/etc/ssh/:/etc/ssh/'])
+
     if runtime == 'podman':
         expected_command_start.extend(['--group-add=root', '--ipc=host'])
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = linters, ansible{27, 28, 29, -base}
-skipsdist = True
+requires =
+    tox>4
+    setuptools>=64
 
 [testenv]
 description = Run tests with {basepython}
@@ -17,12 +19,12 @@ passenv =
     HOME
     RUNNER_TEST_IMAGE_NAME
 usedevelop = True
-commands = pytest {posargs}
+commands = pytest -vv {posargs}
 
-[testenv:linters]
+[testenv:linters{,-py38,-py39,-py310,-py311}]
 description = Run code linters
-basepython = python3.8
-commands=
+skip_install = True
+commands =
     flake8 --version
     flake8 docs ansible_runner test
     yamllint --version
@@ -30,11 +32,11 @@ commands=
 
 [testenv:unit{,-py38,-py39,-py310,-py311}]
 description = Run unit tests
-commands = pytest {posargs:test/unit}
+commands = pytest -vv {posargs:test/unit}
 
 [testenv:integration{,-py38,-py39,-py310,-py311}]
 description = Run integration tests
-commands = pytest {posargs:test/integration}
+commands = pytest -vv {posargs:test/integration}
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
* Force tox 4 for CI
* Adds missing Python 3.11 unit test
* Eliminate use of custom test image
* Update GitHub runner to ubuntu-22.04
* Use codecov GitHub action instead of shell commands
* Make pytest more verbose for easier debugging of failures.
* Modify tests to handle `/etc/ssh` container volume mounts caused by the above changes

Closes #1174 