### PR TITLE
[backport][2.4] Update external_interface.rst (#1353)

### DIFF
--- a/docs/external_interface.rst
+++ b/docs/external_interface.rst
@@ -10,7 +10,7 @@ Alternatively **Runner** can be configured to send events to an external system 
 * HTTP Status/Event Emitter Plugin - `ansible-runner-http GitHub repo <https://github.com/ansible/ansible-runner-http>`_
 * ZeroMQ Status/Event Emitter Plugin - `ansible-runner-zeromq GitHub repo <https://github.com/ansible/ansible-runner-zeromq>`_
 
-Please refer respective repos to configure these plugins.
+Please refer to respective repos to configure these plugins.
 
 .. _plugineventstructure:
 


### PR DESCRIPTION
Update external_interface.rst for missing word

Backport of PR #1353 

(cherry picked from commit c3e8cdb24f784a70328f1bfb54eb9c886148acef)