### PR TITLE
Bump cryptography from 41.0.6 to 42.0.4 in /docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ babel==2.12.1
 certifi==2023.7.22
 cffi==1.15.1
 charset-normalizer==3.1.0
-cryptography==41.0.6
+cryptography>=42.0.4
 docutils==0.18.1
 idna==3.4
 imagesize==1.4.1


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request

