### PR TITLE
Pass inventory directory path instead of file path when using containerization

### DIFF
--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -160,7 +160,7 @@ class RunnerConfig(BaseConfig):
         Prepares the inventory default under ``private_data_dir`` if it's not overridden by the constructor.
         """
         if self.containerized:
-            self.inventory = '/runner/inventory/hosts'
+            self.inventory = '/runner/inventory'
             return
 
         if self.inventory is None:

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -726,6 +726,6 @@ def test_containerization_settings(tmp_path, runtime, mocker):
         ['--env-file', f'{rc.artifact_dir}/env.list'] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \
-        ['my_container', 'ansible-playbook', '-i', '/runner/inventory/hosts', 'main.yaml']
+        ['my_container', 'ansible-playbook', '-i', '/runner/inventory', 'main.yaml']
 
     assert expected_command_start == rc.command


### PR DESCRIPTION
Proposed solution to #1303 by removing the static hosts file from the inventory directory path when in containerized mode. This should allow ansible-runner to read all inventory files with the directory matching non-containerized functionality.

Fixes #1303