### PR TITLE
Mark test test_multiline_blank_write as unstable with pexpect

### DIFF
--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -181,7 +181,11 @@ def test_stdout_file_no_write(rc, runner_mode):
         assert not stdout_path.exists()
 
 
-@pytest.mark.parametrize('runner_mode', ['pexpect', 'subprocess'])
+@pytest.mark.parametrize('runner_mode',
+                         [
+                             pytest.param('pexpect', marks=pytest.mark.xfail(reason="Test is unstable with pexpect")),
+                             'subprocess'
+                         ])
 def test_multiline_blank_write(rc, runner_mode):
     rc.command = ['echo', 'hello_world_marker\n\n\n']
     rc.runner_mode = runner_mode


### PR DESCRIPTION
The `test_multiline_blank_write()` unit test is unstable under `pexpect`. It sometimes fails with:

```
AssertionError: assert '' == 'hello_world_marker\n\n\n\n'
```

Until we can resolve this, mark this with `xfail` when testing with `pexpect`.