### PR TITLE
Update community comms info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,17 @@ Ansible Runner is a tool and Python library that helps when interfacing with Ans
 See the [latest documentation] for usage details.
 
 Get Involved
-============
+------------
 
 * [GitHub issues] to track bug report and feature ideas
 * [GitHub Milestones] to track what's for the next release
 * Want to contribute? Please check out our [contributing guide]
-* Join us in the `#ansible-runner` channel on Libera.chat IRC
-* Join the discussion in [`#awx-project`][irc]
-* For the full list of Ansible email Lists, IRC channels see the [Ansible Mailing lists].
+* Visit the [Community] section of the docs.
+* See the [Ansible communication guide] for complete information about getting in touch.
 
 [GitHub issues]: https://github.com/ansible/ansible-runner/issues
 [GitHub Milestones]: https://github.com/ansible/ansible-runner/milestones
 [contributing guide]: https://github.com/ansible/ansible-runner/blob/devel/CONTRIBUTING.md
-[irc]: https://groups.google.com/forum/#!forum/awx-project
-[Ansible Mailing lists]: https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information
-[latest documentation]: https://ansible-runner.readthedocs.io/en/latest/
+[Community]: https://ansible.readthedocs.io/projects/runner/en/latest/community/
+[Ansible communication guide]: https://docs.ansible.com/ansible/devel/community/communication.html
+[latest documentation]: https://ansible.readthedocs.io/projects/runner/en/latest/

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,0 +1,29 @@
+.. _community:
+
+Community
+=========
+
+We welcome your feedback, questions and ideas.
+Here's how to reach the community.
+
+Code of Conduct
+---------------
+
+All communication and interactions in the Ansible community are governed by the `Ansible code of conduct <https://docs.ansible.com/ansible/devel/community/code_of_conduct.html>`_.
+Please read and abide by it!
+Reach out to our community team at `codeofconduct@ansible.com <mailto:codeofconduct@ansible.com>`_ if you have any questions or need assistance.
+
+Ansible Forum
+-------------
+
+Join the `Ansible Forum <https://forum.ansible.com>`_, the default communication platform for questions and help, development discussions, events, and much more.
+`Register <https://forum.ansible.com/signup?>`_ to join the community.
+Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+
+* `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example `ansible-runner`, `playbook`, and  `awx`.
+* `Posts tagged with 'ansible-runner' <https://forum.ansible.com/tag/ansible-runner>`_: subscribe to participate in project-related conversations.
+* `Bullhorn newsletter <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
+* `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
+* `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
+
+See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.

--- a/docs/community.rst
+++ b/docs/community.rst
@@ -20,7 +20,7 @@ Join the `Ansible Forum <https://forum.ansible.com>`_, the default communication
 `Register <https://forum.ansible.com/signup?>`_ to join the community.
 Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
-* `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example `ansible-runner`, `playbook`, and  `awx`.
+* `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example ``ansible-runner``, ``playbook``, and  ``awx``.
 * `Posts tagged with 'ansible-runner' <https://forum.ansible.com/tag/ansible-runner>`_: subscribe to participate in project-related conversations.
 * `Bullhorn newsletter <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
 * `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Examples of this could include:
 
    intro
    install
+   community
    external_interface
    standalone
    python_interface


### PR DESCRIPTION
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thanks!