### PR TITLE
Fail CI on codecov upload failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
         with:
           files: test/coverage/reports/coverage.xml
           flags: ${{ matrix.py_version.tox_env }}
+          fail_ci_if_error: true
+          verbose: true
 
 
   unit:
@@ -153,3 +155,5 @@ jobs:
         with:
           files: test/coverage/reports/coverage.xml
           flags: ${{ matrix.py_version.tox_env }}
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
I've been seeing failures during CodeCov data uploads. These currently do not fail the CI jobs, but if we are going to start enforcing code coverage, we'll need to ensure the uploads are successful.