### PR TITLE
fix: pin python-daemon<3.0.0 to avoid build errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,8 @@ python_requires = >=3.9
 install_requires =
     pexpect>=4.5
     packaging
-    python-daemon
+    # python-daemon 3.0.0 and 3.0.1 break builds with modern setuptools
+    python-daemon<3.0.0
     pyyaml
     # enable `groups` arg to entry_points missing in 3.9 stdlib importlib.metadata
     importlib-metadata>= 4.6,< 6.3; python_version<'3.10'


### PR DESCRIPTION
Builds of projects that require `ansible-runner` and thereby also require `python-daemon>=3.0.0` in environments with modern versions of `setuptools` are failing with this error:

```
ModuleNotFoundError: No module named 'setuptools.extern'
```

The problematic `extern` import in `python-daemon` was introduced in its `3.0.0` release and has since been fixed in that project's `main` branch, but there is not yet any release including that fix. Simply pinning an older version appears to resolve this build issue and does not appear to introduce any regressions.

After `python-daemon` releases a new version, assuming they do, then we probably should change this from `<3.0.0` to `>3.0.1`.

See also:

* https://pagure.io/python-daemon/issue/92
* https://github.com/quipucords/quipucords/pull/2714