### PR TITLE
Updating UTC handing to use UTC aware objects

### DIFF
--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -70,7 +70,7 @@ CENSORED = "the output has been hidden due to the fact that 'no_log: true' was s
 
 
 def current_time():
-    return datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+    return datetime.datetime.now(datetime.UTC)
 
 
 # use a custom JSON serializer so we can properly handle !unsafe and !vault

--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -70,7 +70,7 @@ CENSORED = "the output has been hidden due to the fact that 'no_log: true' was s
 
 
 def current_time():
-    return datetime.datetime.now(datetime.UTC)
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 # use a custom JSON serializer so we can properly handle !unsafe and !vault

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -82,7 +82,7 @@ class Runner:
 
                 # prefer 'created' from partial data, but verbose events set time here
                 if 'created' not in event_data:
-                    event_data['created'] = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
+                    event_data['created'] = datetime.datetime.now(datetime.UTC).isoformat()
 
                 if self.event_handler is not None:
                     should_write = self.event_handler(event_data)


### PR DESCRIPTION
Python 3.12 will throw DeprecationWarning: datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.now(datetime.UTC)