### PR TITLE
Add type hints to ArtifactLoader

### DIFF
--- a/src/ansible_runner/loader.py
+++ b/src/ansible_runner/loader.py
@@ -16,10 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
+from __future__ import annotations
+
 import os
 import json
 import codecs
 
+from typing import Any, Dict
 from yaml import safe_load, YAMLError
 
 from ansible_runner.exceptions import ConfigurationError
@@ -39,58 +43,49 @@ class ArtifactLoader:
     to load the same file.
     '''
 
-    def __init__(self, base_path):
-        self._cache = {}
+    def __init__(self, base_path: str):
+        self._cache: Dict[str, Any] = {}
         self.base_path = base_path
 
-    def _load_json(self, contents):
+    def _load_json(self, contents: str) -> dict | None:
         '''
         Attempts to deserialize the contents of a JSON object
 
-        Args:
-            contents (string): The contents to deserialize
+        :param str contents: The contents to deserialize.
 
-        Returns:
-            dict: If the contents are JSON serialized
-
-            None: If the contents are not JSON serialized
+        :return: A dict if the contents are JSON serialized,
+            otherwise returns None.
         '''
         try:
             return json.loads(contents)
         except ValueError:
             return None
 
-    def _load_yaml(self, contents):
+    def _load_yaml(self, contents: str) -> dict | None:
         '''
-        Attempts to deserialize the contents of a YAML object
+        Attempts to deserialize the contents of a YAML object.
 
-        Args:
-            contents (string): The contents to deserialize
+        :param str contents: The contents to deserialize.
 
-        Returns:
-            dict: If the contents are YAML serialized
-
-            None: If the contents are not YAML serialized
-        '''
+        :return: A dict if the contents are YAML serialized,
+            otherwise returns None.
+       '''
         try:
             return safe_load(contents)
         except YAMLError:
             return None
 
-    def get_contents(self, path):
+    def _get_contents(self, path: str) -> str:
         '''
         Loads the contents of the file specified by path
 
-        Args:
-            path (string): The relative or absolute path to the file to
-                be loaded.  If the path is relative, then it is combined
-                with the base_path to generate a full path string
+        :param str path: The relative or absolute path to the file to
+            be loaded.  If the path is relative, then it is combined
+            with the base_path to generate a full path string
 
-        Returns:
-            string: The contents of the file as a string
+        :return: The contents of the file as a string
 
-        Raises:
-            ConfigurationError: If the file cannot be loaded
+        :raises: ConfigurationError if the file cannot be loaded.
         '''
         try:
             if not os.path.exists(path):
@@ -103,55 +98,49 @@ class ArtifactLoader:
         except (IOError, OSError) as exc:
             raise ConfigurationError(f"error trying to load file contents: {exc}") from exc
 
-    def abspath(self, path):
+    def abspath(self, path: str) -> str:
         '''
         Transform the path to an absolute path
 
-        Args:
-            path (string): The path to transform to an absolute path
+        :param str path: The path to transform to an absolute path
 
-        Returns:
-            string: The absolute path to the file
+        :return: The absolute path to the file.
         '''
         if not path.startswith(os.path.sep) or path.startswith('~'):
             path = os.path.expanduser(os.path.join(self.base_path, path))
         return path
 
-    def isfile(self, path):
+    def isfile(self, path: str) -> bool:
         '''
         Check if the path is a file
 
-        :params path: The path to the file to check.  If the path is relative
+        :param str path: The path to the file to check.  If the path is relative
             it will be exanded to an absolute path
 
-        :returns: boolean
+        :return: True if path is a file, False otherwise.
         '''
         return os.path.isfile(self.abspath(path))
 
-    def load_file(self, path, objtype=None, encoding='utf-8'):
+    def load_file(self, path: str, objtype: Any | None = None, encoding='utf-8') -> bytes | str | dict | None:
         '''
         Load the file specified by path
 
         This method will first try to load the file contents from cache and
         if there is a cache miss, it will load the contents from disk
 
-        Args:
-            path (string): The full or relative path to the file to be loaded
+        :param str path: The full or relative path to the file to be loaded.
+        :param Any objtype: The object type of the file contents.  This
+            is used to type check the deserialized content against the
+            contents loaded from disk. Ignore serializing if objtype is str.
+            Only Mapping or str types are supported.
+        :param str encoding: The file contents text encoding.
 
-            encoding (string): The file contents text encoding
+        :return: The deserialized file contents which could be either a
+            string object or a dict object
 
-            objtype (object): The object type of the file contents.  This
-                is used to type check the deserialized content against the
-                contents loaded from disk.
-                Ignore serializing if objtype is str.
-
-        Returns:
-            object: The deserialized file contents which could be either a
-                string object or a dict object
-
-        Raises:
-            ConfigurationError:
+        :raises: ConfigurationError on error during file load or deserialization.
         '''
+        parsed_data: bytes | str | dict | None
         path = self.abspath(path)
         debug(f"file path is {path}")
 
@@ -160,11 +149,11 @@ class ArtifactLoader:
 
         try:
             debug(f"cache miss, attempting to load file from disk: {path}")
-            contents = parsed_data = self.get_contents(path)
+            contents = parsed_data = self._get_contents(path)
             if encoding:
                 parsed_data = contents.encode(encoding)
         except ConfigurationError as exc:
-            debug(exc)
+            debug(str(exc))
             raise
         except UnicodeEncodeError as exc:
             raise ConfigurationError('unable to encode file contents') from exc

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -55,7 +55,7 @@ def test_abspath(loader, tmp_path):
 
 
 def test_load_file_text_cache_hit(loader, mocker, tmp_path):
-    mock_get_contents = mocker.patch.object(ansible_runner.loader.ArtifactLoader, 'get_contents')
+    mock_get_contents = mocker.patch.object(ansible_runner.loader.ArtifactLoader, '_get_contents')
     mock_get_contents.return_value = 'test\nstring'
 
     assert not loader._cache
@@ -79,7 +79,7 @@ def test_load_file_text_cache_hit(loader, mocker, tmp_path):
 
 
 def test_load_file_json(loader, mocker, tmp_path):
-    mock_get_contents = mocker.patch.object(ansible_runner.loader.ArtifactLoader, 'get_contents')
+    mock_get_contents = mocker.patch.object(ansible_runner.loader.ArtifactLoader, '_get_contents')
     mock_get_contents.return_value = '---\ntest: string'
 
     assert not loader._cache
@@ -94,7 +94,7 @@ def test_load_file_json(loader, mocker, tmp_path):
 
 
 def test_load_file_type_check(loader, mocker, tmp_path):
-    mock_get_contents = mocker.patch.object(ansible_runner.loader.ArtifactLoader, 'get_contents')
+    mock_get_contents = mocker.patch.object(ansible_runner.loader.ArtifactLoader, '_get_contents')
     mock_get_contents.return_value = '---\ntest: string'
 
     assert not loader._cache
@@ -125,15 +125,15 @@ def test_get_contents_ok(loader, mocker):
 
     mock_open.return_value.__enter__.return_value = handler
 
-    res = loader.get_contents('/tmp')
+    res = loader._get_contents('/tmp')
     assert res == b'test string'
 
 
 def test_get_contents_invalid_path(loader, tmp_path):
     with raises(ConfigurationError):
-        loader.get_contents(tmp_path.joinpath('invalid').as_posix())
+        loader._get_contents(tmp_path.joinpath('invalid').as_posix())
 
 
 def test_get_contents_exception(loader, tmp_path):
     with raises(ConfigurationError):
-        loader.get_contents(tmp_path.as_posix())
+        loader._get_contents(tmp_path.as_posix())


### PR DESCRIPTION
- Adds typing data to `ArtifactLoader` class.
- Class method comments changed to conform to sphinx styling.
- Makes `get_contents()` method private since it is not used outside of the class.
