### PR TITLE
pylint: Fix remaining pylint refactor (Rxxxx) problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,15 @@ disable = [
   "C0115",  # missing-class-docstring
   "C0116",  # missing-function-docstring
   "C0301",  # line-too-long
+  "R0801",  # duplicate-code
   "R0902",  # too-many-instance-attributes
+  "R0903",  # too-few-public-methods
+  "R0904",  # too-many-public-methods
+  "R0911",  # too-many-return-statements
+  "R0912",  # too-many-branches
+  "R0913",  # too-many-arguments
+  "R0914",  # too-many-locals
+  "R0915",  # too-many-statements
 ]
 
 enable = [
@@ -34,6 +42,16 @@ enable = [
   "C0415",  # import-outside-toplevel
   "E1101",  # no-member
   "R0205",  # useless-object-inheritance
+  "R1701",  # consider-merging-isinstance
+  "R1704",  # redefined-argument-from-local
+  "R1705",  # no-else-return
+  "R1710",  # inconsistent-return-statements
+  "R1720",  # no-else-raise
+  "R1724",  # no-else-continue
+  "R1725",  # super-with-arguments
+  "R1729",  # use-a-generator
+  "R1730",  # consider-using-min-builtin
+  "R1732",  # consider-using-with
   "R1735",  # use-dict-literal
   "W0102",  # dangerous-default-value
   "W0108",  # unnecessary-lambda

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -380,7 +380,7 @@ class AnsibleRunnerArgumentParser(argparse.ArgumentParser):
         if 'required: command' in message.lower():
             print_common_usage()
 
-        super(AnsibleRunnerArgumentParser, self).error(message)
+        super().error(message)
 
 
 @contextmanager
@@ -875,7 +875,8 @@ def main(sys_args=None):
                 except Exception:
                     e = traceback.format_exc()
                     if stderr_path:
-                        open(stderr_path, 'w+').write(e)
+                        with open(stderr_path, 'w+') as ep:
+                            ep.write(e)
                     else:
                         sys.stderr.write(e)
                     return 1
@@ -891,12 +892,14 @@ def main(sys_args=None):
         Runner.handle_termination(pid, pidfile=pidfile)
         return 0
 
-    elif vargs.get('command') == 'is-alive':
+    if vargs.get('command') == 'is-alive':
         try:
             os.kill(pid, signal.SIG_DFL)
             return 0
         except OSError:
             return 1
+
+    return 0
 
 
 if __name__ == '__main__':

--- a/src/ansible_runner/cleanup.py
+++ b/src/ansible_runner/cleanup.py
@@ -102,10 +102,10 @@ def delete_associated_folders(dir: str) -> None:
     """Where dir is the private_data_dir for a completed job, this deletes related tmp folders it used"""
     for ident in project_idents(dir):
         registry_auth_pattern = f'{gettempdir()}/{registry_auth_prefix}{ident}_*'
-        for dir in glob.glob(registry_auth_pattern):
-            changed = cleanup_folder(dir)
+        for radir in glob.glob(registry_auth_pattern):
+            changed = cleanup_folder(radir)
             if changed:
-                print(f'Removed associated registry auth dir {dir}')
+                print(f'Removed associated registry auth dir {radir}')
 
 
 def validate_pattern(pattern: str) -> None:

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -360,7 +360,7 @@ class BaseConfig:
             for arg in _book_keeping_copy[1:]:
                 if arg[0] == '-':
                     continue
-                elif _book_keeping_copy[(_book_keeping_copy.index(arg) - 1)][0] != '-':
+                if _book_keeping_copy[(_book_keeping_copy.index(arg) - 1)][0] != '-':
                     _playbook = arg
                     break
 

--- a/src/ansible_runner/config/ansible_cfg.py
+++ b/src/ansible_runner/config/ansible_cfg.py
@@ -58,7 +58,7 @@ class AnsibleCfgConfig(BaseConfig):
             self._ansible_config_exec_path = get_executable_path("ansible-config")
 
         self.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
-        super(AnsibleCfgConfig, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     _supported_actions = ('list', 'dump', 'view')
 

--- a/src/ansible_runner/config/command.py
+++ b/src/ansible_runner/config/command.py
@@ -61,7 +61,7 @@ class CommandConfig(BaseConfig):
 
         self.execution_mode = BaseExecutionMode.NONE
 
-        super(CommandConfig, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     _ANSIBLE_NON_INERACTIVE_CMDS = (
         'ansible-config',
@@ -107,5 +107,5 @@ class CommandConfig(BaseConfig):
         if self.execution_mode == BaseExecutionMode.GENERIC_COMMANDS \
            and 'python' in self.executable_cmd.split(os.pathsep)[-1] and self.cmdline_args is None:
             raise ConfigurationError("Runner requires python filename for execution")
-        elif self.execution_mode == BaseExecutionMode.NONE:
+        if self.execution_mode == BaseExecutionMode.NONE:
             raise ConfigurationError("No executable for runner to run")

--- a/src/ansible_runner/config/doc.py
+++ b/src/ansible_runner/config/doc.py
@@ -58,7 +58,7 @@ class DocConfig(BaseConfig):
             self._ansible_doc_exec_path = get_executable_path("ansible-doc")
 
         self.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
-        super(DocConfig, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     _supported_response_formats = ('json', 'human')
 

--- a/src/ansible_runner/config/inventory.py
+++ b/src/ansible_runner/config/inventory.py
@@ -57,7 +57,7 @@ class InventoryConfig(BaseConfig):
             self._ansible_inventory_exec_path = get_executable_path("ansible-inventory")
 
         self.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
-        super(InventoryConfig, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     _supported_response_formats = ('json', 'yaml', 'toml')
     _supported_actions = ('graph', 'host', 'list')

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -73,7 +73,7 @@ class RunnerConfig(BaseConfig):
 
         self.runner_mode = "pexpect"
 
-        super(RunnerConfig, self).__init__(private_data_dir, **kwargs)
+        super().__init__(private_data_dir, **kwargs)
 
         self.playbook = playbook
         self.inventory = inventory
@@ -142,9 +142,9 @@ class RunnerConfig(BaseConfig):
 
         if self.execution_mode == ExecutionMode.ANSIBLE_PLAYBOOK and self.playbook is None:
             raise ConfigurationError("Runner playbook required when running ansible-playbook")
-        elif self.execution_mode == ExecutionMode.ANSIBLE and self.module is None:
+        if self.execution_mode == ExecutionMode.ANSIBLE and self.module is None:
             raise ConfigurationError("Runner module required when running ansible")
-        elif self.execution_mode == ExecutionMode.NONE:
+        if self.execution_mode == ExecutionMode.NONE:
             raise ConfigurationError("No executable for runner to run")
 
         self.handle_command_wrap()
@@ -174,7 +174,7 @@ class RunnerConfig(BaseConfig):
         """
 
         # setup common env settings
-        super(RunnerConfig, self).prepare_env()
+        super().prepare_env()
 
         self.process_isolation_path = self.settings.get('process_isolation_path', self.process_isolation_path)
         self.process_isolation_hide_paths = self.settings.get('process_isolation_hide_paths', self.process_isolation_hide_paths)

--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -92,9 +92,9 @@ class AnsibleJSONEncoderLocal(json.JSONEncoder):
             if isinstance(encrypted_form, bytes):
                 encrypted_form = encrypted_form.decode('utf-8')
             return {'__ansible_vault': encrypted_form}
-        elif isinstance(o, (datetime.date, datetime.datetime)):
+        if isinstance(o, (datetime.date, datetime.datetime)):
             return o.isoformat()
-        return super(AnsibleJSONEncoderLocal, self).default(o)
+        return super().default(o)
 
 
 class IsolatedFileWrite:
@@ -341,7 +341,7 @@ class CallbackModule(DefaultCallbackModule):
     ]
 
     def __init__(self):
-        super(CallbackModule, self).__init__()
+        super().__init__()
         self._host_start = {}
         self.task_uuids = set()
         self.duplicate_task_counts = collections.defaultdict(lambda: 1)
@@ -455,7 +455,7 @@ class CallbackModule(DefaultCallbackModule):
             'uuid': self.playbook_uuid,
         }
         with self.capture_event_data('playbook_on_start', **event_data):
-            super(CallbackModule, self).v2_playbook_on_start(playbook)
+            super().v2_playbook_on_start(playbook)
 
     def v2_playbook_on_vars_prompt(self, varname, private=True, prompt=None,
                                    encrypt=None, confirm=False, salt_size=None,
@@ -472,7 +472,7 @@ class CallbackModule(DefaultCallbackModule):
             'unsafe': unsafe,
         }
         with self.capture_event_data('playbook_on_vars_prompt', **event_data):
-            super(CallbackModule, self).v2_playbook_on_vars_prompt(
+            super().v2_playbook_on_vars_prompt(
                 varname, private, prompt, encrypt, confirm, salt_size, salt,
                 default,
             )
@@ -482,7 +482,7 @@ class CallbackModule(DefaultCallbackModule):
             'included_file': included_file._filename if included_file is not None else None,
         }
         with self.capture_event_data('playbook_on_include', **event_data):
-            super(CallbackModule, self).v2_playbook_on_include(included_file)
+            super().v2_playbook_on_include(included_file)
 
     def v2_playbook_on_play_start(self, play):
         if IS_ADHOC:
@@ -520,22 +520,22 @@ class CallbackModule(DefaultCallbackModule):
             'uuid': str(play._uuid),
         }
         with self.capture_event_data('playbook_on_play_start', **event_data):
-            super(CallbackModule, self).v2_playbook_on_play_start(play)
+            super().v2_playbook_on_play_start(play)
 
     def v2_playbook_on_import_for_host(self, result, imported_file):
         # NOTE: Not used by Ansible 2.x.
         with self.capture_event_data('playbook_on_import_for_host'):
-            super(CallbackModule, self).v2_playbook_on_import_for_host(result, imported_file)
+            super().v2_playbook_on_import_for_host(result, imported_file)
 
     def v2_playbook_on_not_import_for_host(self, result, missing_file):
         # NOTE: Not used by Ansible 2.x.
         with self.capture_event_data('playbook_on_not_import_for_host'):
-            super(CallbackModule, self).v2_playbook_on_not_import_for_host(result, missing_file)
+            super().v2_playbook_on_not_import_for_host(result, missing_file)
 
     def v2_playbook_on_setup(self):
         # NOTE: Not used by Ansible 2.x.
         with self.capture_event_data('playbook_on_setup'):
-            super(CallbackModule, self).v2_playbook_on_setup()
+            super().v2_playbook_on_setup()
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         if IS_ADHOC:
@@ -566,7 +566,7 @@ class CallbackModule(DefaultCallbackModule):
             'uuid': task_uuid,
         }
         with self.capture_event_data('playbook_on_task_start', **event_data):
-            super(CallbackModule, self).v2_playbook_on_task_start(task, is_conditional)
+            super().v2_playbook_on_task_start(task, is_conditional)
 
     def v2_playbook_on_cleanup_task_start(self, task):
         # NOTE: Not used by Ansible 2.x.
@@ -578,7 +578,7 @@ class CallbackModule(DefaultCallbackModule):
             'is_conditional': True,
         }
         with self.capture_event_data('playbook_on_task_start', **event_data):
-            super(CallbackModule, self).v2_playbook_on_cleanup_task_start(task)
+            super().v2_playbook_on_cleanup_task_start(task)
 
     def v2_playbook_on_handler_task_start(self, task):
         # NOTE: Re-using playbook_on_task_start event for this v2-specific
@@ -592,15 +592,15 @@ class CallbackModule(DefaultCallbackModule):
             'is_conditional': True,
         }
         with self.capture_event_data('playbook_on_task_start', **event_data):
-            super(CallbackModule, self).v2_playbook_on_handler_task_start(task)
+            super().v2_playbook_on_handler_task_start(task)
 
     def v2_playbook_on_no_hosts_matched(self):
         with self.capture_event_data('playbook_on_no_hosts_matched'):
-            super(CallbackModule, self).v2_playbook_on_no_hosts_matched()
+            super().v2_playbook_on_no_hosts_matched()
 
     def v2_playbook_on_no_hosts_remaining(self):
         with self.capture_event_data('playbook_on_no_hosts_remaining'):
-            super(CallbackModule, self).v2_playbook_on_no_hosts_remaining()
+            super().v2_playbook_on_no_hosts_remaining()
 
     def v2_playbook_on_notify(self, handler, host):
         # NOTE: Not used by Ansible < 2.5.
@@ -609,7 +609,7 @@ class CallbackModule(DefaultCallbackModule):
             'handler': handler.get_name(),
         }
         with self.capture_event_data('playbook_on_notify', **event_data):
-            super(CallbackModule, self).v2_playbook_on_notify(handler, host)
+            super().v2_playbook_on_notify(handler, host)
 
     '''
     ansible_stats is, retroactively, added in 2.2
@@ -630,13 +630,13 @@ class CallbackModule(DefaultCallbackModule):
         }
 
         with self.capture_event_data('playbook_on_stats', **event_data):
-            super(CallbackModule, self).v2_playbook_on_stats(stats)
+            super().v2_playbook_on_stats(stats)
 
     @staticmethod
     def _get_event_loop(task):
         if hasattr(task, 'loop_with'):  # Ansible >=2.5
             return task.loop_with
-        elif hasattr(task, 'loop'):  # Ansible <2.4
+        if hasattr(task, 'loop'):  # Ansible <2.4
             return task.loop
         return None
 
@@ -667,7 +667,7 @@ class CallbackModule(DefaultCallbackModule):
             'event_loop': self._get_event_loop(result._task),
         }
         with self.capture_event_data('runner_on_ok', **event_data):
-            super(CallbackModule, self).v2_runner_on_ok(result)
+            super().v2_runner_on_ok(result)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         # FIXME: Add verbosity for exception/results output.
@@ -684,7 +684,7 @@ class CallbackModule(DefaultCallbackModule):
             'event_loop': self._get_event_loop(result._task),
         }
         with self.capture_event_data('runner_on_failed', **event_data):
-            super(CallbackModule, self).v2_runner_on_failed(result, ignore_errors)
+            super().v2_runner_on_failed(result, ignore_errors)
 
     def v2_runner_on_skipped(self, result):
         host_start, end_time, duration = self._get_result_timing_data(result)
@@ -698,7 +698,7 @@ class CallbackModule(DefaultCallbackModule):
             'event_loop': self._get_event_loop(result._task),
         }
         with self.capture_event_data('runner_on_skipped', **event_data):
-            super(CallbackModule, self).v2_runner_on_skipped(result)
+            super().v2_runner_on_skipped(result)
 
     def v2_runner_on_unreachable(self, result):
         host_start, end_time, duration = self._get_result_timing_data(result)
@@ -712,7 +712,7 @@ class CallbackModule(DefaultCallbackModule):
             'res': result._result,
         }
         with self.capture_event_data('runner_on_unreachable', **event_data):
-            super(CallbackModule, self).v2_runner_on_unreachable(result)
+            super().v2_runner_on_unreachable(result)
 
     def v2_runner_on_no_hosts(self, task):
         # NOTE: Not used by Ansible 2.x.
@@ -720,7 +720,7 @@ class CallbackModule(DefaultCallbackModule):
             'task': task,
         }
         with self.capture_event_data('runner_on_no_hosts', **event_data):
-            super(CallbackModule, self).v2_runner_on_no_hosts(task)
+            super().v2_runner_on_no_hosts(task)
 
     def v2_runner_on_async_poll(self, result):
         # NOTE: Not used by Ansible 2.x.
@@ -731,7 +731,7 @@ class CallbackModule(DefaultCallbackModule):
             'jid': result._result.get('ansible_job_id'),
         }
         with self.capture_event_data('runner_on_async_poll', **event_data):
-            super(CallbackModule, self).v2_runner_on_async_poll(result)
+            super().v2_runner_on_async_poll(result)
 
     def v2_runner_on_async_ok(self, result):
         # NOTE: Not used by Ansible 2.x.
@@ -742,7 +742,7 @@ class CallbackModule(DefaultCallbackModule):
             'jid': result._result.get('ansible_job_id'),
         }
         with self.capture_event_data('runner_on_async_ok', **event_data):
-            super(CallbackModule, self).v2_runner_on_async_ok(result)
+            super().v2_runner_on_async_ok(result)
 
     def v2_runner_on_async_failed(self, result):
         # NOTE: Not used by Ansible 2.x.
@@ -753,7 +753,7 @@ class CallbackModule(DefaultCallbackModule):
             'jid': result._result.get('ansible_job_id'),
         }
         with self.capture_event_data('runner_on_async_failed', **event_data):
-            super(CallbackModule, self).v2_runner_on_async_failed(result)
+            super().v2_runner_on_async_failed(result)
 
     def v2_runner_on_file_diff(self, result, diff):
         # NOTE: Not used by Ansible 2.x.
@@ -763,7 +763,7 @@ class CallbackModule(DefaultCallbackModule):
             'diff': diff,
         }
         with self.capture_event_data('runner_on_file_diff', **event_data):
-            super(CallbackModule, self).v2_runner_on_file_diff(result, diff)
+            super().v2_runner_on_file_diff(result, diff)
 
     def v2_on_file_diff(self, result):
         # NOTE: Logged as runner_on_file_diff.
@@ -773,7 +773,7 @@ class CallbackModule(DefaultCallbackModule):
             'diff': result._result.get('diff'),
         }
         with self.capture_event_data('runner_on_file_diff', **event_data):
-            super(CallbackModule, self).v2_on_file_diff(result)
+            super().v2_on_file_diff(result)
 
     def v2_runner_item_on_ok(self, result):
         event_data = {
@@ -782,7 +782,7 @@ class CallbackModule(DefaultCallbackModule):
             'res': result._result,
         }
         with self.capture_event_data('runner_item_on_ok', **event_data):
-            super(CallbackModule, self).v2_runner_item_on_ok(result)
+            super().v2_runner_item_on_ok(result)
 
     def v2_runner_item_on_failed(self, result):
         event_data = {
@@ -791,7 +791,7 @@ class CallbackModule(DefaultCallbackModule):
             'res': result._result,
         }
         with self.capture_event_data('runner_item_on_failed', **event_data):
-            super(CallbackModule, self).v2_runner_item_on_failed(result)
+            super().v2_runner_item_on_failed(result)
 
     def v2_runner_item_on_skipped(self, result):
         event_data = {
@@ -800,7 +800,7 @@ class CallbackModule(DefaultCallbackModule):
             'res': result._result,
         }
         with self.capture_event_data('runner_item_on_skipped', **event_data):
-            super(CallbackModule, self).v2_runner_item_on_skipped(result)
+            super().v2_runner_item_on_skipped(result)
 
     def v2_runner_retry(self, result):
         event_data = {
@@ -809,7 +809,7 @@ class CallbackModule(DefaultCallbackModule):
             'res': result._result,
         }
         with self.capture_event_data('runner_retry', **event_data):
-            super(CallbackModule, self).v2_runner_retry(result)
+            super().v2_runner_retry(result)
 
     def v2_runner_on_start(self, host, task):
         event_data = {
@@ -818,4 +818,4 @@ class CallbackModule(DefaultCallbackModule):
         }
         self._host_start[host.get_name()] = current_time()
         with self.capture_event_data('runner_on_start', **event_data):
-            super(CallbackModule, self).v2_runner_on_start(host, task)
+            super().v2_runner_on_start(host, task)

--- a/src/ansible_runner/loader.py
+++ b/src/ansible_runner/loader.py
@@ -58,7 +58,7 @@ class ArtifactLoader:
         try:
             return json.loads(contents)
         except ValueError:
-            pass
+            return None
 
     def _load_yaml(self, contents):
         '''
@@ -75,7 +75,7 @@ class ArtifactLoader:
         try:
             return safe_load(contents)
         except YAMLError:
-            pass
+            return None
 
     def get_contents(self, path):
         '''

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -114,6 +114,9 @@ class Runner:
         Launch the Ansible task configured in self.config (A RunnerConfig object), returns once the
         invocation is complete
         '''
+
+        # pylint: disable=R1732
+
         password_patterns = []
         password_values = []
 
@@ -514,13 +517,13 @@ class Runner:
         if container_name:
             container_cli = self.config.process_isolation_executable
             cmd = [container_cli, 'kill', container_name]
-            proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
-            _, stderr = proc.communicate()
-            if proc.returncode:
-                logger.info("Error from %s kill %s command:\n%s",
-                            container_cli, container_name, stderr)
-            else:
-                logger.info("Killed container %s", container_name)
+            with Popen(cmd, stdout=PIPE, stderr=PIPE) as proc:
+                _, stderr = proc.communicate()
+                if proc.returncode:
+                    logger.info("Error from %s kill %s command:\n%s",
+                                container_cli, container_name, stderr)
+                else:
+                    logger.info("Killed container %s", container_name)
 
     @classmethod
     def handle_termination(cls, pid, pidfile=None, is_cancel=True):

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -112,6 +112,9 @@ class Worker:
 
     def _keepalive_loop(self):
         """Main loop for keepalive injection thread; exits when keepalive interval is <= 0"""
+
+        # pylint: disable=R1732
+
         while self._keepalive_interval_sec > 0:
             # block until output has occurred or keepalive interval elapses
             if self._output_event.wait(timeout=self._keepalive_interval_sec):

--- a/src/ansible_runner/utils/__init__.py
+++ b/src/ansible_runner/utils/__init__.py
@@ -97,7 +97,7 @@ def isinventory(obj):
     Returns:
         boolean: True if the object is an inventory dict and False if it is not
     '''
-    return isinstance(obj, MutableMapping) or isinstance(obj, str)
+    return isinstance(obj, (MutableMapping, str))
 
 
 def check_isolation_executable_installed(isolation_executable):
@@ -106,14 +106,14 @@ def check_isolation_executable_installed(isolation_executable):
     '''
     cmd = [isolation_executable, '--version']
     try:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        proc.communicate()
-        return bool(proc.returncode == 0)
-    except (OSError, ValueError) as e:
-        if isinstance(e, ValueError) or getattr(e, 'errno', 1) != 2:  # ENOENT, no such file or directory
-            raise RuntimeError(f'{isolation_executable} unavailable for unexpected reason.') from e
-        return False
+        with subprocess.Popen(cmd,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE) as proc:
+            proc.communicate()
+            return bool(proc.returncode == 0)
+    except FileNotFoundError:
+        pass
+    return False
 
 
 def dump_artifact(obj, path, filename=None):
@@ -433,7 +433,7 @@ def ensure_str(s, encoding='utf-8', errors='strict'):
     """
     if not isinstance(s, (str, bytes)):
         raise TypeError(f"not expecting type '{type(s)}'")
-    elif isinstance(s, bytes):
+    if isinstance(s, bytes):
         s = s.decode(encoding, errors)
     return s
 

--- a/src/ansible_runner/utils/base64io.py
+++ b/src/ansible_runner/utils/base64io.py
@@ -85,7 +85,7 @@ class Base64IO(io.IOBase):
             raise TypeError(
                 f"Base64IO wrapped object must have attributes: {repr(sorted(required_attrs))}"
             )
-        super(Base64IO, self).__init__()
+        super().__init__()
         self.__wrapped = wrapped
         self.__read_buffer = b""
         self.__write_buffer = b""
@@ -126,8 +126,7 @@ class Base64IO(io.IOBase):
             method = getattr(self.__wrapped, method_name)
         except AttributeError:
             return False
-        else:
-            return method()
+        return method()
 
     def writable(self):
         # type: () -> bool
@@ -259,7 +258,7 @@ class Base64IO(io.IOBase):
         # Remove whitespace from read data and attempt to read more data to get the desired
         # number of bytes.
 
-        if any([char in data for char in string.whitespace.encode("utf-8")]):
+        if any(char in data for char in string.whitespace.encode("utf-8")):
             data = self._read_additional_data_removing_whitespace(data, _bytes_to_read)
 
         results = io.BytesIO()

--- a/src/ansible_runner/utils/capacity.py
+++ b/src/ansible_runner/utils/capacity.py
@@ -35,10 +35,10 @@ def ensure_uuid(uuid_file_path: Path | None = None, mode: int = 0o0600):
         # Read the contents of file if it already exists
         saved_uuid = uuid_file_path.read_text()
         return saved_uuid.strip()
-    else:
-        # Generate a new UUID if file is not found
-        newly_generated_uuid = _set_uuid(uuid_file_path, mode)
-        return newly_generated_uuid
+
+    # Generate a new UUID if file is not found
+    newly_generated_uuid = _set_uuid(uuid_file_path, mode)
+    return newly_generated_uuid
 
 
 def _set_uuid(uuid_file_path: Path | None = None, mode: int = 0o0600):

--- a/src/ansible_runner/utils/streaming.py
+++ b/src/ansible_runner/utils/streaming.py
@@ -1,3 +1,5 @@
+# pylint: disable=R0914
+
 import io
 import time
 import tempfile
@@ -66,8 +68,7 @@ def unstream_dir(stream: io.FileIO, length: int, target_directory: str) -> None:
                 remaining = length
                 chunk_size = 1024 * 1000  # 1 MB
                 while remaining != 0:
-                    if chunk_size >= remaining:
-                        chunk_size = remaining
+                    chunk_size = min(chunk_size, remaining)
 
                     data = source.read(chunk_size)
                     target.write(data)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -38,7 +38,8 @@ def is_pre_ansible211():
             return False
     except importlib_metadata.PackageNotFoundError:
         # Must be ansible-base or ansible
-        return True
+        pass
+    return True
 
 
 @pytest.fixture(scope='session')
@@ -55,6 +56,7 @@ def is_pre_ansible212():
             return True
     except importlib_metadata.PackageNotFoundError:
         pass
+    return False
 
 
 @pytest.fixture(scope="session")

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -11,7 +11,6 @@ from pexpect import TIMEOUT, EOF
 import pytest
 
 from ansible_runner.config.runner import RunnerConfig, ExecutionMode
-from ansible_runner.interface import init_runner
 from ansible_runner.loader import ArtifactLoader
 from ansible_runner.exceptions import ConfigurationError
 
@@ -517,26 +516,6 @@ def test_wrap_args_with_ssh_agent_silent(mocker):
         'sh', '-c',
         "trap 'rm -f /tmp/sshkey' EXIT && ssh-add /tmp/sshkey 2>/dev/null && rm -f /tmp/sshkey && ansible-playbook main.yaml"
     ]
-
-
-@pytest.mark.parametrize('executable_present', [True, False])
-def test_process_isolation_executable_not_found(executable_present, mocker):
-    mocker.patch('ansible_runner.runner_config.RunnerConfig.prepare')
-    mock_sys = mocker.patch('ansible_runner.interface.sys')
-    mock_subprocess = mocker.patch('ansible_runner.utils.subprocess')
-    # Mock subprocess.Popen indicates if
-    # process isolation executable is present
-    mock_proc = mocker.Mock()
-    mock_proc.returncode = (0 if executable_present else 1)
-    mock_subprocess.Popen.return_value = mock_proc
-
-    kwargs = {'process_isolation': True,
-              'process_isolation_executable': 'fake_executable'}
-    init_runner(**kwargs)
-    if executable_present:
-        assert not mock_sys.exit.called
-    else:
-        assert mock_sys.exit.called
 
 
 def test_bwrap_process_isolation_defaults(mocker):

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -15,6 +15,7 @@ import pytest
 from ansible_runner.utils import (
     isplaybook,
     isinventory,
+    check_isolation_executable_installed,
     args2cmdline,
     sanitize_container_name,
     signal_handler,
@@ -46,6 +47,11 @@ def test_isinventory_invalid(inventory):
 def test_args2cmdline():
     res = args2cmdline('ansible', '-m', 'setup', 'localhost')
     assert res == 'ansible -m setup localhost'
+
+
+def test_check_isolation_executable_installed():
+    assert check_isolation_executable_installed("true")
+    assert not check_isolation_executable_installed("does-not-exist")
 
 
 @pytest.mark.parametrize('container_name,expected_name', [


### PR DESCRIPTION
Corrects many of the refactor suggestions from pylint. Some others are ignored (`too-many-*` and `too-few-*`, for example) because of the work required to rewrite the code.

Tests for `check_isolation_executable_installed()` were required to be modified (due to adding use of context manager for `Popen()`) to be much simpler and not require `Mock`-ing the world.