### PR TITLE
Fix for non-str ident

### DIFF
--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -267,7 +267,7 @@ class Processor(object):
         else:
             project_artifacts = os.path.abspath(os.path.join(self.private_data_dir, 'artifacts'))
             if ident := kwargs.get('ident'):
-                self.artifact_dir = os.path.join(project_artifacts, ident)
+                self.artifact_dir = os.path.join(project_artifacts, str(ident))
             else:
                 self.artifact_dir = project_artifacts
 

--- a/test/unit/test_streaming.py
+++ b/test/unit/test_streaming.py
@@ -1,0 +1,16 @@
+import os
+
+from ansible_runner.streaming import Processor
+
+
+class TestProcessor:
+
+    def test_artifact_dir_with_int_ident(self, tmp_path):
+        kwargs = {
+            'private_data_dir': str(tmp_path),
+            'ident': 123,
+        }
+        p = Processor(**kwargs)
+        assert p.artifact_dir == os.path.join(kwargs['private_data_dir'],
+                                              'artifacts',
+                                              str(kwargs['ident']))


### PR DESCRIPTION
Convert `ident` to a string type since it can be an `int` type.