### PR TITLE
docs/execution_environment.rst: add a note with reference to Getting started EE guide

### DIFF
--- a/docs/execution_environments.rst
+++ b/docs/execution_environments.rst
@@ -3,8 +3,12 @@
 Using Runner with Execution Environments
 ========================================
 
+.. note::
+
+  For an Execution Environments general technology overview and to learn how get started using it in a few easy steps, see the `Getting started with Execution Environments guide <https://docs.ansible.com/ansible/devel/getting_started_ee/index.html>`_.
+
 **Execution Environments** are meant to be a consistent, reproducible, portable,
-and sharable method to run Ansible Automation jobs in the exact same way on
+and shareable method to run Ansible Automation jobs in the exact same way on
 your laptop as they are executed in `Ansible AWX <https://github.com/ansible/awx/>`_.
 This aids in the development of automation jobs and Ansible Content that is
 meant to be run in **Ansible AWX**,
@@ -43,7 +47,7 @@ When running a job remotely via AWX, Ansible Runner can pick up the authenticati
 information from the Container Registry Credential that was provided by the user. The ``host``,
 ``username``, ``password``, and ``verify_ssl`` inputs from the credential are passed into Ansible Runner via the ``container_auth_data``
 dictionary as key word arguments into a ``json`` file which gets deleted at the end of the job run (even if
-the job was canceled/interrupted), enabling the bypassing of sensitive information from any potentially
+the job was cancelled/interrupted), enabling the bypassing of sensitive information from any potentially
 persistent job-related files.
 
 Notes and Considerations


### PR DESCRIPTION
This PR:
- in order to implement https://github.com/ansible-community/community-team/issues/230, adds a reference to the Get started EE guide. So unfamiliar readers, who'll get intrigued, can quickly access the info and get started.
- fixes a couple of typos found along the way