### PR TITLE
Remove use of six library

### DIFF
--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -1,5 +1,4 @@
 ansible-core
 pexpect
-six
 sphinx
 sphinx-ansible-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,7 +19,6 @@ pygments==2.15.1
 pyyaml==6.0
 requests==2.28.2
 resolvelib==0.8.1
-six==1.16.0
 snowballstemmer==2.2.0
 sphinx==6.2.1
 sphinx-ansible-theme==0.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     packaging
     python-daemon
     pyyaml
-    six
     # enable `groups` arg to entry_points missing in 3.9 stdlib importlib.metadata
     importlib-metadata>= 4.6,< 6.3; python_version<'3.10'
 

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -28,7 +28,6 @@ from uuid import uuid4
 from collections.abc import Mapping
 
 import pexpect
-from six import iteritems, string_types
 
 from ansible_runner import defaults
 from ansible_runner.output import debug
@@ -170,7 +169,7 @@ class BaseConfig:
                 if self.passwords:
                     self.expect_passwords = {
                         re.compile(pattern, re.M): password
-                        for pattern, password in iteritems(self.passwords)
+                        for pattern, password in self.passwords.items()
                     }
             except Exception as e:
                 debug(f'Failed to compile RE from passwords: {e}')
@@ -242,7 +241,7 @@ class BaseConfig:
 
         try:
             if self.ssh_key_data is None:
-                self.ssh_key_data = self.loader.load_file('env/ssh_key', string_types)
+                self.ssh_key_data = self.loader.load_file('env/ssh_key', str)
         except ConfigurationError:
             debug("Not loading ssh key")
             self.ssh_key_data = None

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -24,9 +24,6 @@ import stat
 import tempfile
 import shutil
 
-import six
-from six import string_types, text_type
-
 from ansible_runner import output
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
@@ -209,10 +206,7 @@ class RunnerConfig(BaseConfig):
 
     def prepare_command(self):
         try:
-            cmdline_args = self.loader.load_file('args', string_types, encoding=None)
-
-            if six.PY2 and isinstance(cmdline_args, text_type):
-                cmdline_args = cmdline_args.encode('utf-8')
+            cmdline_args = self.loader.load_file('args', str, encoding=None)
             self.command = shlex.split(cmdline_args)
             self.execution_mode = ExecutionMode.RAW
         except ConfigurationError:
@@ -240,10 +234,7 @@ class RunnerConfig(BaseConfig):
             if self.cmdline_args:
                 cmdline_args = self.cmdline_args
             else:
-                cmdline_args = self.loader.load_file('env/cmdline', string_types, encoding=None)
-
-            if six.PY2 and isinstance(cmdline_args, text_type):
-                cmdline_args = cmdline_args.encode('utf-8')
+                cmdline_args = self.loader.load_file('env/cmdline', str, encoding=None)
 
             args = shlex.split(cmdline_args)
             exec_list.extend(args)

--- a/src/ansible_runner/loader.py
+++ b/src/ansible_runner/loader.py
@@ -21,7 +21,6 @@ import json
 import codecs
 
 from yaml import safe_load, YAMLError
-from six import string_types
 
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.output import debug
@@ -144,7 +143,7 @@ class ArtifactLoader:
             objtype (object): The object type of the file contents.  This
                 is used to type check the deserialized content against the
                 contents loaded from disk.
-                Ignore serializing if objtype is string_types
+                Ignore serializing if objtype is str.
 
         Returns:
             object: The deserialized file contents which could be either a
@@ -170,7 +169,7 @@ class ArtifactLoader:
         except UnicodeEncodeError:
             raise ConfigurationError('unable to encode file contents')
 
-        if objtype is not string_types:
+        if objtype is not str:
             for deserializer in (self._load_json, self._load_yaml):
                 parsed_data = deserializer(contents)
                 if parsed_data:

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -10,7 +10,6 @@ import codecs
 import collections
 import datetime
 import logging
-import six
 import pexpect
 
 import ansible_runner.plugins
@@ -195,7 +194,7 @@ class Runner:
             cwd = self.config.cwd
             pexpect_env = self.config.env
         env = {
-            ensure_str(k): ensure_str(v) if k != 'PATH' and isinstance(v, six.text_type) else v
+            ensure_str(k): ensure_str(v) if k != 'PATH' and isinstance(v, str) else v
             for k, v in pexpect_env.items()
         }
 
@@ -301,16 +300,13 @@ class Runner:
                     close=lambda: None,
                 )
 
-                def _decode(x):
-                    return x.decode('utf-8') if six.PY2 else x
-
                 # create the events directory (the callback plugin won't run, so it
                 # won't get created)
                 events_directory = os.path.join(self.config.artifact_dir, 'job_events')
                 if not os.path.exists(events_directory):
                     os.mkdir(events_directory, 0o700)
-                stdout_handle.write(_decode(str(e)))
-                stdout_handle.write(_decode('\n'))
+                stdout_handle.write(str(e))
+                stdout_handle.write('\n')
 
             job_start = time.time()
             while child.isalive():

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import json
 import os
 import yaml
-import six
 
 from ansible_runner.interface import init_runner
 
@@ -435,8 +434,6 @@ def test_large_stdout_parsing_when_using_json_output(executor, playbook):
     #
     # This tests to confirm we don't pollute the stdout output with non-json
     # lines when a single event has a lot of output.
-    if six.PY2:
-        pytest.skip('Ansible in python2 uses different syntax.')
     executor.config.env['ANSIBLE_NOCOLOR'] = str(True)
     executor.run()
     with executor.stdout as f:

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -4,7 +4,6 @@ import json
 import os
 import re
 import pytest
-import six
 import sys
 
 from ansible_runner import Runner
@@ -42,8 +41,6 @@ def test_run_command(rc):
 
 def test_run_command_with_unicode(rc):
     expected = '"utf-8-䉪ቒ칸ⱷ?噂폄蔆㪗輥"'
-    if six.PY2:
-        expected = expected.decode('utf-8')
     rc.command = ['echo', '"utf-8-䉪ቒ칸ⱷ?噂폄蔆㪗輥"']
     rc.envvars = {"䉪ቒ칸": "蔆㪗輥"}
     rc.prepare_env()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -6,7 +6,6 @@ pytest-mock
 pytest-timeout
 pytest-xdist==2.5.0
 types-pyyaml
-types-six
 flake8==4.0.1
 yamllint
 cryptography

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -7,7 +7,6 @@ from functools import partial
 from test.utils.common import RSAKey
 
 import pytest
-import six
 from pexpect import TIMEOUT, EOF
 
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
@@ -76,11 +75,11 @@ def test_prepare_environment_vars_only_strings_from_file(mocker):
 
     rc._prepare_env()
     assert 'A' in rc.env
-    assert isinstance(rc.env['A'], six.string_types)
+    assert isinstance(rc.env['A'], str)
     assert 'B' in rc.env
-    assert isinstance(rc.env['B'], six.string_types)
+    assert isinstance(rc.env['B'], str)
     assert 'C' in rc.env
-    assert isinstance(rc.env['C'], six.string_types)
+    assert isinstance(rc.env['C'], str)
     assert 'D' in rc.env
     assert rc.env['D'] == 'D'
 
@@ -90,11 +89,11 @@ def test_prepare_environment_vars_only_strings_from_interface():
     rc._prepare_env()
 
     assert 'A' in rc.env
-    assert isinstance(rc.env['A'], six.string_types)
+    assert isinstance(rc.env['A'], str)
     assert 'B' in rc.env
-    assert isinstance(rc.env['B'], six.string_types)
+    assert isinstance(rc.env['B'], str)
     assert 'C' in rc.env
-    assert isinstance(rc.env['C'], six.string_types)
+    assert isinstance(rc.env['C'], str)
     assert 'D' in rc.env
     assert rc.env['D'] == 'D'
 

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -9,7 +9,6 @@ from test.utils.common import RSAKey
 
 from pexpect import TIMEOUT, EOF
 import pytest
-import six
 
 from ansible_runner.config.runner import RunnerConfig, ExecutionMode
 from ansible_runner.interface import init_runner
@@ -82,11 +81,11 @@ def test_prepare_environment_vars_only_strings(mocker):
 
     rc.prepare_env()
     assert 'A' in rc.env
-    assert isinstance(rc.env['A'], six.string_types)
+    assert isinstance(rc.env['A'], str)
     assert 'B' in rc.env
-    assert isinstance(rc.env['B'], six.string_types)
+    assert isinstance(rc.env['B'], str)
     assert 'C' in rc.env
-    assert isinstance(rc.env['C'], six.string_types)
+    assert isinstance(rc.env['C'], str)
     assert 'D' in rc.env
     assert rc.env['D'] == 'D'
 

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 
 from pytest import raises, fixture
-from six import string_types
 
 import ansible_runner.loader
 
@@ -62,7 +61,7 @@ def test_load_file_text_cache_hit(loader, mocker, tmp_path):
     testfile = tmp_path.joinpath('test').as_posix()
 
     # cache miss
-    res = loader.load_file(testfile, string_types)
+    res = loader.load_file(testfile, str)
     assert mock_get_contents.called
     assert mock_get_contents.called_with_args(testfile)
     assert res == b'test\nstring'
@@ -71,7 +70,7 @@ def test_load_file_text_cache_hit(loader, mocker, tmp_path):
     mock_get_contents.reset_mock()
 
     # cache hit
-    res = loader.load_file(testfile, string_types)
+    res = loader.load_file(testfile, str)
     assert not mock_get_contents.called
     assert res == b'test\nstring'
     assert testfile in loader._cache

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -11,7 +11,6 @@ from test.utils.common import iterate_timeout
 
 import pexpect
 import pytest
-import six
 
 from ansible_runner import Runner
 from ansible_runner.exceptions import CallbackError, AnsibleRunnerException
@@ -84,7 +83,7 @@ def test_verbose_event_created_time(rc):
         assert datetime.datetime.fromisoformat(event['created']).tzinfo == datetime.timezone.utc
 
 
-@pytest.mark.parametrize('value', ['abc123', six.u('Iñtërnâtiônàlizætiøn')])
+@pytest.mark.parametrize('value', ['abc123', 'Iñtërnâtiônàlizætiøn'])
 def test_env_vars(rc, value):
     rc.command = [sys.executable, '-c', 'import os; print(os.getenv("X_MY_ENV"))']
     rc.env = {'X_MY_ENV': value}


### PR DESCRIPTION
We no longer support Python 2, so this library is an unnecessary dependency.