### PR TITLE
feat: support changing stdout callback plugin and its options

### DIFF
--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -46,10 +46,10 @@ DOCUMENTATION = '''
     short_description: Playbook event dispatcher for ansible-runner
     version_added: "2.0"
     description:
-        - This callback is necessary for ansible-runner to work
+      - This callback is necessary for ansible-runner to work
+      - This callback works by dynamically inheriting from the original stdout callback plugin
+      - Configurable parameters conform to the original stdout callback plugin
     type: stdout
-    extends_documentation_fragment:
-      - default_callback
     requirements:
       - Set as stdout in config
 '''
@@ -64,7 +64,9 @@ elif IS_ADHOC:
 else:
     default_stdout_callback = 'default'
 
-DefaultCallbackModule: CallbackBase = callback_loader.get(default_stdout_callback).__class__
+_DefaultCallbackModule = callback_loader.get(default_stdout_callback)
+DefaultCallbackModuleMeta: CallbackBase = _DefaultCallbackModule.__class__
+DefaultCallbackModuleName: str = _DefaultCallbackModule._load_name
 
 CENSORED = "the output has been hidden due to the fact that 'no_log: true' was specified for this result"
 
@@ -314,7 +316,7 @@ def display_with_context(f):
 Display.display = display_with_context(Display.display)
 
 
-class CallbackModule(DefaultCallbackModule):
+class CallbackModule(DefaultCallbackModuleMeta):
     '''
     Callback module for logging ansible/ansible-playbook events.
     '''
@@ -351,6 +353,16 @@ class CallbackModule(DefaultCallbackModule):
 
         # NOTE: Ansible doesn't generate a UUID for playbook_on_start so do it for them.
         self.playbook_uuid = str(uuid.uuid4())
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        # since the options are gathered by referring self._load_name,
+        # temporarily fake the plugin name itself as the originally specified plugin
+        _current_load_name = self._load_name
+        self._load_name = DefaultCallbackModuleName
+
+        # get the options for the originally specified plugin and restore the plugin name
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
+        self._load_name = _current_load_name
 
     @contextlib.contextmanager
     def capture_event_data(self, event, **event_data):


### PR DESCRIPTION
## Summary

This PR adds (maybe) full support of changing stdout callback plugin and its options.

- To change stdout callback plugin, specify `ANSIBLE_STDOUT_CALLBACK` environment variable (`stdout_callback` in `ansible.cfg` is  ignored)
- To change its options, specify desired environment variables, or keys in `ansible.cfg`

~~Closes 1322~~, Closes #994

## Design

- To minimize side effects, I did not significantly change the current implementation
- I avoided the method suggested by #994 that dynamically loading the `DOCUMENTATION` because it would make `ansible-doc` not work

## Architecture

- The problem with the current implementation is that although `ANSIBLE_STDOUT_CALLBACK` allows any plugin to be specified, only `default_callback` is specified in the `extends_documentation_fragment`, which means that we cannot specify any options at all except for the options in `default_callback`. This prevents many of the callback plugins from loading their own options, resulting in an error.
- Therefore, we should allow `awx_display` to have the options specified for the originally specified plugin
- Currently, all plugin options are loaded by `self.set_options`, but the options to be loaded are filtered using `self._load_name` ([source](https://github.com/ansible/ansible/blob/stable-2.17/lib/ansible/plugins/callback/__init__.py#L181))
- Since `self._load_name` is the name of the plugin, if this is faked only when `self.set_options` is executed, the original plugin options can be set to `awx_display`
- This allows any callback plugin to work properly with any options
- The implementation for loading options using `self._load_name` has not changed since Ansible 2.5

## Additional Information

@sivel @AlanCoding @nitzmahone @bcoca
I think it would be useful to be able to use any callback plugins with a small modification, what do you think of this implementation? I know it is never best to fake the name, but I think it would be great if there is a small improvement with a small (and not best) change in a short term, since a major renovation takes lots of time to complete designing and implemantation.

I could make it possible to control faking `_load_name` with a feature flag `ALLOW_CUSTOM_CALLBACK_PLUGIN` or something similar, but first I made a draft PR with minimal changes.