### PR TITLE
Exclude `/run/host-services` When Using Docker Desktop on MacOS

### DIFF
--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -397,9 +397,14 @@ class BaseConfig:
                                    dst_mount_path: str | None = None,
                                    labels: str | None = None
                                    ) -> None:
+        if src_mount_path is None:
+            logger.debug("Source volume mount path was not provided")
+            return
 
-        if src_mount_path is None or not os.path.exists(src_mount_path):
-            logger.debug("Source volume mount path does not exist: %s", src_mount_path)
+        if not os.path.exists(src_mount_path) and not (
+            self.containerized and self.process_isolation_executable == "docker" and os.path.abspath(src_mount_path).startswith("/run/host-services")
+        ):
+            logger.debug("Source volume mount path does not exit {0}".format(src_mount_path))
             return
 
         # ensure source is abs


### PR DESCRIPTION
* Docker Desktop takes care of setting up ssh-agent forwarding from MacOS but does in a way that is only allowed to `root` inside the container
* As documented at the time of commit at https://docs.docker.com/desktop/networking/#ssh-agent-forwarding
* Move the `None` check ahead of the path checking with a specific error message to clearly differentiate that error from path checking errors

Partially addresses #1292 by exempting paths starting with `/run/host-services` in `containerized` mode on `docker`  from the source path check.

I'd like to hear feedback on making `--user root` the default for `docker` possibly when a volume mount has a path sourced in `/run/host-services` on `docker` or in all cases on `docker`.

A similar fix like this one will be required in order to resolve https://github.com/ansible/ansible-navigator/issues/1593 after/if this is merged into `ansible-runner` as well.