### PR TITLE
Allow shutil to copy into existing isolation directory

### DIFF
--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -135,7 +135,7 @@ class RunnerConfig(BaseConfig):
             self.directory_isolation_path = tempfile.mkdtemp(prefix='runner_di_', dir=self.directory_isolation_path)
             if os.path.exists(self.project_dir):
                 output.debug(f"Copying directory tree from {self.project_dir} to {self.directory_isolation_path} for working directory isolation")
-                shutil.copytree(self.project_dir, self.directory_isolation_path, symlinks=True)
+                shutil.copytree(self.project_dir, self.directory_isolation_path, dirs_exist_ok=True, symlinks=True)
 
         self.prepare_inventory()
         self.prepare_command()

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -239,7 +239,7 @@ def test_prepare_env_directory_isolation_from_settings(mocker, project_fixtures)
     mkdtemp.assert_called_once_with(prefix='runner_di_', dir='/tmp/runner')
 
     # The project files should be copied to the isolation path.
-    copy_tree.assert_called_once_with(rc.project_dir, rc.directory_isolation_path, symlinks=True)
+    copy_tree.assert_called_once_with(rc.project_dir, rc.directory_isolation_path, dirs_exist_ok=True, symlinks=True)
 
 
 def test_prepare_inventory(mocker):


### PR DESCRIPTION
Fixes #1309 by adding `dirs_exist_ok=True` to the `copytree` call. Tested locally and the directory correctly populates with project directory files.