### PR TITLE
Add pylint to CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,20 @@ module = [
     "pexpect",
 ]
 ignore_missing_imports = true
+
+[tool.pylint.main]
+output-format = "colorized"
+disable = [
+  "all",
+
+  # Some codes we will leave disabled
+  "C0103",  # invalid-name
+  "C0114",  # missing-module-docstring
+  "C0116",  # missing-function-docstring
+  "C0301",  # line-too-long
+  "R0902",  # too-many-instance-attributes
+]
+
+enable = [
+  "W0102",  # dangerous-default-value
+]

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,5 @@
 mypy==1.3.0
+pylint==2.17.4
 pytest==7.1.2
 pytest-cov
 pytest-mock

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
     yamllint --version
     yamllint -s .
     mypy src/ansible_runner
+    pylint src/ansible_runner
 
 [testenv:unit{,-py39,-py310,-py311}]
 description = Run unit tests


### PR DESCRIPTION
Adding `pylint` to the CI linting tests.

The plan is to slowly enable individual checks until we get the number of errors down a bit. Disabled all checks for now except for `W0102 - dangerous-default-value`.
