### PR TITLE
Upgrade tox to fix build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "tox==4.5.0"
+          python3 -m pip install "tox==4.11.3"
 
       - name: Create tox environment
         run: tox --notest
@@ -74,7 +74,7 @@ jobs:
       - name: Install tox
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "tox==4.5.0" build
+          python3 -m pip install "tox==4.11.3" build
 
       - name: Prepare runner test container
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Install tox
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "tox==4.5.0"
+          python3 -m pip install "tox==4.11.3"
 
       - name: Create tox environment
         run: tox --notest


### PR DESCRIPTION
Seems the latest version of `pyproject-api` (1.6.1) is not compatible with older versions of `tox` (see https://github.com/tox-dev/tox/issues/3110), so we need to upgrade our version to the latest.