### PR TITLE
Improve 'worker --worker-info' portability

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ python_requires = >=3.9
 install_requires =
     pexpect>=4.5
     packaging
+    psutil
     python-daemon
     pyyaml
     six

--- a/src/ansible_runner/utils/ensure_uuid.py
+++ b/src/ansible_runner/utils/ensure_uuid.py
@@ -1,27 +1,6 @@
-import multiprocessing
-import re
 import uuid
 
 from pathlib import Path
-
-
-def get_cpu_count():
-    # `multiprocessing` info: https://docs.python.org/3/library/multiprocessing.html
-    cpu_count = multiprocessing.cpu_count()
-    return cpu_count
-
-
-def get_mem_in_bytes():
-    try:
-        with open('/proc/meminfo') as f:
-            mem = f.read()
-        matched = re.search(r'^MemTotal:\s+(\d+)', mem)
-        if matched:
-            mem_capacity = int(matched.groups()[0])
-        return mem_capacity * 1024
-    except FileNotFoundError:
-        error = "The /proc/meminfo file could not found, memory capacity undiscoverable."
-        return error
 
 
 def ensure_uuid(uuid_file_path=None, mode=0o0600):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -4,6 +4,7 @@ pytest-cov
 pytest-mock
 pytest-timeout
 pytest-xdist==2.5.0
+types-psutil
 types-pyyaml
 types-six
 flake8==4.0.1

--- a/test/unit/__main__/main/test_worker.py
+++ b/test/unit/__main__/main/test_worker.py
@@ -1,5 +1,6 @@
 import ansible_runner.__main__ as ansible_runner__main__
 import pytest
+from yaml import safe_load
 
 
 def test_worker_delete(mocker):
@@ -43,3 +44,14 @@ def test_worker_delete_private_data_dir(mocker, tmp_path):
     mock_rmtree.assert_called_once_with(str(tmp_path), ignore_errors=True)
     mock_register_for_cleanup.assert_called_once_with(str(tmp_path))
     mock_mkdtemp.assert_not_called()
+
+
+def test_worker_info(mocker, capsys):
+    sys_args = ['worker', '--worker-info']
+    ansible_runner__main__.main(sys_args)
+
+    captured = capsys.readouterr()
+    data = safe_load(captured.out)
+    assert 'cpu_count' in data and isinstance(data['cpu_count'], int)
+    assert 'mem_in_bytes' in data and isinstance(data['mem_in_bytes'], int)
+    assert 'runner_version' in data and data['runner_version'] == ansible_runner__main__.VERSION

--- a/test/unit/utils/test_uuid.py
+++ b/test/unit/utils/test_uuid.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansible_runner.utils.capacity import (
+from ansible_runner.utils.ensure_uuid import (
     _set_uuid,
     ensure_uuid,
 )
@@ -9,14 +9,14 @@ from ansible_runner.utils.capacity import (
 @pytest.fixture
 def mock_uuid(mocker):
     uuid = 'f6bf3d15-7a6b-480a-b29c-eb4d0acf38ce'
-    mocker.patch('ansible_runner.utils.capacity.uuid.uuid4', return_value=uuid)
+    mocker.patch('ansible_runner.utils.ensure_uuid.uuid.uuid4', return_value=uuid)
 
     return uuid
 
 
 @pytest.fixture
 def mock_home_path(mocker, tmp_path):
-    mocker.patch('ansible_runner.utils.capacity.Path.home', return_value=tmp_path)
+    mocker.patch('ansible_runner.utils.ensure_uuid.Path.home', return_value=tmp_path)
 
 
 def test_set_uuid(mock_uuid, mock_home_path, tmp_path):
@@ -68,7 +68,7 @@ def test_set_uuid_bad_path(mock_uuid, tmp_path):
 
 
 def test_ensure_uuid(mocker, mock_uuid, mock_home_path, tmp_path):
-    mock_set_uuid = mocker.patch('ansible_runner.utils.capacity._set_uuid', return_value=mock_uuid)
+    mock_set_uuid = mocker.patch('ansible_runner.utils.ensure_uuid._set_uuid', return_value=mock_uuid)
 
     uuid = ensure_uuid()
 
@@ -77,7 +77,7 @@ def test_ensure_uuid(mocker, mock_uuid, mock_home_path, tmp_path):
 
 
 def test_ensure_uuid_does_not_exist(mocker, mock_uuid, tmp_path):
-    mock_set_uuid = mocker.patch('ansible_runner.utils.capacity._set_uuid', return_value=mock_uuid)
+    mock_set_uuid = mocker.patch('ansible_runner.utils.ensure_uuid._set_uuid', return_value=mock_uuid)
 
     uuid_path = tmp_path / 'uuid'
     uuid = ensure_uuid(uuid_path)
@@ -87,7 +87,7 @@ def test_ensure_uuid_does_not_exist(mocker, mock_uuid, tmp_path):
 
 
 def test_ensure_uuid_exists(mocker, mock_uuid, tmp_path):
-    mock_set_uuid = mocker.patch('ansible_runner.utils.capacity._set_uuid', return_value=mock_uuid)
+    mock_set_uuid = mocker.patch('ansible_runner.utils.ensure_uuid._set_uuid', return_value=mock_uuid)
     uuid_path = tmp_path / 'uuid'
     uuid_path.write_text(mock_uuid + '\n')
 
@@ -98,7 +98,7 @@ def test_ensure_uuid_exists(mocker, mock_uuid, tmp_path):
 
 
 def test_ensure_uuid_exists_mode(mocker, mock_uuid, tmp_path):
-    mock_set_uuid = mocker.patch('ansible_runner.utils.capacity._set_uuid', return_value=mock_uuid)
+    mock_set_uuid = mocker.patch('ansible_runner.utils.ensure_uuid._set_uuid', return_value=mock_uuid)
     uuid_path = tmp_path / 'uuid'
     uuid_path.touch(0o775)
 


### PR DESCRIPTION
The `--worker-info` option to the `worker` command depended on `/proc/meminfo` existing. We can use the `psutil` package (a new requirement) to make this more portable.

This also improves code coverage by removing unnecessary, custom capacity querying methods, and adding a test for the `--worker-info` option.