### PR TITLE
Add the become flag and become_user var to the callback plugin

### DIFF
--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -411,6 +411,8 @@ class CallbackModule(DefaultCallbackModule):
             'task': (task.name or task.action),
             'task_uuid': str(task._uuid),
             'task_action': task.action,
+            'task_become': task.become,
+            'task_become_user': task.become_user,
             'resolved_action': getattr(task, 'resolved_action', task.action),
             'task_args': '',
         }

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -223,6 +223,35 @@ def test_resolved_actions(executor, playbook, skipif_pre_ansible212):  # pylint:
     assert events[2]["event_data"]["resolved_action"] == "ansible.builtin.shell"
 
 
+@pytest.mark.parametrize(
+    "playbook",
+    [
+        {
+            "become_task.yml": """
+- name: becometask
+  connection: local
+  hosts: all
+  gather_facts: no
+  tasks:
+    - shell: echo "resolved actions test!"
+      become: true
+      become_user: root
+"""
+        },  # noqa
+    ],
+)
+def test_become_task(executor, playbook, skipif_pre_ansible212):  # pylint: disable=W0613,W0621
+    executor.run()
+    events = list(executor.events)
+
+    # task 1
+    assert events[2]["event"] == "playbook_on_task_start"
+    assert "task_become" in events[2]["event_data"]
+    assert "task_become_user" in events[2]["event_data"]
+    assert events[2]["event_data"]["task_become"] == "true"
+    assert events[2]["event_data"]["task_become_user"] == "root"
+
+
 @pytest.mark.parametrize("playbook", [
 {'loop_with_no_log.yml': '''
 - name: playbook variable should not be overwritten when using no log

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -240,7 +240,7 @@ def test_resolved_actions(executor, playbook, skipif_pre_ansible212):  # pylint:
         },  # noqa
     ],
 )
-def test_become_task(executor, playbook, skipif_pre_ansible212):  # pylint: disable=W0613,W0621
+def test_become_task(executor, playbook):  # pylint: disable=W0613,W0621
     executor.run()
     events = list(executor.events)
 

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -248,7 +248,7 @@ def test_become_task(executor, playbook):  # pylint: disable=W0613,W0621
     assert events[2]["event"] == "playbook_on_task_start"
     assert "task_become" in events[2]["event_data"]
     assert "task_become_user" in events[2]["event_data"]
-    assert events[2]["event_data"]["task_become"] == True
+    assert events[2]["event_data"]["task_become"]
     assert events[2]["event_data"]["task_become_user"] == "root"
 
 

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -248,7 +248,7 @@ def test_become_task(executor, playbook, skipif_pre_ansible212):  # pylint: disa
     assert events[2]["event"] == "playbook_on_task_start"
     assert "task_become" in events[2]["event_data"]
     assert "task_become_user" in events[2]["event_data"]
-    assert events[2]["event_data"]["task_become"] == "true"
+    assert events[2]["event_data"]["task_become"] == True
     assert events[2]["event_data"]["task_become_user"] == "root"
 
 


### PR DESCRIPTION
* Enables propagating the become flag and become user to external logs allowing the use of become to be audited