### PR TITLE
Refactor and test dump_artifact() method

### DIFF
--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -6,7 +6,7 @@ from ansible_runner.utils import dump_artifact
 
 def test_artifact_permissions(tmp_path):
     """Artifacts should allow user read/write"""
-    filename = dump_artifact("artifact content", str(tmp_path))
+    filename = dump_artifact("artifact content", str(tmp_path), 'sample.txt')
     file_mode = stat.S_IMODE(os.stat(filename).st_mode)
     user_rw = stat.S_IRUSR | stat.S_IWUSR
     assert (user_rw & file_mode) == user_rw, "file mode is incorrect"

--- a/test/unit/utils/test_dump_artifacts.py
+++ b/test/unit/utils/test_dump_artifacts.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansible_runner.utils import dump_artifacts
+from ansible_runner.utils import dump_artifact, dump_artifacts
 
 
 def test_dump_artifacts_private_data_dir_does_not_exists():
@@ -220,3 +220,59 @@ def test_dump_artifacts_extra_keys(mocker, key, value, value_str):
 
     mock_dump_artifact.assert_called_once_with(value_str, '/tmp/env', key)
     assert 'settings' not in kwargs
+
+
+def test_dump_artifact_new_file(tmp_path):
+    '''
+    Test dump_artifact() with a file that does not exist.
+    '''
+    contents = 'blerg'
+
+    artifacts_dir = tmp_path / 'artifacts'
+    assert not artifacts_dir.exists()
+
+    filename = 'main.json'
+    expected_file = artifacts_dir / filename
+    assert not expected_file.exists()
+
+    ret = dump_artifact(contents, str(artifacts_dir), filename)
+    assert ret == str(expected_file)
+    assert contents == expected_file.read_text()
+
+
+def test_dump_artifact_existing_file_diff_contents(tmp_path):
+    '''
+    Test dump_artifact() with a file that exists but has contents that
+    are different from the supplied new contents.
+    '''
+    contents = 'blerg'
+
+    artifacts_dir = tmp_path / 'artifacts'
+    artifacts_dir.mkdir()
+
+    filename = 'main.json'
+    expected_file = artifacts_dir / filename
+    expected_file.write_text('flooblah')
+
+    ret = dump_artifact(contents, str(artifacts_dir), filename)
+    assert ret == str(expected_file)
+    assert contents == expected_file.read_text()
+
+
+def test_dump_artifact_existing_file_same_contents(tmp_path):
+    '''
+    Test dump_artifact() with a file that exists and has contents
+    that are identical to the supplied new contents.
+    '''
+    contents = 'blerg'
+
+    artifacts_dir = tmp_path / 'artifacts'
+    artifacts_dir.mkdir()
+
+    filename = 'main.json'
+    expected_file = artifacts_dir / filename
+    expected_file.write_text(contents)
+
+    ret = dump_artifact(contents, str(artifacts_dir), filename)
+    assert ret == str(expected_file)
+    assert contents == expected_file.read_text()


### PR DESCRIPTION
The `mypy` linter currently complains about the `dump_artifact()` method once typing is added to it. This is because there exists a code branch where `hexdigest()` could be called on a variable with a `None` type. The code logic was also overly complex. This is simplified by reorganizing it slightly, and not allowing for the `filename` parameter to be `None` (we never pass it that value except in a unit test). Some unit tests are added to make sure it functions as expected.

I think we _could_ simplify this code even further:
 - not convinced the comparison of file contents to the new contents is even necessary... we could just always overwrite.
 - returning the final filename seems silly since that data is known to the caller (we could instead return a bool to indicate if the file was written)

I didn't make those other changes, though, since I wanted to leave the current functionality intact until a later date, and I only want to fix the linting issue in this PR.