### PR TITLE
pylint: disable R0401 across all files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ disable = [
   "C0115",  # missing-class-docstring
   "C0116",  # missing-function-docstring
   "C0301",  # line-too-long
+  "R0401",  # cyclic-import
   "R0801",  # duplicate-code
   "R0902",  # too-many-instance-attributes
   "R0903",  # too-few-public-methods

--- a/test/unit/config/test_doc.py
+++ b/test/unit/config/test_doc.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable: R0401
 
 import os
 import pytest


### PR DESCRIPTION
For some reason, this refactor warning (`R0401` -- cyclic-import) seems to randomly appear in various files (e.g., test_doc.py, test_uuid.py). Disable across the entire project for now. The entry to disable in `test_doc.py` was the wrong format anyway.