### PR TITLE
pylint: enable W0212

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ enable = [
   "W0102",  # dangerous-default-value
   "W0108",  # unnecessary-lambda
   "W0201",  # attribute-defined-outside-init
+  "W0212",  # protected-access
   "W0612",  # unused-variable
   "W0707",  # raise-missing-from
   "W1202",  # logging-format-interpolation

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -143,7 +143,7 @@ class BaseConfig:
     def containerized(self):
         return self.process_isolation and self.process_isolation_executable in self._CONTAINER_ENGINES
 
-    def _prepare_env(self, runner_mode='pexpect'):
+    def prepare_env(self, runner_mode='pexpect'):
         """
         Manages reading environment metadata files under ``private_data_dir`` and merging/updating
         with existing values so the :py:class:`ansible_runner.runner.Runner` object can read and use them easily
@@ -314,7 +314,7 @@ class BaseConfig:
         for k, v in sorted(self.env.items()):
             debug(f' {k}: {v}')
 
-    def _handle_command_wrap(self, execution_mode, cmdline_args):
+    def handle_command_wrap(self, execution_mode, cmdline_args):
         if self.ssh_key_data:
             logger.debug('ssh key data added')
             self.command = self.wrap_args_with_ssh_agent(self.command, self.ssh_key_path)

--- a/src/ansible_runner/config/ansible_cfg.py
+++ b/src/ansible_runner/config/ansible_cfg.py
@@ -69,7 +69,7 @@ class AnsibleCfgConfig(BaseConfig):
 
         if action != 'dump' and only_changed:
             raise ConfigurationError("only_changed is applicable for action 'dump'")
-        self._prepare_env(runner_mode=self.runner_mode)
+        self.prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = []
 
         self.cmdline_args.append(action)
@@ -80,4 +80,4 @@ class AnsibleCfgConfig(BaseConfig):
             self.cmdline_args.append('--only-changed')
 
         self.command = [self._ansible_config_exec_path] + self.cmdline_args
-        self._handle_command_wrap(self.execution_mode, self.cmdline_args)
+        self.handle_command_wrap(self.execution_mode, self.cmdline_args)

--- a/src/ansible_runner/config/command.py
+++ b/src/ansible_runner/config/command.py
@@ -82,10 +82,10 @@ class CommandConfig(BaseConfig):
         if self.runner_mode is None:
             self._set_runner_mode()
 
-        self._prepare_env(runner_mode=self.runner_mode)
+        self.prepare_env(runner_mode=self.runner_mode)
         self._prepare_command()
 
-        self._handle_command_wrap(self.execution_mode, self.cmdline_args)
+        self.handle_command_wrap(self.execution_mode, self.cmdline_args)
 
     def _prepare_command(self):
         """

--- a/src/ansible_runner/config/doc.py
+++ b/src/ansible_runner/config/doc.py
@@ -72,7 +72,7 @@ class DocConfig(BaseConfig):
         if not isinstance(plugin_names, list):
             raise ConfigurationError(f"plugin_names should be of type list, instead received {plugin_names} of type {type(plugin_names)}")
 
-        self._prepare_env(runner_mode=self.runner_mode)
+        self.prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = []
 
         if response_format == 'json':
@@ -93,7 +93,7 @@ class DocConfig(BaseConfig):
         self.cmdline_args.extend(plugin_names)
 
         self.command = [self._ansible_doc_exec_path] + self.cmdline_args
-        self._handle_command_wrap(self.execution_mode, self.cmdline_args)
+        self.handle_command_wrap(self.execution_mode, self.cmdline_args)
 
     def prepare_plugin_list_command(self, list_files=None, response_format=None, plugin_type=None,
                                     playbook_dir=None, module_path=None):
@@ -102,7 +102,7 @@ class DocConfig(BaseConfig):
             raise ConfigurationError(f"Invalid response_format {response_format}, "
                                      f'valid value is one of either {", ".join(DocConfig._supported_response_formats)}')
 
-        self._prepare_env(runner_mode=self.runner_mode)
+        self.prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = []
 
         if list_files:
@@ -123,13 +123,13 @@ class DocConfig(BaseConfig):
             self.cmdline_args.extend(['-M', module_path])
 
         self.command = [self._ansible_doc_exec_path] + self.cmdline_args
-        self._handle_command_wrap(self.execution_mode, self.cmdline_args)
+        self.handle_command_wrap(self.execution_mode, self.cmdline_args)
 
     def prepare_role_list_command(self, collection_name, playbook_dir):
         """
         ansible-doc -t role -l -j <collection_name>
         """
-        self._prepare_env(runner_mode=self.runner_mode)
+        self.prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = ['-t', 'role', '-l', '-j']
         if playbook_dir:
             self.cmdline_args.extend(['--playbook-dir', playbook_dir])
@@ -137,13 +137,13 @@ class DocConfig(BaseConfig):
             self.cmdline_args.append(collection_name)
 
         self.command = [self._ansible_doc_exec_path] + self.cmdline_args
-        self._handle_command_wrap(self.execution_mode, self.cmdline_args)
+        self.handle_command_wrap(self.execution_mode, self.cmdline_args)
 
     def prepare_role_argspec_command(self, role_name, collection_name, playbook_dir):
         """
         ansible-doc -t role -j <collection_name>.<role_name>
         """
-        self._prepare_env(runner_mode=self.runner_mode)
+        self.prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = ['-t', 'role', '-j']
         if playbook_dir:
             self.cmdline_args.extend(['--playbook-dir', playbook_dir])
@@ -152,4 +152,4 @@ class DocConfig(BaseConfig):
         self.cmdline_args.append(role_name)
 
         self.command = [self._ansible_doc_exec_path] + self.cmdline_args
-        self._handle_command_wrap(self.execution_mode, self.cmdline_args)
+        self.handle_command_wrap(self.execution_mode, self.cmdline_args)

--- a/src/ansible_runner/config/inventory.py
+++ b/src/ansible_runner/config/inventory.py
@@ -82,7 +82,7 @@ class InventoryConfig(BaseConfig):
         if action == "graph" and response_format and response_format != 'json':
             raise ConfigurationError("'graph' action supports only 'json' response format")
 
-        self._prepare_env(runner_mode=self.runner_mode)
+        self.prepare_env(runner_mode=self.runner_mode)
         self.cmdline_args = []
 
         self.cmdline_args.append(f'--{action}')
@@ -111,4 +111,4 @@ class InventoryConfig(BaseConfig):
             self.cmdline_args.append('--export')
 
         self.command = [self._ansible_inventory_exec_path] + self.cmdline_args
-        self._handle_command_wrap(self.execution_mode, self.cmdline_args)
+        self.handle_command_wrap(self.execution_mode, self.cmdline_args)

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -147,7 +147,7 @@ class RunnerConfig(BaseConfig):
         elif self.execution_mode == ExecutionMode.NONE:
             raise ConfigurationError("No executable for runner to run")
 
-        self._handle_command_wrap()
+        self.handle_command_wrap()
 
         debug('env:')
         for k, v in sorted(self.env.items()):
@@ -174,7 +174,7 @@ class RunnerConfig(BaseConfig):
         """
 
         # setup common env settings
-        super(RunnerConfig, self)._prepare_env()
+        super(RunnerConfig, self).prepare_env()
 
         self.process_isolation_path = self.settings.get('process_isolation_path', self.process_isolation_path)
         self.process_isolation_hide_paths = self.settings.get('process_isolation_hide_paths', self.process_isolation_hide_paths)
@@ -389,7 +389,7 @@ class RunnerConfig(BaseConfig):
         new_args.extend(args)
         return new_args
 
-    def _handle_command_wrap(self):
+    def handle_command_wrap(self):
         # wrap args for ssh-agent
         if self.ssh_key_data:
             debug('ssh-agent agrs added')

--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# pylint: disable=W0212
+
 from __future__ import (absolute_import, division, print_function)
 
 

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -150,6 +150,7 @@ class Worker:
         Utility decorator to synchronize event writes and flushes to avoid keepalives splatting in the middle of
         mid-write events, and reset keepalive interval on write completion.
         """
+        # pylint: disable=W0212
         @wraps(wrapped_method)
         def wrapper(self, *args, **kwargs):
             with self._output_lock:

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -6,7 +6,7 @@ import os
 
 def test_combine_python_and_file_settings(project_fixtures):
     rc = BaseConfig(private_data_dir=str(project_fixtures / 'job_env'), settings={'job_timeout': 40}, container_image='bar')
-    rc._prepare_env()
+    rc.prepare_env()
     assert rc.settings == {'job_timeout': 40, 'process_isolation': True}
 
 

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -45,7 +45,7 @@ def test_base_config_with_artifact_dir(tmp_path, patch_private_data_dir):
     assert rc.private_data_dir.startswith(base_private_data_dir)
     assert len(rc.private_data_dir) > len(base_private_data_dir)
 
-    rc._prepare_env()
+    rc.prepare_env()
     assert not tmp_path.joinpath('artifacts').exists()
     assert tmp_path.joinpath('this-is-some-dir').exists()
 
@@ -73,7 +73,7 @@ def test_prepare_environment_vars_only_strings_from_file(mocker):
 
     mocker.patch.object(rc.loader, 'load_file', side_effect=envvar_side_effect)
 
-    rc._prepare_env()
+    rc.prepare_env()
     assert 'A' in rc.env
     assert isinstance(rc.env['A'], str)
     assert 'B' in rc.env
@@ -86,7 +86,7 @@ def test_prepare_environment_vars_only_strings_from_file(mocker):
 
 def test_prepare_environment_vars_only_strings_from_interface():
     rc = BaseConfig(envvars={'D': 'D', 'A': 1, 'B': True, 'C': 'foo'})
-    rc._prepare_env()
+    rc.prepare_env()
 
     assert 'A' in rc.env
     assert isinstance(rc.env['A'], str)
@@ -100,7 +100,7 @@ def test_prepare_environment_vars_only_strings_from_interface():
 
 def test_prepare_environment_pexpect_defaults():
     rc = BaseConfig()
-    rc._prepare_env()
+    rc.prepare_env()
 
     assert len(rc.expect_passwords) == 2
     assert TIMEOUT in rc.expect_passwords
@@ -116,7 +116,7 @@ def test_prepare_env_passwords(mocker):
     password_side_effect = partial(load_file_side_effect, 'env/passwords', value)
 
     mocker.patch.object(rc.loader, 'load_file', side_effect=password_side_effect)
-    rc._prepare_env()
+    rc.prepare_env()
     rc.expect_passwords.pop(TIMEOUT)
     rc.expect_passwords.pop(EOF)
     assert len(rc.expect_passwords) == 1
@@ -126,20 +126,20 @@ def test_prepare_env_passwords(mocker):
 
 def test_prepare_environment_subprocess_defaults():
     rc = BaseConfig()
-    rc._prepare_env(runner_mode="subprocess")
+    rc.prepare_env(runner_mode="subprocess")
     assert rc.subprocess_timeout is None
 
 
 def test_prepare_environment_subprocess_timeout():
     rc = BaseConfig(timeout=100)
-    rc._prepare_env(runner_mode="subprocess")
+    rc.prepare_env(runner_mode="subprocess")
 
     assert rc.subprocess_timeout == 100
 
 
 def test_prepare_env_settings_defaults():
     rc = BaseConfig()
-    rc._prepare_env()
+    rc.prepare_env()
     assert rc.settings == {}
 
 
@@ -150,13 +150,13 @@ def test_prepare_env_settings(mocker):
     settings_side_effect = partial(load_file_side_effect, 'env/settings', value)
 
     mocker.patch.object(rc.loader, 'load_file', side_effect=settings_side_effect)
-    rc._prepare_env()
+    rc.prepare_env()
     assert rc.settings == value
 
 
 def test_prepare_env_sshkey_defaults():
     rc = BaseConfig()
-    rc._prepare_env()
+    rc.prepare_env()
     assert rc.ssh_key_data is None
 
 
@@ -168,13 +168,13 @@ def test_prepare_env_sshkey(mocker):
     sshkey_side_effect = partial(load_file_side_effect, 'env/ssh_key', rsa_private_key_value)
 
     mocker.patch.object(rc.loader, 'load_file', side_effect=sshkey_side_effect)
-    rc._prepare_env()
+    rc.prepare_env()
     assert rc.ssh_key_data == rsa_private_key_value
 
 
 def test_prepare_env_defaults():
     rc = BaseConfig(host_cwd='/tmp/project')
-    rc._prepare_env()
+    rc.prepare_env()
 
     assert rc.idle_timeout is None
     assert rc.job_timeout is None
@@ -193,7 +193,7 @@ def test_prepare_env_ansible_vars(mocker, tmp_path):
     rc.env = {}
     rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
 
-    rc._prepare_env()
+    rc.prepare_env()
 
     assert not hasattr(rc, 'ssh_key_path')
     assert not hasattr(rc, 'command')
@@ -216,7 +216,7 @@ def test_prepare_with_ssh_key(mocker, tmp_path):
     rc.ssh_key_data = rsa_key.private
     rc.command = 'ansible-playbook'
     rc.cmdline_args = []
-    rc._prepare_env()
+    rc.prepare_env()
 
     assert rc.ssh_key_path == custom_artifacts.joinpath('ssh_key_data').as_posix()
     assert open_fifo_write_mock.called
@@ -298,8 +298,8 @@ def test_containerization_settings(tmp_path, runtime, mocker):
     rc.container_image = 'my_container'
     rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
     rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
-    rc._prepare_env()
-    rc._handle_command_wrap(rc.execution_mode, rc.cmdline_args)
+    rc.prepare_env()
+    rc.handle_command_wrap(rc.execution_mode, rc.cmdline_args)
 
     extra_container_args = []
     if runtime == 'podman':
@@ -356,8 +356,8 @@ def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
     rc.container_volume_mounts = ['/host1:/container1', 'host2:/container2']
     mock_containerized.return_value = True
     rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
-    rc._prepare_env()
-    rc._handle_command_wrap(rc.execution_mode, rc.cmdline_args)
+    rc.prepare_env()
+    rc.handle_command_wrap(rc.execution_mode, rc.cmdline_args)
 
     expected = {
         'docker': None,

--- a/test/unit/config/test_container_volmount_generation.py
+++ b/test/unit/config/test_container_volmount_generation.py
@@ -1,6 +1,8 @@
 """ Ensure the generation of container volume mounts is handled
 predictably and consistently """
 
+# pylint: disable=W0212
+
 import os
 from typing import NamedTuple
 

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -1,3 +1,5 @@
+# pylint: disable=W0212
+
 from io import BytesIO
 
 from pytest import raises, fixture

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -1,3 +1,5 @@
+# pylint: disable=W0212
+
 import datetime
 import io
 import json


### PR DESCRIPTION
Enable pylint warning W0212 to warn of access to protected class members.

Some protected methods were renamed (removed the leading underscore) where it made sense (e.g., where subclasses accessed the member, thus it shouldn't be private). For tests, accessing private members makes testing simpler, so that warning is ignored in those instances.