### PR TITLE
pylint: enable W0201

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ enable = [
   "R1735",  # use-dict-literal
   "W0102",  # dangerous-default-value
   "W0108",  # unnecessary-lambda
+  "W0201",  # attribute-defined-outside-init
   "W0612",  # unused-variable
   "W0707",  # raise-missing-from
   "W1202",  # logging-format-interpolation

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -16,6 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# pylint: disable=W0201
+
 import json
 import logging
 import os

--- a/src/ansible_runner/config/ansible_cfg.py
+++ b/src/ansible_runner/config/ansible_cfg.py
@@ -16,6 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# pylint: disable=W0201
+
 import logging
 
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode

--- a/src/ansible_runner/config/command.py
+++ b/src/ansible_runner/config/command.py
@@ -16,6 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# pylint: disable=W0201
+
 import logging
 import os
 

--- a/src/ansible_runner/config/doc.py
+++ b/src/ansible_runner/config/doc.py
@@ -16,6 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# pylint: disable=W0201
+
 import logging
 
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode

--- a/src/ansible_runner/config/inventory.py
+++ b/src/ansible_runner/config/inventory.py
@@ -16,6 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# pylint: disable=W0201
+
 import logging
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -16,6 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+# pylint: disable=W0201
+
 import json
 import logging
 import os

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -38,6 +38,7 @@ class Runner:
         self.status = "unstarted"
         self.rc = None
         self.remove_partials = remove_partials
+        self.last_stdout_update = 0.0
 
         # default runner mode to pexpect
         self.runner_mode = self.config.runner_mode if hasattr(self.config, 'runner_mode') else 'pexpect'

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -31,6 +31,9 @@ class UUIDEncoder(json.JSONEncoder):
 class MockConfig:
     def __init__(self, settings):
         self.settings = settings
+        self.command = None
+        self.cwd = None
+        self.env = None
 
 
 class Transmitter:


### PR DESCRIPTION
Enable pylint warning `W0201` (attribute-defined-outside-init).

This warning is disabled for files in the `config` source directory since those will take quite a bit of time to fix up properly as they make _heavy_ use of this programming style. However, this should prevent new code from containing the error.