### PR TITLE
Enable pylint check C0209

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,6 @@
 extends: default
 
-ignore: |
-  .tox
+ignore-from-file: .gitignore
 
 rules:
   braces:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,6 @@ disable = [
 ]
 
 enable = [
+  "C0209",  # consider-using-f-string
   "W0102",  # dangerous-default-value
 ]

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -149,7 +149,7 @@ DEFAULT_CLI_ARGS = {
             dict(
                 default=DEFAULT_RUNNER_BINARY,
                 help="specifies the full path pointing to the Ansible binaries "
-                     "(default={})".format(DEFAULT_RUNNER_BINARY)
+                     f"(default={DEFAULT_RUNNER_BINARY})"
             ),
         ),
         (
@@ -158,7 +158,7 @@ DEFAULT_CLI_ARGS = {
                 default=DEFAULT_UUID,
                 help="an identifier that will be used when generating the artifacts "
                      "directory and can be used to uniquely identify a playbook run "
-                     "(default={})".format(DEFAULT_UUID)
+                     f"(default={DEFAULT_UUID})"
             ),
         ),
         (
@@ -432,18 +432,18 @@ def role_manager(vargs):
 
         playbook = dump_artifact(json.dumps(play), project_path, filename)
         kwargs.playbook = playbook
-        output.debug('using playbook file %s' % playbook)
+        output.debug(f"using playbook file {playbook}")
 
         if vargs.get('inventory'):
             inventory_file = os.path.join(vargs.get('private_data_dir'), 'inventory', vargs.get('inventory'))
             if not os.path.exists(inventory_file):
                 raise AnsibleRunnerException('location specified by --inventory does not exist')
             kwargs.inventory = inventory_file
-            output.debug('using inventory file %s' % inventory_file)
+            output.debug(f"using inventory file {inventory_file}")
 
         roles_path = vargs.get('roles_path') or os.path.join(vargs.get('private_data_dir'), 'roles')
         roles_path = os.path.abspath(roles_path)
-        output.debug('setting ANSIBLE_ROLES_PATH to %s' % roles_path)
+        output.debug(f"setting ANSIBLE_ROLES_PATH to {roles_path}")
 
         envvars = {}
         if envvars_exists:

--- a/src/ansible_runner/config/ansible_cfg.py
+++ b/src/ansible_runner/config/ansible_cfg.py
@@ -47,7 +47,7 @@ class AnsibleCfgConfig(BaseConfig):
         # runner params
         self.runner_mode = runner_mode if runner_mode else 'subprocess'
         if self.runner_mode not in ['pexpect', 'subprocess']:
-            raise ConfigurationError("Invalid runner mode {0}, valid value is either 'pexpect' or 'subprocess'".format(self.runner_mode))
+            raise ConfigurationError(f"Invalid runner mode {self.runner_mode}, valid value is either 'pexpect' or 'subprocess'")
 
         if kwargs.get("process_isolation"):
             self._ansible_config_exec_path = "ansible-config"
@@ -62,7 +62,7 @@ class AnsibleCfgConfig(BaseConfig):
     def prepare_ansible_config_command(self, action, config_file=None, only_changed=None):
 
         if action not in AnsibleCfgConfig._supported_actions:
-            raise ConfigurationError("Invalid action {0}, valid value is one of either {1}".format(action, ", ".join(AnsibleCfgConfig._supported_actions)))
+            raise ConfigurationError(f'Invalid action {action}, valid value is one of either {", ".join(AnsibleCfgConfig._supported_actions)}')
 
         if action != 'dump' and only_changed:
             raise ConfigurationError("only_changed is applicable for action 'dump'")

--- a/src/ansible_runner/config/command.py
+++ b/src/ansible_runner/config/command.py
@@ -51,7 +51,7 @@ class CommandConfig(BaseConfig):
             raise ConfigurationError("input_fd is applicable only with 'subprocess' runner mode")
 
         if runner_mode and runner_mode not in ['pexpect', 'subprocess']:
-            raise ConfigurationError("Invalid runner mode {0}, valid value is either 'pexpect' or 'subprocess'".format(runner_mode))
+            raise ConfigurationError(f"Invalid runner mode {runner_mode}, valid value is either 'pexpect' or 'subprocess'")
 
         # runner params
         self.runner_mode = runner_mode

--- a/src/ansible_runner/config/doc.py
+++ b/src/ansible_runner/config/doc.py
@@ -47,7 +47,7 @@ class DocConfig(BaseConfig):
         # runner params
         self.runner_mode = runner_mode if runner_mode else 'subprocess'
         if self.runner_mode not in ['pexpect', 'subprocess']:
-            raise ConfigurationError("Invalid runner mode {0}, valid value is either 'pexpect' or 'subprocess'".format(self.runner_mode))
+            raise ConfigurationError(f"Invalid runner mode {self.runner_mode}, valid value is either 'pexpect' or 'subprocess'")
 
         if kwargs.get("process_isolation"):
             self._ansible_doc_exec_path = "ansible-doc"
@@ -63,11 +63,11 @@ class DocConfig(BaseConfig):
                                     snippet=False, playbook_dir=None, module_path=None):
 
         if response_format and response_format not in DocConfig._supported_response_formats:
-            raise ConfigurationError("Invalid response_format {0}, valid value is one of either {1}".format(response_format,
-                                                                                                            ", ".join(DocConfig._supported_response_formats)))
+            raise ConfigurationError(f'Invalid response_format {response_format}, '
+                                     f'valid value is one of either {", ".join(DocConfig._supported_response_formats)}')
 
         if not isinstance(plugin_names, list):
-            raise ConfigurationError("plugin_names should be of type list, instead received {0} of type {1}".format(plugin_names, type(plugin_names)))
+            raise ConfigurationError(f"plugin_names should be of type list, instead received {plugin_names} of type {type(plugin_names)}")
 
         self._prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = []
@@ -96,8 +96,8 @@ class DocConfig(BaseConfig):
                                     playbook_dir=None, module_path=None):
 
         if response_format and response_format not in DocConfig._supported_response_formats:
-            raise ConfigurationError("Invalid response_format {0}, valid value is one of either {1}".format(response_format,
-                                                                                                            ", ".join(DocConfig._supported_response_formats)))
+            raise ConfigurationError(f"Invalid response_format {response_format}, "
+                                     f'valid value is one of either {", ".join(DocConfig._supported_response_formats)}')
 
         self._prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = []

--- a/src/ansible_runner/config/inventory.py
+++ b/src/ansible_runner/config/inventory.py
@@ -46,7 +46,7 @@ class InventoryConfig(BaseConfig):
         # runner params
         self.runner_mode = runner_mode if runner_mode else 'subprocess'
         if self.runner_mode not in ['pexpect', 'subprocess']:
-            raise ConfigurationError("Invalid runner mode {0}, valid value is either 'pexpect' or 'subprocess'".format(self.runner_mode))
+            raise ConfigurationError(f"Invalid runner mode {self.runner_mode}, valid value is either 'pexpect' or 'subprocess'")
 
         if kwargs.get("process_isolation"):
             self._ansible_inventory_exec_path = "ansible-inventory"
@@ -64,14 +64,14 @@ class InventoryConfig(BaseConfig):
                                   output_file=None, export=None):
 
         if action not in InventoryConfig._supported_actions:
-            raise ConfigurationError("Invalid action {0}, valid value is one of either {1}".format(action, ", ".join(InventoryConfig._supported_actions)))
+            raise ConfigurationError(f'Invalid action {action}, valid value is one of either {", ".join(InventoryConfig._supported_actions)}')
 
         if response_format and response_format not in InventoryConfig._supported_response_formats:
-            raise ConfigurationError("Invalid response_format {0}, valid value is one of "
-                                     "either {1}".format(response_format, ", ".join(InventoryConfig._supported_response_formats)))
+            raise ConfigurationError(f"Invalid response_format {response_format}, valid value is one of "
+                                     f"either {', '.join(InventoryConfig._supported_response_formats)}")
 
         if not isinstance(inventories, list):
-            raise ConfigurationError("inventories should be of type list, instead received {0} of type {1}".format(inventories, type(inventories)))
+            raise ConfigurationError(f"inventories should be of type list, instead received {inventories} of type {type(inventories)}")
 
         if action == "host" and host is None:
             raise ConfigurationError("Value of host parameter is required when action in 'host'")
@@ -82,7 +82,7 @@ class InventoryConfig(BaseConfig):
         self._prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = []
 
-        self.cmdline_args.append('--{0}'.format(action))
+        self.cmdline_args.append(f'--{action}')
         if action == 'host':
             self.cmdline_args.append(host)
 
@@ -90,7 +90,7 @@ class InventoryConfig(BaseConfig):
             self.cmdline_args.extend(['-i', inv])
 
         if response_format in ['yaml', 'toml']:
-            self.cmdline_args.append('--{0}'.format(response_format))
+            self.cmdline_args.append(f'--{response_format}')
 
         if playbook_dir:
             self.cmdline_args.extend(['--playbook-dir', playbook_dir])

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -134,8 +134,7 @@ class RunnerConfig(BaseConfig):
         if self.sandboxed and self.directory_isolation_path is not None:
             self.directory_isolation_path = tempfile.mkdtemp(prefix='runner_di_', dir=self.directory_isolation_path)
             if os.path.exists(self.project_dir):
-                output.debug("Copying directory tree from {} to {} for working directory isolation".format(self.project_dir,
-                                                                                                           self.directory_isolation_path))
+                output.debug(f"Copying directory tree from {self.project_dir} to {self.directory_isolation_path} for working directory isolation")
                 shutil.copytree(self.project_dir, self.directory_isolation_path, symlinks=True)
 
         self.prepare_inventory()
@@ -270,35 +269,35 @@ class RunnerConfig(BaseConfig):
                 extravars_path = '/runner/env/extravars'
             else:
                 extravars_path = self.loader.abspath('env/extravars')
-            exec_list.extend(['-e', '@{}'.format(extravars_path)])
+            exec_list.extend(['-e', f'@{extravars_path}'])
 
         if self.extra_vars:
             if isinstance(self.extra_vars, dict) and self.extra_vars:
                 extra_vars_list = []
                 for k in self.extra_vars:
-                    extra_vars_list.append("\"{}\":{}".format(k, json.dumps(self.extra_vars[k])))
+                    extra_vars_list.append(f"\"{k}\":{json.dumps(self.extra_vars[k])}")
 
                 exec_list.extend(
                     [
                         '-e',
-                        '{%s}' % ','.join(extra_vars_list)
+                        f'{{{",".join(extra_vars_list)}}}'
                     ]
                 )
             elif self.loader.isfile(self.extra_vars):
-                exec_list.extend(['-e', '@{}'.format(self.loader.abspath(self.extra_vars))])
+                exec_list.extend(['-e', f'@{self.loader.abspath(self.extra_vars)}'])
 
         if self.verbosity:
             v = 'v' * self.verbosity
-            exec_list.append('-{}'.format(v))
+            exec_list.append(f'-{v}')
 
         if self.tags:
-            exec_list.extend(['--tags', '{}'.format(self.tags)])
+            exec_list.extend(['--tags', self.tags])
 
         if self.skip_tags:
-            exec_list.extend(['--skip-tags', '{}'.format(self.skip_tags)])
+            exec_list.extend(['--skip-tags', self.skip_tags])
 
         if self.forks:
-            exec_list.extend(['--forks', '{}'.format(self.forks)])
+            exec_list.extend(['--forks', str(self.forks)])
 
         # Other parameters
         if self.execution_mode == ExecutionMode.ANSIBLE_PLAYBOOK:
@@ -351,7 +350,7 @@ class RunnerConfig(BaseConfig):
 
         for path in sorted(set(self.process_isolation_hide_paths or [])):
             if not os.path.exists(path):
-                logger.debug('hide path not found: {0}'.format(path))
+                logger.debug(f'hide path not found: {path}')
                 continue
             path = os.path.realpath(path)
             if os.path.isdir(path):
@@ -361,7 +360,7 @@ class RunnerConfig(BaseConfig):
                 handle, new_path = tempfile.mkstemp(dir=self.process_isolation_path_actual)
                 os.close(handle)
                 os.chmod(new_path, stat.S_IRUSR | stat.S_IWUSR)
-            new_args.extend(['--bind', '{0}'.format(new_path), '{0}'.format(path)])
+            new_args.extend(['--bind', new_path, path])
 
         if self.private_data_dir:
             show_paths = [self.private_data_dir]
@@ -370,18 +369,18 @@ class RunnerConfig(BaseConfig):
 
         for path in sorted(set(self.process_isolation_ro_paths or [])):
             if not os.path.exists(path):
-                logger.debug('read-only path not found: {0}'.format(path))
+                logger.debug(f'read-only path not found: {path}')
                 continue
             path = os.path.realpath(path)
-            new_args.extend(['--ro-bind', '{0}'.format(path), '{0}'.format(path)])
+            new_args.extend(['--ro-bind', path, path])
 
         show_paths.extend(self.process_isolation_show_paths or [])
         for path in sorted(set(show_paths)):
             if not os.path.exists(path):
-                logger.debug('show path not found: {0}'.format(path))
+                logger.debug(f'show path not found: {path}')
                 continue
             path = os.path.realpath(path)
-            new_args.extend(['--bind', '{0}'.format(path), '{0}'.format(path)])
+            new_args.extend(['--bind', path, path])
 
         if self.execution_mode == ExecutionMode.ANSIBLE_PLAYBOOK:
             # playbook runs should cwd to the SCM checkout dir

--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -107,7 +107,7 @@ class IsolatedFileWrite:
         # Strip off the leading key identifying characters :1:ev-
         event_uuid = key[len(':1:ev-'):]
         # Write data in a staging area and then atomic move to pickup directory
-        filename = '{}-partial.json'.format(event_uuid)
+        filename = f"{event_uuid}-partial.json"
         if not os.path.exists(os.path.join(self.private_data_dir, 'job_events')):
             os.mkdir(os.path.join(self.private_data_dir, 'job_events'), 0o700)
         dropoff_location = os.path.join(self.private_data_dir, 'job_events', filename)
@@ -226,18 +226,18 @@ class EventContext(object):
         b64data = base64.b64encode(json.dumps(data).encode('utf-8')).decode()
         with self.display_lock:
             # pattern corresponding to OutputEventFilter expectation
-            fileobj.write(u'\x1b[K')
+            fileobj.write('\x1b[K')
             for offset in range(0, len(b64data), max_width):
                 chunk = b64data[offset:offset + max_width]
-                escaped_chunk = u'{}\x1b[{}D'.format(chunk, len(chunk))
+                escaped_chunk = f'{chunk}\x1b[{len(chunk)}D'
                 fileobj.write(escaped_chunk)
-            fileobj.write(u'\x1b[K')
+            fileobj.write('\x1b[K')
             if flush:
                 fileobj.flush()
 
     def dump_begin(self, fileobj):
         begin_dict = self.get_begin_dict()
-        self.cache.set(":1:ev-{}".format(begin_dict['uuid']), begin_dict)
+        self.cache.set(f":1:ev-{begin_dict['uuid']}", begin_dict)
         self.dump(fileobj, {'uuid': begin_dict['uuid']})
 
     def dump_end(self, fileobj):
@@ -421,7 +421,7 @@ class CallbackModule(DefaultCallbackModule):
             if task.no_log:
                 task_ctx['task_args'] = "the output has been hidden due to the fact that 'no_log: true' was specified for this result"
             else:
-                task_args = ', '.join(('%s=%s' % a for a in task.args.items()))
+                task_args = ', '.join((f'{k}={v}' for k, v in task.args.items()))
                 task_ctx['task_args'] = task_args
         if getattr(task, '_role', None):
             task_role = task._role._role_name

--- a/src/ansible_runner/loader.py
+++ b/src/ansible_runner/loader.py
@@ -95,14 +95,14 @@ class ArtifactLoader(object):
         '''
         try:
             if not os.path.exists(path):
-                raise ConfigurationError('specified path does not exist %s' % path)
+                raise ConfigurationError(f"specified path does not exist {path}")
             with codecs.open(path, encoding='utf-8') as f:
                 data = f.read()
 
             return data
 
         except (IOError, OSError) as exc:
-            raise ConfigurationError('error trying to load file contents: %s' % exc)
+            raise ConfigurationError(f"error trying to load file contents: {exc}")
 
     def abspath(self, path):
         '''
@@ -154,13 +154,13 @@ class ArtifactLoader(object):
             ConfigurationError:
         '''
         path = self.abspath(path)
-        debug('file path is %s' % path)
+        debug(f"file path is {path}")
 
         if path in self._cache:
             return self._cache[path]
 
         try:
-            debug('cache miss, attempting to load file from disk: %s' % path)
+            debug(f"cache miss, attempting to load file from disk: {path}")
             contents = parsed_data = self.get_contents(path)
             if encoding:
                 parsed_data = contents.encode(encoding)
@@ -177,7 +177,7 @@ class ArtifactLoader(object):
                     break
 
             if objtype and not isinstance(parsed_data, objtype):
-                debug('specified file %s is not of type %s' % (path, objtype))
+                debug(f"specified file {path} is not of type {objtype}")
                 raise ConfigurationError('invalid file serialization type for contents')
 
         self._cache[path] = parsed_data

--- a/src/ansible_runner/output.py
+++ b/src/ansible_runner/output.py
@@ -53,14 +53,14 @@ def set_logfile(filename: str) -> None:
 def set_debug(value: str) -> None:
     global DEBUG_ENABLED
     if value.lower() not in ('enable', 'disable'):
-        raise ValueError('value must be one of `enable` or `disable`, got %s' % value)
+        raise ValueError(f"value must be one of `enable` or `disable`, got {value}")
     DEBUG_ENABLED = value.lower() == 'enable'
 
 
 def set_traceback(value: str) -> None:
     global TRACEBACK_ENABLED
     if value.lower() not in ('enable', 'disable'):
-        raise ValueError('value must be one of `enable` or `disable`, got %s' % value)
+        raise ValueError(f"value must be one of `enable` or `disable`, got {value}")
     TRACEBACK_ENABLED = value.lower() == 'enable'
 
 

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -55,14 +55,14 @@ class Runner(object):
         '''
         self.last_stdout_update = time.time()
         if 'uuid' in event_data:
-            filename = '{}-partial.json'.format(event_data['uuid'])
+            filename = f"{event_data['uuid']}-partial.json"
             partial_filename = os.path.join(self.config.artifact_dir,
                                             'job_events',
                                             filename)
             full_filename = os.path.join(self.config.artifact_dir,
                                          'job_events',
-                                         '{}-{}.json'.format(event_data['counter'],
-                                                             event_data['uuid']))
+                                         f"{event_data['counter']}-{event_data['uuid']}.json"
+                                         )
             try:
                 event_data.update(dict(runner_ident=str(self.config.ident)))
                 try:
@@ -73,7 +73,7 @@ class Runner(object):
                         os.remove(partial_filename)
                 except IOError as e:
                     msg = "Failed to open ansible stdout callback plugin partial data" \
-                          " file {} with error {}".format(partial_filename, str(e))
+                          f" file {partial_filename} with error {str(e)}"
                     debug(msg)
                     if self.config.check_job_event_data:
                         raise AnsibleRunnerException(msg)
@@ -95,7 +95,7 @@ class Runner(object):
                         json.dump(event_data, write_file)
                     os.rename(temporary_filename, full_filename)
             except IOError as e:
-                debug("Failed writing event data: {}".format(e))
+                debug(f"Failed writing event data: {e}")
 
     def status_callback(self, status):
         self.status = status
@@ -188,7 +188,7 @@ class Runner(object):
             with open(env_file_host, 'w') as f:
                 f.write(
                     '\n'.join(
-                        ["{}={}".format(key, value) for key, value in self.config.env.items()]
+                        [f"{key}={value}" for key, value in self.config.env.items()]
                     )
                 )
         else:
@@ -244,15 +244,13 @@ class Runner(object):
                 stderr_response = proc_out.stderr
                 self.rc = proc_out.returncode
             except CalledProcessError as exc:
-                logger.debug("{cmd} execution failed, returncode: {rc}, output: {output}, stdout: {stdout}, stderr: {stderr}".format(
-                    cmd=exc.cmd, rc=exc.returncode, output=exc.output, stdout=exc.stdout, stderr=exc.stderr))
+                logger.debug(f"{exc.cmd} execution failed, returncode: {exc.returncode}, output: {exc.output}, stdout: {exc.stdout}, stderr: {exc.stderr}")
                 self.rc = exc.returncode
                 self.errored = True
                 stdout_response = exc.stdout
                 stderr_response = exc.stderr
             except TimeoutExpired as exc:
-                logger.debug("{cmd} execution timedout, timeout: {timeout}, output: {output}, stdout: {stdout}, stderr: {stderr}".format(
-                    cmd=exc.cmd, timeout=exc.timeout, output=exc.output, stdout=exc.stdout, stderr=exc.stderr))
+                logger.debug(f"{exc.cmd} execution timedout, timeout: {exc.timeout}, output: {exc.output}, stdout: {exc.stdout}, stderr: {exc.stderr}")
                 self.rc = 254
                 stdout_response = exc.stdout
                 stderr_response = exc.stderr
@@ -262,7 +260,7 @@ class Runner(object):
                 stderr_response = traceback.format_exc()
                 self.rc = 254
                 self.errored = True
-                logger.debug("received exception: {exc}".format(exc=str(exc)))
+                logger.debug(f"received exception: {exc}")
 
             if self.timed_out or self.errored:
                 self.kill_container()
@@ -328,7 +326,7 @@ class Runner(object):
                         # TODO: logger.exception('Could not check cancel callback - cancelling immediately')
                         # if isinstance(extra_update_fields, dict):
                         #     extra_update_fields['job_explanation'] = "System error during job execution, check system logs"
-                        raise CallbackError("Exception in Cancel Callback: {}".format(e))
+                        raise CallbackError(f"Exception in Cancel Callback: {e}")
                 if self.config.job_timeout and not self.canceled and (time.time() - job_start) > self.config.job_timeout:
                     self.timed_out = True
                     # if isinstance(extra_update_fields, dict):
@@ -384,13 +382,13 @@ class Runner(object):
             try:
                 self.artifacts_handler(self.config.artifact_dir)
             except Exception as e:
-                raise CallbackError("Exception in Artifact Callback: {}".format(e))
+                raise CallbackError(f"Exception in Artifact Callback: {e}")
 
         if self.finished_callback is not None:
             try:
                 self.finished_callback(self)
             except Exception as e:
-                raise CallbackError("Exception in Finished Callback: {}".format(e))
+                raise CallbackError(f"Exception in Finished Callback: {e}")
         return self.status, self.rc
 
     @property
@@ -465,7 +463,7 @@ class Runner(object):
             time.sleep(0.05)
             wait_time = datetime.datetime.now() - now
             if wait_time.total_seconds() > 60:
-                raise AnsibleRunnerException("events directory is missing: %s" % event_path)
+                raise AnsibleRunnerException(f"events directory is missing: {event_path}")
 
         while self.status == "running":
             for event, old_evnts in collect_new_events(event_path, old_events):
@@ -518,9 +516,9 @@ class Runner(object):
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
             _, stderr = proc.communicate()
             if proc.returncode:
-                logger.info('Error from {} kill {} command:\n{}'.format(container_cli, container_name, stderr))
+                logger.info(f"Error from {container_cli} kill {container_name} command:\n{stderr}")
             else:
-                logger.info("Killed container {}".format(container_name))
+                logger.info(f"Killed container {container_name}")
 
     @classmethod
     def handle_termination(cls, pid, pidfile=None, is_cancel=True):

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -266,8 +266,8 @@ class Processor(object):
             self.artifact_dir = os.path.abspath(kwargs.get('artifact_dir'))
         else:
             project_artifacts = os.path.abspath(os.path.join(self.private_data_dir, 'artifacts'))
-            if kwargs.get('ident'):
-                self.artifact_dir = os.path.join(project_artifacts, "{}".format(kwargs.get('ident')))
+            if ident := kwargs.get('ident'):
+                self.artifact_dir = os.path.join(project_artifacts, ident)
             else:
                 self.artifact_dir = project_artifacts
 

--- a/src/ansible_runner/utils/__init__.py
+++ b/src/ansible_runner/utils/__init__.py
@@ -211,7 +211,7 @@ def dump_artifacts(kwargs):
         if not roles_path:
             roles_path = os.path.join(private_data_dir, 'roles')
         else:
-            roles_path += ':{}'.format(os.path.join(private_data_dir, 'roles'))
+            roles_path += f":{os.path.join(private_data_dir, 'roles')}"
 
         kwargs['envvars']['ANSIBLE_ROLES_PATH'] = roles_path
 
@@ -444,7 +444,7 @@ def ensure_str(s, encoding='utf-8', errors='strict'):
       - ``bytes`` -> decoded to ``str``
     """
     if not isinstance(s, (text_type, binary_type)):
-        raise TypeError("not expecting type '%s'" % type(s))
+        raise TypeError(f"not expecting type '{type(s)}'")
     if PY2 and isinstance(s, text_type):
         s = s.encode(encoding, errors)
     elif PY3 and isinstance(s, binary_type):
@@ -470,11 +470,11 @@ def cli_mounts():
             'ENVS': ['SSH_AUTH_SOCK'],
             'PATHS': [
                 {
-                    'src': '{}/.ssh/'.format(os.environ['HOME']),
+                    'src': f"{os.environ['HOME']}/.ssh/",
                     'dest': '/home/runner/.ssh/'
                 },
                 {
-                    'src': '{}/.ssh/'.format(os.environ['HOME']),
+                    'src': f"{os.environ['HOME']}/.ssh/",
                     'dest': '/root/.ssh/'
                 },
                 {

--- a/src/ansible_runner/utils/base64io.py
+++ b/src/ansible_runner/utils/base64io.py
@@ -83,7 +83,7 @@ class Base64IO(io.IOBase):
         required_attrs = ("read", "write", "close", "closed", "flush")
         if not all(hasattr(wrapped, attr) for attr in required_attrs):
             raise TypeError(
-                "Base64IO wrapped object must have attributes: %s" % (repr(sorted(required_attrs)),)
+                f"Base64IO wrapped object must have attributes: {repr(sorted(required_attrs))}"
             )
         super(Base64IO, self).__init__()
         self.__wrapped = wrapped


### PR DESCRIPTION
Enables pylint check C0209 (consider-using-f-string) and changes all non-f-string formats.

Also, change yamllint config to ignore files specified in `.gitignore` so local runs of the `linters` tox environment are more likely to succeed.