### PR TITLE
Fix invalid inventory with relative pvt data dir

### DIFF
--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -158,14 +158,20 @@ class RunnerConfig(BaseConfig):
     def prepare_inventory(self):
         """
         Prepares the inventory default under ``private_data_dir`` if it's not overridden by the constructor.
+
+        We make sure that if inventory is a path, that it is an absolute path.
         """
         if self.containerized:
             self.inventory = '/runner/inventory'
             return
 
         if self.inventory is None:
+            # At this point we expect self.private_data_dir to be an absolute path
+            # since that is expanded in the base class.
             if os.path.exists(os.path.join(self.private_data_dir, "inventory")):
                 self.inventory = os.path.join(self.private_data_dir, "inventory")
+        elif isinstance(self.inventory, str) and os.path.exists(self.inventory):
+            self.inventory = os.path.abspath(self.inventory)
 
     def prepare_env(self):
         """

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -249,13 +249,16 @@ def test_prepare_inventory(mocker):
     rc = RunnerConfig(private_data_dir='/')
     rc.prepare_inventory()
     assert rc.inventory == '/inventory'
+
     rc.inventory = '/tmp/inventory'
     rc.prepare_inventory()
     assert rc.inventory == '/tmp/inventory'
+
+    path_exists.return_value = False
     rc.inventory = 'localhost,anotherhost,'
     rc.prepare_inventory()
     assert rc.inventory == 'localhost,anotherhost,'
-    path_exists.return_value = False
+
     rc.inventory = None
     rc.prepare_inventory()
     assert rc.inventory is None


### PR DESCRIPTION
Since the current working directory is set to the location of the playbook being executed, a relative pvt data directory would cause an invalid inventory path if custom inventory content was provided as a string.

Fixes #1216 
