### PR TITLE
Bump setuptools and setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45, <=69.0.2", "setuptools-scm[toml]>=6.2, <=8.0.4"]  # pin max versions of build deps and update as needed
+requires = ["setuptools>=45, <=70.0.0", "setuptools-scm[toml]>=6.2, <=8.1.0"]  # pin max versions of build deps and update as needed
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Newest `git` release can output dates in a format that older Pythons cannot parse. This is causing `setuptools_scm` to fail in our CI setup (bug report https://github.com/pypa/setuptools_scm/issues/1038). Bump that req and also `setuptools` while we're at it.