### PR TITLE
Add lib symlink to bwrap call

### DIFF
--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -339,6 +339,7 @@ class RunnerConfig(BaseConfig):
             '--ro-bind', '/etc', '/etc',
             '--ro-bind', '/usr', '/usr',
             '--ro-bind', '/opt', '/opt',
+            '--symlink', 'usr/lib', '/lib',
             '--symlink', 'usr/lib64', '/lib64',
         ])
 

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -544,6 +544,7 @@ def test_bwrap_process_isolation_defaults(mocker):
         '--ro-bind', '/etc', '/etc',
         '--ro-bind', '/usr', '/usr',
         '--ro-bind', '/opt', '/opt',
+        '--symlink', 'usr/lib', '/lib',
         '--symlink', 'usr/lib64', '/lib64',
         '--bind', '/', '/',
         '--chdir', '/project',

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -599,6 +599,7 @@ def test_bwrap_process_isolation_and_directory_isolation(mocker, patch_private_d
         '--ro-bind', '/etc', '/etc',
         '--ro-bind', '/usr', '/usr',
         '--ro-bind', '/opt', '/opt',
+        '--symlink', 'usr/lib', '/lib',
         '--symlink', 'usr/lib64', '/lib64',
         '--bind', '/', '/',
         '--chdir', os.path.realpath(rc.directory_isolation_path),
@@ -637,6 +638,7 @@ def test_process_isolation_settings(mocker, tmp_path):
         '--ro-bind', '/etc', '/etc',
         '--ro-bind', '/usr', '/usr',
         '--ro-bind', '/opt', '/opt',
+        '--symlink', 'usr/lib', '/lib',
         '--symlink', 'usr/lib64', '/lib64',
     ]
     index = len(expected)


### PR DESCRIPTION
Fixes #1310 by adding a /usr/lib to /lib symlink in calls to `bwrap` for sandboxing.