### PR TITLE
Disable --tty for subprocess when parent process is non-tty

### DIFF
--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import re
+import sys
 import stat
 import tempfile
 import shutil
@@ -495,7 +496,7 @@ class BaseConfig:
         new_args = [self.process_isolation_executable]
         new_args.extend(['run', '--rm'])
 
-        if self.runner_mode == 'pexpect' or getattr(self, 'input_fd', False):
+        if self.runner_mode == 'pexpect' or self.runner_mode == "subprocess" and sys.stdout.isatty():
             new_args.extend(['--tty'])
 
         new_args.append('--interactive')


### PR DESCRIPTION
First, stdin not need --tty option, it only dependent --interactive option. Secendly, when running in subprocess mode, disable --tty option if parent process does not have a tty. This prevents the subprocess incorrectly detecting tty and enabling interactive features like `ansible-config init`.
For example, if you use `ansible-navigator config init -m stdout > config`, the subprocess will incorrectly detect tty and waiting 'q' to exit less and cause errors of config. This change avoids that.

More code see at here [ansible_navigator](https://github.com/ansible/ansible-navigator/blob/2ae20268b665b665a480da9eb7f3c39acaa01e53/src/ansible_navigator/runner/command_base.py#L38). ansible_navigator enable input_fd even if in non-tty mode, It is understandable because they are able to control the input and output based on needs.