### PR TITLE
Improve argument streaming for remote job execution (part 1)

### DIFF
--- a/docs/ansible_runner.config.rst
+++ b/docs/ansible_runner.config.rst
@@ -7,4 +7,5 @@ Submodules
 ansible_runner.config.runner module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. autoclass:: ansible_runner.config.runner.BaseConfig
 .. autoclass:: ansible_runner.config.runner.RunnerConfig

--- a/docs/ansible_runner.rst
+++ b/docs/ansible_runner.rst
@@ -25,6 +25,7 @@ ansible_runner.interface module
 
 .. automodule:: ansible_runner.interface
     :members:
+    :exclude-members: init_runner
     :undoc-members:
     :show-inheritance:
 

--- a/docs/ansible_runner.rst
+++ b/docs/ansible_runner.rst
@@ -45,14 +45,6 @@ ansible_runner.runner module
     :undoc-members:
     :show-inheritance:
 
-ansible_runner.runner\_config module
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: ansible_runner.runner_config
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 ansible_runner.utils module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,10 @@ def _get_version():
 
 
 nitpicky = True
+nitpick_ignore = {
+    ('py:class', '_io.FileIO')
+}
+
 default_role = 'any'  # This catches single backticks (incorrectly) used for inline code formatting
 project = 'ansible-runner'
 copyright = f'2018-{datetime.datetime.today().year}, Red Hat, Inc'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,7 +1,7 @@
-.. _intro:
+.. _config:
 
-Introduction to Ansible Runner
-==============================
+Configuring Ansible Runner
+==========================
 
 **Runner** is intended to be most useful as part of automation and tooling that needs to invoke Ansible and consume its results.
 Most of the parameterization of the **Ansible** command line is also available on the **Runner** command line but **Runner** also

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ want to manage the complexities of the interface on their own (such as CI/CD pla
 for running ``ansible`` and ``ansible-playbook`` tasks and gathers the output from it. It does this by presenting a common interface that doesn't
 change, even as **Ansible** itself grows and evolves.
 
-Part of what makes this tooling useful is that it can gather its inputs in a flexible way (See :ref:`intro`:). It also has a system for storing the
+Part of what makes this tooling useful is that it can gather its inputs in a flexible way (See :ref:`config`). It also has a system for storing the
 output (stdout) and artifacts (host-level event data, fact data, etc) of the playbook run.
 
 There are 3 primary ways of interacting with **Runner**
@@ -30,18 +30,12 @@ Examples of this could include:
 * Sending status to Ansible AWX
 * Sending events to an external logging service
 
-
 .. toctree::
    :maxdepth: 1
-   :caption: Introduction
-
-   intro
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Installation and Upgrade
+   :caption: Installation, Upgrade & Configuration
 
    install
+   configuration
    porting_guides/porting_guide
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,17 +33,33 @@ Examples of this could include:
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents:
+   :caption: Introduction
 
    intro
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Installation and Upgrade
+
    install
-   community
+   porting_guides/porting_guide
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Using Ansible Runner
+
    external_interface
    standalone
    python_interface
    execution_environments
    remote_jobs
    modules
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Getting Help
+
+   community
 
 
 Indices and tables

--- a/docs/porting_guides/porting_guide.rst
+++ b/docs/porting_guides/porting_guide.rst
@@ -1,0 +1,12 @@
+*****************************
+Ansible Runner Porting Guides
+*****************************
+
+This section lists porting guides that can help you when upgrading to newer
+versions of ``ansible-runner``.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   porting_guide_v2.5

--- a/docs/porting_guides/porting_guide_v2.5.rst
+++ b/docs/porting_guides/porting_guide_v2.5.rst
@@ -35,7 +35,7 @@ object. For example:
 .. code-block:: python
 
     import ansible_runner
-    config = ansible_runner.RunnerConfig('private_data_dir': '/tmp/demo', 'playbook': 'test.yml')
+    config = ansible_runner.RunnerConfig(private_data_dir='/tmp/demo', playbook='test.yml')
     r = ansible_runner.interface.run(config=config)
 
 The above is identical to the more familiar usage of the API:
@@ -43,4 +43,4 @@ The above is identical to the more familiar usage of the API:
 .. code-block:: python
 
     import ansible_runner
-    r = ansible_runner.interface.run('private_data_dir': '/tmp/demo', 'playbook': 'test.yml')
+    r = ansible_runner.interface.run(private_data_dir='/tmp/demo', playbook='test.yml')

--- a/docs/porting_guides/porting_guide_v2.5.rst
+++ b/docs/porting_guides/porting_guide_v2.5.rst
@@ -44,3 +44,19 @@ The above is identical to the more familiar usage of the API:
 
     import ansible_runner
     r = ansible_runner.interface.run(private_data_dir='/tmp/demo', playbook='test.yml')
+
+Deprecations
+============
+
+The ``RunnerConfig`` object currently allows for the ``private_data_dir`` parameter to be initialized
+as a positional parameter. For example:
+
+.. code-block:: python
+
+    config = ansible_runner.RunnerConfig('/tmp/demo', playbook='test.yml')
+
+This is the only positional argument currently allowed. A future release will require this parameter to be keyword only.
+
+.. code-block:: python
+
+    config = ansible_runner.RunnerConfig(private_data_dir='/tmp/demo', playbook='test.yml')

--- a/docs/porting_guides/porting_guide_v2.5.rst
+++ b/docs/porting_guides/porting_guide_v2.5.rst
@@ -1,0 +1,46 @@
+********************************
+Ansible Runner 2.5 Porting Guide
+********************************
+
+This section discusses the behavioral changes between ``ansible-runner`` version 2.4 and version 2.5.
+
+.. contents:: Topics
+
+Changes to the Python Interface
+===============================
+
+:ref:`Remote job execution <remote_jobs>` could experience problems when transmitting job arguments
+to a worker node with an older version of ``ansible-runner``. If the older worker received a job
+argument that it did not understand, like a new API value, that worker would terminate abnormally.
+To address this, a two-stage plan was devised:
+
+#. Modify the streaming job arguments so that only job arguments that have non-default values are
+   streamed to the worker node. A new API job argument will not be problematic for older workers
+   unless that argument is actually used.
+#. Have the worker node fail gracefully on unrecognized job arguments.
+
+The first step of this process is implemented in this version of ``ansible-runner``. The second
+step will be completed in a future version.
+
+For this change, it was necessary to modify how the ``run()`` and ``run_async()`` functions
+of the :ref:`Python API <python_interface>` are implemented. The API function arguments are now completely
+defined in the ``RunnerConfig`` object where we can have better control of the job arguments, and both
+functions now take an optional ``config`` parameter.
+
+For backward compatibility, keyword arguments to the ``run()/run_async()`` API functions are passed
+along to the ``RunnerConfig`` object initialization for you. Alternatively, you may choose to use
+the more up-to-date signature of those API functions where you pass in a manually created ``RunnerConfig``
+object. For example:
+
+.. code-block:: python
+
+    import ansible_runner
+    config = ansible_runner.RunnerConfig('private_data_dir': '/tmp/demo', 'playbook': 'test.yml')
+    r = ansible_runner.interface.run(config=config)
+
+The above is identical to the more familiar usage of the API:
+
+.. code-block:: python
+
+    import ansible_runner
+    r = ansible_runner.interface.run('private_data_dir': '/tmp/demo', 'playbook': 'test.yml')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ disable = [
   "C0115",  # missing-class-docstring
   "C0116",  # missing-function-docstring
   "C0301",  # line-too-long
+  "C0302",  # too-many-lines
   "R0401",  # cyclic-import
   "R0801",  # duplicate-code
   "R0902",  # too-many-instance-attributes

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -44,7 +44,8 @@ from yaml import safe_dump, safe_load
 from ansible_runner import run
 from ansible_runner import output
 from ansible_runner import cleanup
-from ansible_runner.utils import dump_artifact, Bunch, register_for_cleanup
+from ansible_runner._internal._dump_artifacts import dump_artifact
+from ansible_runner.utils import Bunch, register_for_cleanup
 from ansible_runner.utils.capacity import get_cpu_count, get_mem_in_bytes, ensure_uuid
 from ansible_runner.utils.importlib_compat import importlib_metadata
 from ansible_runner.runner import Runner
@@ -822,14 +823,11 @@ def main(sys_args=None):
             else:
                 vargs['inventory'] = abs_inv
 
-    output.configure()
-
-    # enable or disable debug mode
-    output.set_debug('enable' if vargs.get('debug') else 'disable')
-
-    # set the output logfile
+    debug = bool(vargs.get('debug'))
+    logfile = ''
     if ('logfile' in args) and vargs.get('logfile'):
-        output.set_logfile(vargs.get('logfile'))
+        logfile = vargs.get('logfile')
+    output.configure(debug, logfile)
 
     output.debug('starting debug logging')
 

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -45,6 +45,7 @@ from ansible_runner import run
 from ansible_runner import output
 from ansible_runner import cleanup
 from ansible_runner._internal._dump_artifacts import dump_artifact
+from ansible_runner.defaults import default_process_isolation_executable
 from ansible_runner.utils import Bunch, register_for_cleanup
 from ansible_runner.utils.capacity import get_cpu_count, get_mem_in_bytes, ensure_uuid
 from ansible_runner.utils.importlib_compat import importlib_metadata
@@ -884,8 +885,8 @@ def main(sys_args=None):
                     "project_dir": vargs.get('project_dir'),
                     "artifact_dir": vargs.get('artifact_dir'),
                     "roles_path": [vargs.get('roles_path')] if vargs.get('roles_path') else None,
-                    "process_isolation": vargs.get('process_isolation'),
-                    "process_isolation_executable": vargs.get('process_isolation_executable'),
+                    "process_isolation": bool(vargs.get('process_isolation')),
+                    "process_isolation_executable": vargs.get('process_isolation_executable') or default_process_isolation_executable,
                     "process_isolation_path": vargs.get('process_isolation_path'),
                     "process_isolation_hide_paths": vargs.get('process_isolation_hide_paths'),
                     "process_isolation_show_paths": vargs.get('process_isolation_show_paths'),

--- a/src/ansible_runner/_internal/_dump_artifacts.py
+++ b/src/ansible_runner/_internal/_dump_artifacts.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import tempfile
+
+from collections.abc import MutableMapping
+
+from ansible_runner.config.runner import RunnerConfig
+from ansible_runner.utils import isinventory, isplaybook
+
+
+def dump_artifacts(config: RunnerConfig) -> None:
+    """Introspect the arguments and dump objects to disk"""
+    if config.role:
+        role = {'name': config.role}
+        if config.role_vars:
+            role['vars'] = config.role_vars
+
+        hosts = config.host_pattern or 'all'
+        play = [{'hosts': hosts, 'roles': [role]}]
+
+        if config.role_skip_facts:
+            play[0]['gather_facts'] = False
+
+        config.playbook = play
+
+        if config.envvars is None:
+            config.envvars = {}
+
+        roles_path = config.roles_path
+        if not roles_path:
+            roles_path = os.path.join(config.private_data_dir, 'roles')
+        else:
+            roles_path += f":{os.path.join(config.private_data_dir, 'roles')}"
+
+        config.envvars['ANSIBLE_ROLES_PATH'] = roles_path
+
+    playbook = config.playbook
+    if playbook:
+        # Ensure the play is a list of dictionaries
+        if isinstance(playbook, MutableMapping):
+            playbook = [playbook]
+
+        if isplaybook(playbook):
+            path = os.path.join(config.private_data_dir, 'project')
+            config.playbook = dump_artifact(json.dumps(playbook), path, 'main.json')
+
+    obj = config.inventory
+    if obj and isinventory(obj):
+        path = os.path.join(config.private_data_dir, 'inventory')
+        if isinstance(obj, MutableMapping):
+            config.inventory = dump_artifact(json.dumps(obj), path, 'hosts.json')
+        elif isinstance(obj, str):
+            if not os.path.exists(os.path.join(path, obj)):
+                config.inventory = dump_artifact(obj, path, 'hosts')
+            elif os.path.isabs(obj):
+                config.inventory = obj
+            else:
+                config.inventory = os.path.join(path, obj)
+
+    if not config.suppress_env_files:
+        for key in ('envvars', 'extravars', 'passwords', 'settings'):
+            obj = getattr(config, key, None)
+            if obj and not os.path.exists(os.path.join(config.private_data_dir, 'env', key)):
+                path = os.path.join(config.private_data_dir, 'env')
+                dump_artifact(json.dumps(obj), path, key)
+
+        for key in ('ssh_key', 'cmdline'):
+            obj = getattr(config, key, None)
+            if obj and not os.path.exists(os.path.join(config.private_data_dir, 'env', key)):
+                path = os.path.join(config.private_data_dir, 'env')
+                dump_artifact(obj, path, key)
+
+
+def dump_artifact(obj: str,
+                  path: str,
+                  filename: str | None = None
+                  ) -> str:
+    """Write the artifact to disk at the specified path
+
+    :param str obj: The string object to be dumped to disk in the specified
+        path. The artifact filename will be automatically created.
+    :param str path: The full path to the artifacts data directory.
+    :param str filename: The name of file to write the artifact to.
+        If the filename is not provided, then one will be generated.
+
+    :return: The full path filename for the artifact that was generated.
+    """
+    if not os.path.exists(path):
+        os.makedirs(path, mode=0o700)
+
+    p_sha1 = hashlib.sha1()
+    p_sha1.update(obj.encode(encoding='UTF-8'))
+
+    if filename is None:
+        _, fn = tempfile.mkstemp(dir=path)
+    else:
+        fn = os.path.join(path, filename)
+
+    if os.path.exists(fn):
+        c_sha1 = hashlib.sha1()
+        with open(fn) as f:
+            contents = f.read()
+        c_sha1.update(contents.encode(encoding='UTF-8'))
+
+    if not os.path.exists(fn) or p_sha1.hexdigest() != c_sha1.hexdigest():
+        lock_fp = os.path.join(path, '.artifact_write_lock')
+        lock_fd = os.open(lock_fp, os.O_RDWR | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR)
+        fcntl.lockf(lock_fd, fcntl.LOCK_EX)
+
+        try:
+            with open(fn, 'w') as f:
+                os.chmod(fn, stat.S_IRUSR | stat.S_IWUSR)
+                f.write(str(obj))
+        finally:
+            fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+            os.remove(lock_fp)
+
+    return fn

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -62,6 +62,11 @@ class BaseExecutionMode(Enum):
     GENERIC_COMMANDS = 2
 
 
+# Metadata string values
+class MetaValues(Enum):
+    STREAMABLE = 'streamable'
+
+
 @dataclass
 class BaseConfig:
     """The base configuration object.
@@ -77,38 +82,38 @@ class BaseConfig:
     # No other config objects make use of positional parameters, so this should be fine.
     #
     # Example use case: RunnerConfig("/tmp/demo", playbook="main.yml", ...)
-    private_data_dir: str | None = field(metadata={}, default=None)
+    private_data_dir: str | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
 
-    artifact_dir: str | None = field(metadata={}, default=None)
-    check_job_event_data: bool = field(metadata={}, default=False)
-    container_auth_data: dict[str, str] | None = field(metadata={}, default=None)
-    container_image: str = field(metadata={}, default="")
-    container_options: list[str] | None = field(metadata={}, default=None)
-    container_volume_mounts: list[str] | None = field(metadata={}, default=None)
-    container_workdir: str | None = field(metadata={}, default=None)
-    envvars: dict[str, Any] | None = field(metadata={}, default=None)
-    fact_cache: str | None = field(metadata={}, default=None)
-    fact_cache_type: str = field(metadata={}, default='jsonfile')
-    host_cwd: str | None = field(metadata={}, default=None)
-    ident: str | None = field(metadata={}, default=None)
-    json_mode: bool = field(metadata={}, default=False)
-    keepalive_seconds: int | None = field(metadata={}, default=None)
-    passwords: dict[str, str] | None = field(metadata={}, default=None)
-    process_isolation: bool = field(metadata={}, default=False)
-    process_isolation_executable: str = field(metadata={}, default=defaults.default_process_isolation_executable)
-    project_dir: str | None = field(metadata={}, default=None)
-    quiet: bool = field(metadata={}, default=False)
-    rotate_artifacts: int = field(metadata={}, default=0)
-    settings: dict | None = field(metadata={}, default=None)
-    ssh_key: str | None = field(metadata={}, default=None)
-    suppress_env_files: bool = field(metadata={}, default=False)
-    timeout: int | None = field(metadata={}, default=None)
+    artifact_dir: str | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    check_job_event_data: bool = False
+    container_auth_data: dict[str, str] | None = None
+    container_image: str = ""
+    container_options: list[str] | None = None
+    container_volume_mounts: list[str] | None = None
+    container_workdir: str | None = None
+    envvars: dict[str, Any] | None = None
+    fact_cache: str | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    fact_cache_type: str = 'jsonfile'
+    host_cwd: str | None = None
+    ident: str | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    json_mode: bool = False
+    keepalive_seconds: int | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    passwords: dict[str, str] | None = None
+    process_isolation: bool = False
+    process_isolation_executable: str = defaults.default_process_isolation_executable
+    project_dir: str | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    quiet: bool = False
+    rotate_artifacts: int = 0
+    settings: dict | None = None
+    ssh_key: str | None = None
+    suppress_env_files: bool = False
+    timeout: int | None = None
 
-    event_handler: Callable[[dict], None] | None = None
-    status_handler: Callable[[dict, BaseConfig], bool] | None = None
-    artifacts_handler: Callable[[str], None] | None = None
-    cancel_callback: Callable[[], bool] | None = None
-    finished_callback: Callable[[BaseConfig], None] | None = None
+    event_handler: Callable[[dict], None] | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    status_handler: Callable[[dict, BaseConfig], bool] | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    artifacts_handler: Callable[[str], None] | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    cancel_callback: Callable[[], bool] | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
+    finished_callback: Callable[[BaseConfig], None] | None = field(metadata={MetaValues.STREAMABLE: False}, default=None)
 
     _CONTAINER_ENGINES = ('docker', 'podman')
 

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -63,14 +63,6 @@ class BaseExecutionMode(Enum):
 
 
 @dataclass
-class _ArgField(dict):
-    required: bool = True
-
-    def __getattr__(self, attr):
-        return self[attr]
-
-
-@dataclass
 class BaseConfig:
 
     # This MUST be the first field we define to handle the use case where a RunnerConfig object
@@ -78,32 +70,32 @@ class BaseConfig:
     # No other config objects make use of positional parameters, so this should be fine.
     #
     # Example use case: RunnerConfig("/tmp/demo", playbook="main.yml", ...)
-    private_data_dir: str | None = field(metadata=_ArgField(), default=None)
+    private_data_dir: str | None = field(metadata={}, default=None)
 
-    artifact_dir: str | None = field(metadata=_ArgField(), default=None)
-    check_job_event_data: bool = field(metadata=_ArgField(), default=False)
-    container_auth_data: dict[str, str] | None = field(metadata=_ArgField(), default=None)
-    container_image: str = field(metadata=_ArgField(), default="")
-    container_options: list[str] | None = field(metadata=_ArgField(), default=None)
-    container_volume_mounts: list[str] | None = field(metadata=_ArgField(), default=None)
-    container_workdir: str | None = field(metadata=_ArgField(), default=None)
-    envvars: dict[str, Any] | None = field(metadata=_ArgField(), default=None)
-    fact_cache: str | None = field(metadata=_ArgField(), default=None)
-    fact_cache_type: str = field(metadata=_ArgField(), default='jsonfile')
-    host_cwd: str | None = field(metadata=_ArgField(), default=None)
-    ident: str | None = field(metadata=_ArgField(), default=None)
-    json_mode: bool = field(metadata=_ArgField(), default=False)
-    keepalive_seconds: int | None = field(metadata=_ArgField(), default=None)
-    passwords: dict[str, str] | None = field(metadata=_ArgField(), default=None)
-    process_isolation: bool = field(metadata=_ArgField(), default=False)
-    process_isolation_executable: str = field(metadata=_ArgField(), default=defaults.default_process_isolation_executable)
-    project_dir: str | None = field(metadata=_ArgField(), default=None)
-    quiet: bool = field(metadata=_ArgField(), default=False)
-    rotate_artifacts: int = field(metadata=_ArgField(), default=0)
-    settings: dict | None = field(metadata=_ArgField(), default=None)
-    ssh_key: str | None = field(metadata=_ArgField(), default=None)
-    suppress_env_files: bool = field(metadata=_ArgField(), default=False)
-    timeout: int | None = field(metadata=_ArgField(), default=None)
+    artifact_dir: str | None = field(metadata={}, default=None)
+    check_job_event_data: bool = field(metadata={}, default=False)
+    container_auth_data: dict[str, str] | None = field(metadata={}, default=None)
+    container_image: str = field(metadata={}, default="")
+    container_options: list[str] | None = field(metadata={}, default=None)
+    container_volume_mounts: list[str] | None = field(metadata={}, default=None)
+    container_workdir: str | None = field(metadata={}, default=None)
+    envvars: dict[str, Any] | None = field(metadata={}, default=None)
+    fact_cache: str | None = field(metadata={}, default=None)
+    fact_cache_type: str = field(metadata={}, default='jsonfile')
+    host_cwd: str | None = field(metadata={}, default=None)
+    ident: str | None = field(metadata={}, default=None)
+    json_mode: bool = field(metadata={}, default=False)
+    keepalive_seconds: int | None = field(metadata={}, default=None)
+    passwords: dict[str, str] | None = field(metadata={}, default=None)
+    process_isolation: bool = field(metadata={}, default=False)
+    process_isolation_executable: str = field(metadata={}, default=defaults.default_process_isolation_executable)
+    project_dir: str | None = field(metadata={}, default=None)
+    quiet: bool = field(metadata={}, default=False)
+    rotate_artifacts: int = field(metadata={}, default=0)
+    settings: dict | None = field(metadata={}, default=None)
+    ssh_key: str | None = field(metadata={}, default=None)
+    suppress_env_files: bool = field(metadata={}, default=False)
+    timeout: int | None = field(metadata={}, default=None)
 
     _CONTAINER_ENGINES = ('docker', 'podman')
 

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -67,9 +67,9 @@ class BaseConfig:
     """The base configuration object.
 
     This object has multiple initialization responsibilities, including:
-        - guaranteeing the `private_data_dir` directory exists
-        - guaranteeing that `ident` value is set
-        - setting the various work directory attributes based on `private_data_dir`
+        - guaranteeing the 'private_data_dir' directory exists
+        - guaranteeing that 'ident' value is set
+        - setting the various work directory attributes based on 'private_data_dir'
     """
 
     # This MUST be the first field we define to handle the use case where a RunnerConfig object

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -73,31 +73,37 @@ class _ArgField(dict):
 @dataclass
 class BaseConfig:
 
+    # This MUST be the first field we define to handle the use case where a RunnerConfig object
+    # is instantiated with private_data_dir as the first positional argument (non-keyword).
+    # No other config objects make use of positional parameters, so this should be fine.
+    #
+    # Example use case: RunnerConfig("/tmp/demo", playbook="main.yml", ...)
     private_data_dir: str | None = field(metadata=_ArgField(), default=None)
-    host_cwd: str | None = field(metadata=_ArgField(), default=None)
-    envvars: dict[str, Any] | None = field(metadata=_ArgField(), default=None)
-    passwords: dict[str, str] | None = field(metadata=_ArgField(), default=None)
-    settings: dict | None = field(metadata=_ArgField(), default=None)
-    project_dir: str | None = field(metadata=_ArgField(), default=None)
+
     artifact_dir: str | None = field(metadata=_ArgField(), default=None)
-    fact_cache_type: str = field(metadata=_ArgField(), default='jsonfile')
+    check_job_event_data: bool = field(metadata=_ArgField(), default=False)
+    container_auth_data: dict[str, str] | None = field(metadata=_ArgField(), default=None)
+    container_image: str = field(metadata=_ArgField(), default="")
+    container_options: list[str] | None = field(metadata=_ArgField(), default=None)
+    container_volume_mounts: list[str] | None = field(metadata=_ArgField(), default=None)
+    container_workdir: str | None = field(metadata=_ArgField(), default=None)
+    envvars: dict[str, Any] | None = field(metadata=_ArgField(), default=None)
     fact_cache: str | None = field(metadata=_ArgField(), default=None)
+    fact_cache_type: str = field(metadata=_ArgField(), default='jsonfile')
+    host_cwd: str | None = field(metadata=_ArgField(), default=None)
+    ident: str | None = field(metadata=_ArgField(), default=None)
+    json_mode: bool = field(metadata=_ArgField(), default=False)
+    keepalive_seconds: int | None = field(metadata=_ArgField(), default=None)
+    passwords: dict[str, str] | None = field(metadata=_ArgField(), default=None)
     process_isolation: bool = field(metadata=_ArgField(), default=False)
     process_isolation_executable: str = field(metadata=_ArgField(), default=defaults.default_process_isolation_executable)
-    container_image: str = field(metadata=_ArgField(), default="")
-    container_volume_mounts: list[str] | None = field(metadata=_ArgField(), default=None)
-    container_options: list[str] | None = field(metadata=_ArgField(), default=None)
-    container_workdir: str | None = field(metadata=_ArgField(), default=None)
-    container_auth_data: dict[str, str] | None = field(metadata=_ArgField(), default=None)
-    ident: str | None = field(metadata=_ArgField(), default=None)
-    rotate_artifacts: int = field(metadata=_ArgField(), default=0)
-    timeout: int | None = field(metadata=_ArgField(), default=None)
-    ssh_key: str | None = field(metadata=_ArgField(), default=None)
+    project_dir: str | None = field(metadata=_ArgField(), default=None)
     quiet: bool = field(metadata=_ArgField(), default=False)
-    json_mode: bool = field(metadata=_ArgField(), default=False)
-    check_job_event_data: bool = field(metadata=_ArgField(), default=False)
+    rotate_artifacts: int = field(metadata=_ArgField(), default=0)
+    settings: dict | None = field(metadata=_ArgField(), default=None)
+    ssh_key: str | None = field(metadata=_ArgField(), default=None)
     suppress_env_files: bool = field(metadata=_ArgField(), default=False)
-    keepalive_seconds: int | None = field(metadata=_ArgField(), default=None)
+    timeout: int | None = field(metadata=_ArgField(), default=None)
 
     _CONTAINER_ENGINES = ('docker', 'podman')
 

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -64,6 +64,7 @@ class BaseExecutionMode(Enum):
 
 # Metadata string values
 class MetaValues(Enum):
+    # When True, value is emitted from Transmitter to send to Worker.
     TRANSMIT = 'transmit'
 
 

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -166,6 +166,12 @@ class BaseConfig:
         Manages reading environment metadata files under ``private_data_dir`` and merging/updating
         with existing values so the :py:class:`ansible_runner.runner.Runner` object can read and use them easily
         """
+
+        if self.ident is None:
+            raise ConfigurationError("ident value cannot be None")
+        if self.artifact_dir is None:
+            raise ConfigurationError("artifact_dir value cannot be None")
+
         self.runner_mode = runner_mode
         try:
             if self.settings and isinstance(self.settings, dict):
@@ -174,6 +180,10 @@ class BaseConfig:
                 self.settings = self.loader.load_file('env/settings', Mapping)  # type: ignore
         except ConfigurationError:
             debug("Not loading settings")
+            self.settings = {}
+
+        # Safety net
+        if self.settings is None:
             self.settings = {}
 
         if self.runner_mode == 'pexpect':
@@ -485,6 +495,12 @@ class BaseConfig:
                                        execution_mode: BaseExecutionMode,
                                        cmdline_args: list[str]
                                        ) -> list[str]:
+        if self.artifact_dir is None:
+            raise ConfigurationError("artifact_dir value cannot be None")
+
+        if self.private_data_dir is None:
+            raise ConfigurationError("private_data_dir value cannot be None")
+
         new_args = [self.process_isolation_executable]
         new_args.extend(['run', '--rm'])
 
@@ -632,6 +648,9 @@ class BaseConfig:
         Given an existing command line and parameterization this will return the same command line wrapped with the
         necessary calls to ``ssh-agent``
         """
+        if self.ident is None:
+            raise ConfigurationError("ident value cannot be None")
+
         if self.containerized:
             artifact_dir = os.path.join("/runner/artifacts", self.ident)
             ssh_key_path = os.path.join(artifact_dir, "ssh_key_data")

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -144,7 +144,7 @@ class BaseConfig:
     fact_cache: str | None = field(metadata={MetaValues.TRANSMIT: False}, default=None)
     fact_cache_type: str = 'jsonfile'
     host_cwd: str | None = None
-    ident: str | None = field(metadata={MetaValues.TRANSMIT: False}, default=None)
+    ident: str | None = None
     json_mode: bool = False
     keepalive_seconds: int | None = field(metadata={MetaValues.TRANSMIT: False}, default=None)
     passwords: dict[str, str] | None = None
@@ -167,10 +167,22 @@ class BaseConfig:
     _CONTAINER_ENGINES = ('docker', 'podman')
 
     def __post_init__(self) -> None:
+        """
+        Completes object initialization after the Dataclass __init__() call is complete.
+
+        Finish initialization by setting other attribute defaults and normalize the path attributes
+        by setting absolute paths. Also make sure that the private_data_dir and artifact directories
+        exist, creating them if necessary.
+
+        The Runner, Transmitter, Worker and Processor objects all depend, in some manner, on this
+        path normalization being completed when they are initialized (mostly for private_data_dir).
+
+        BaseConfig and RunnerConfig both make use of the ArtifactLoader object that is created here.
+        """
         # pylint: disable=W0613
 
         self.command: list[str] = []
-        self.registry_auth_path: str
+        self.registry_auth_path: str = ""
         self.container_name: str = ""  # like other properties, not accurate until prepare is called
         if self.container_image is None:
             self.container_image = ''

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -73,9 +73,57 @@ class BaseConfig:
     """The base configuration object.
 
     This object has multiple initialization responsibilities, including:
-        - guaranteeing the 'private_data_dir' directory exists
-        - guaranteeing that 'ident' value is set
-        - setting the various work directory attributes based on 'private_data_dir'
+        - guaranteeing the ``private_data_dir`` directory exists
+        - guaranteeing that ``ident`` value is set
+        - setting the various work directory attributes based on ``private_data_dir``
+
+    :param str private_data_dir: The directory containing all runner metadata needed to invoke the runner
+        module. Output artifacts will also be stored here for later consumption.
+    :param str artifact_dir: The path to the directory where artifacts should live. This defaults to
+        ``artifacts`` under ``private_data_dir``.
+    :param bool check_job_event_data: Check if job events data is completely generated. If event data is
+        not completely generated and if value is set to ``True`` it will raise an `AnsibleRunnerException` exception.
+        If set to ``False``, it log a debug message and continue execution. Default value is ``False``.
+    :param dict container_auth_data: Container registry authentication data containing ``host``, ``username``, and
+        ``password`` entries.
+    :param str container_image: Container image to use when running an ansible task.
+    :param list container_options: List of container options to pass to execution engine.
+    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir`. Default to ``None``.
+    :param str container_workdir: The working directory within the container.
+    :param dict envvars: Environment variables to be used when running Ansible. Environment variables will also be
+        read from ``env/envvars`` in ``private_data_dir``.
+    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in
+        artifacts directory. This is only used for ``jsonfile`` type fact caches.
+    :param str fact_cache_type: A string of the type of fact cache to use. Defaults to ``jsonfile``.
+    :param str host_cwd: The host current working directory to be mounted within the container (if enabled) and will be
+        the work directory within container.
+    :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
+        the artifact directory holding the results of the invocation.
+    :param bool json_mode: Store event data in place of stdout on the console and in the stdout file.
+    :param int keepalive_seconds: Use within the streaming Worker object to inject a keepalive event.
+    :param dict passwords: A dictionary containing password prompt patterns and response values used when processing
+        output from Ansible. Passwords will also be read from ``env/passwords`` in ``private_data_dir``.
+    :param bool process_isolation: Enable process isolation, using either a container engine (e.g. podman) or a
+        sandbox (e.g. bwrap).
+    :param str process_isolation_executable: Process isolation executable or container engine used to isolate
+        execution. (default: podman)
+    :param str project_dir: The path to the playbook content. Defaults to ``project`` within ``private_data_dir``.
+    :param bool quiet: Disable all output.
+    :param int rotate_artifacts: Keep at most n artifact directories. Disable with a value of ``0`` (the default).
+    :param dict settings: A dictionary containing settings values for the ``ansible-runner`` runtime environment.
+        These will also be read from ``env/settings`` in ``private_data_dir``.
+    :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
+    :param bool suppress_env_files: Disable the writing of files into the ``env`` which may store sensitive information.
+    :param int timeout: The timeout value, in seconds, that will be passed to either ``pexpect`` of ``subprocess``
+        invocation (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will
+        force cancel the execution.
+    :param Callable event_handler: An optional callback that will be invoked any time an event is received by Runner itself.
+        Return ``True`` to keep the event
+    :param Callable cancel_callback: An optional callback that can inform runner to cancel (returning ``True``) or not
+        (returning ``False``).
+    :param Callable finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
+    :param Callable status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
+    :param Callable artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
     """
 
     # This MUST be the first field we define to handle the use case where a RunnerConfig object

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -31,7 +31,7 @@ import shutil
 from dataclasses import dataclass, field
 
 from ansible_runner import output
-from ansible_runner.config._base import _ArgField, BaseConfig, BaseExecutionMode
+from ansible_runner.config._base import BaseConfig, BaseExecutionMode
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.output import debug
 from ansible_runner.utils import register_for_cleanup
@@ -67,29 +67,29 @@ class RunnerConfig(BaseConfig):
     """
 
     # 'binary' comes from the --binary CLI opt for an alternative ansible command path
-    binary: str | None = field(metadata=_ArgField(), default=None)
-    cmdline: str | None = field(metadata=_ArgField(), default=None)
-    directory_isolation_base_path: str | None = field(metadata=_ArgField(), default=None)
-    extravars: dict | None = field(metadata=_ArgField(), default=None)
-    forks: int | None = field(metadata=_ArgField(), default=None)
-    host_pattern: str | None = field(metadata=_ArgField(), default=None)
-    inventory: str | dict | list | None = field(metadata=_ArgField(), default=None)
-    limit: str | None = field(metadata=_ArgField(), default=None)
-    module: str | None = field(metadata=_ArgField(), default=None)
-    module_args: str | None = field(metadata=_ArgField(), default=None)
-    omit_event_data: bool = field(metadata=_ArgField(), default=False)
-    only_failed_event_data: bool = field(metadata=_ArgField(), default=False)
-    playbook: str | None = field(metadata=_ArgField(), default=None)
-    process_isolation_hide_paths: str | list | None = field(metadata=_ArgField(), default=None)
-    process_isolation_ro_paths: str | list | None = field(metadata=_ArgField(), default=None)
-    process_isolation_show_paths: str | list | None = field(metadata=_ArgField(), default=None)
-    process_isolation_path: str | None = field(metadata=_ArgField(), default=None)
-    roles_path: str | None = field(metadata=_ArgField(), default=None)
-    skip_tags: str | None = field(metadata=_ArgField(), default=None)
-    suppress_ansible_output: bool = field(metadata=_ArgField(), default=False)
-    suppress_output_file: bool = field(metadata=_ArgField(), default=False)
-    tags: str | None = field(metadata=_ArgField(), default=None)
-    verbosity: int | None = field(metadata=_ArgField(), default=None)
+    binary: str | None = field(metadata={}, default=None)
+    cmdline: str | None = field(metadata={}, default=None)
+    directory_isolation_base_path: str | None = field(metadata={}, default=None)
+    extravars: dict | None = field(metadata={}, default=None)
+    forks: int | None = field(metadata={}, default=None)
+    host_pattern: str | None = field(metadata={}, default=None)
+    inventory: str | dict | list | None = field(metadata={}, default=None)
+    limit: str | None = field(metadata={}, default=None)
+    module: str | None = field(metadata={}, default=None)
+    module_args: str | None = field(metadata={}, default=None)
+    omit_event_data: bool = field(metadata={}, default=False)
+    only_failed_event_data: bool = field(metadata={}, default=False)
+    playbook: str | None = field(metadata={}, default=None)
+    process_isolation_hide_paths: str | list | None = field(metadata={}, default=None)
+    process_isolation_ro_paths: str | list | None = field(metadata={}, default=None)
+    process_isolation_show_paths: str | list | None = field(metadata={}, default=None)
+    process_isolation_path: str | None = field(metadata={}, default=None)
+    roles_path: str | None = field(metadata={}, default=None)
+    skip_tags: str | None = field(metadata={}, default=None)
+    suppress_ansible_output: bool = field(metadata={}, default=False)
+    suppress_output_file: bool = field(metadata={}, default=False)
+    tags: str | None = field(metadata={}, default=None)
+    verbosity: int | None = field(metadata={}, default=None)
 
     def __post_init__(self) -> None:
         # NOTE: Cannot call base class __init__() here as that causes some recursion madness.

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -79,12 +79,15 @@ class RunnerConfig(BaseConfig):
     module_args: str | None = field(metadata={}, default=None)
     omit_event_data: bool = field(metadata={}, default=False)
     only_failed_event_data: bool = field(metadata={}, default=False)
-    playbook: str | None = field(metadata={}, default=None)
+    playbook: str | dict | list | None = field(metadata={}, default=None)
     process_isolation_hide_paths: str | list | None = field(metadata={}, default=None)
     process_isolation_ro_paths: str | list | None = field(metadata={}, default=None)
     process_isolation_show_paths: str | list | None = field(metadata={}, default=None)
     process_isolation_path: str | None = field(metadata={}, default=None)
+    role: str = ""
+    role_skip_facts: bool = False
     roles_path: str | None = field(metadata={}, default=None)
+    role_vars: dict[str, str] | None = None
     skip_tags: str | None = field(metadata={}, default=None)
     suppress_ansible_output: bool = field(metadata={}, default=False)
     suppress_output_file: bool = field(metadata={}, default=False)
@@ -120,6 +123,21 @@ class RunnerConfig(BaseConfig):
     @directory_isolation_path.setter
     def directory_isolation_path(self, value):
         self.directory_isolation_base_path = value
+
+    @property
+    def hosts(self):
+        """
+        Alias for backward compatibility.
+
+        dump_artifacts() makes reference to 'hosts' kwargs (API) value, even though it
+        is undocumented as an API parameter to interface.run(). We make it equivalent
+        to 'host_pattern' here to not break anyone.
+        """
+        return self.host_pattern
+
+    @hosts.setter
+    def hosts(self, value):
+        self.host_pattern = value
 
     @property
     def extra_vars(self):

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -50,12 +50,11 @@ class ExecutionMode():
 
 @dataclass
 class RunnerConfig(BaseConfig):
-    """
-    A ``Runner`` configuration object that's meant to encapsulate the configuration used by the
+    """A ``Runner`` configuration object that's meant to encapsulate the configuration used by the
     :py:mod:`ansible_runner.runner.Runner` object to launch and manage the invocation of ``ansible``
     and ``ansible-playbook``
 
-    Typically this object is initialized for you when using the standard ``run`` interfaces in :py:mod:`ansible_runner.interface`
+    Typically, this object is initialized for you when using the standard ``run`` interfaces in :py:mod:`ansible_runner.interface`
     but can be used to construct the ``Runner`` configuration to be invoked elsewhere. It can also be overridden to provide different
     functionality to the Runner object.
 
@@ -65,6 +64,48 @@ class RunnerConfig(BaseConfig):
     >>> r = Runner(config=rc)
     >>> r.run()
 
+    This class inherites all the initialization parameters of the `BaseConfig` parent class, plus:
+
+    :param BinaryIO _input: An optional file or file-like object for use as input in a streaming pipeline.
+    :param BinaryIO _output: An optional file or file-like object for use as output in a streaming pipeline.
+    :param str binary: Path to an alternative ansible command.
+    :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
+    :param str directory_isolation_base_path: An optional path will be used as the base path to create a temp directory.
+        The project contents will be copied to this location which will then be used as the working directory during
+        playbook execution.
+    :param dict extravars: Extra variables to be passed to Ansible at runtime using ``-e``. Extra vars will also be
+                      read from ``env/extravars`` in ``private_data_dir``.
+    :param int forks: Control Ansible parallel concurrency.
+    :param str host_pattern: The host pattern to match when running in ad-hoc mode.
+    :param str or dict or list inventory: Overrides the inventory directory/file (supplied at ``private_data_dir/inventory``) with
+        a specific host or list of hosts. This can take the form of:
+
+            - Path to the inventory file in the ``private_data_dir/inventory`` directory or
+              an absolute path to the inventory file
+            - Native python dict supporting the YAML/json inventory structure
+            - A text INI formatted string
+            - A list of inventory sources, or an empty list to disable passing inventory
+    :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used.
+    :param str module: The module that will be invoked in ad-hoc mode by runner when executing Ansible.
+    :param str module_args: The module arguments that will be supplied to ad-hoc mode.
+    :param bool omit_event_data: Omits extra ansible event data from event payload (stdout and event still included).
+    :param bool only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included).
+    :param bool only_transmit_kwargs: If ``True``, the streaming Transmitter process will only send job arguments.
+    :param str or dict or list playbook: The playbook (either a list or dictionary of plays, or as a path relative to
+        ``private_data_dir/project``) that will be invoked by runner when executing Ansible.
+    :param str or list process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
+    :param str or list process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
+    :param str or list process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
+    :param str process_isolation_path: Path that an isolated playbook run will use for staging. (default: ``/tmp``)
+    :param str role: Name of the role to execute.
+    :param bool role_skip_facts: If ``True``, ``gather_facts`` will be set to ``False`` for execution of the namedgit  ``role``.
+    :param str or list roles_path: Directory or list of directories to assign to ``ANSIBLE_ROLES_PATH``.
+    :param dict role_vars: Variables and their values to use with the named ``role``.
+    :param str skip_tags: Value to pass to the ``--skip-tags`` option of ``ansible-playbook``.
+    :param bool suppress_ansible_output: If ``True``, Ansible output will not appear to stdout.
+    :param bool suppress_output_file: If ``True``, Ansible output will not be written to a file in the artifacts directory.
+    :param str tags: Value to pass to the ``--tags`` option of ``ansible-playbook``.
+    :param int verbosity: Control the verbosity level of ansible-playbook.
     """
 
     _input: BinaryIO | None = field(metadata={MetaValues.TRANSMIT: False}, default=None)
@@ -205,7 +246,7 @@ class RunnerConfig(BaseConfig):
         - prepare_command
 
         It's also responsible for wrapping the command with the proper ssh agent invocation
-        and setting early ANSIBLE_ environment variables.
+        and setting early ``ANSIBLE_`` environment variables.
         """
         # ansible_path = find_executable('ansible')
         # if ansible_path is None or not os.access(ansible_path, os.X_OK):

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -28,7 +28,7 @@ import stat
 import tempfile
 import shutil
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from typing import Any
 
 from ansible_runner import output
@@ -80,6 +80,7 @@ class RunnerConfig(BaseConfig):
     module_args: str | None = None
     omit_event_data: bool = False
     only_failed_event_data: bool = False
+    only_transmit_kwargs: bool = field(metadata={MetaValues.TRANSMIT: False}, default=False)
     playbook: str | dict | list | None = None
     process_isolation_hide_paths: str | list | None = None
     process_isolation_ro_paths: str | list | None = None

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -64,7 +64,7 @@ class RunnerConfig(BaseConfig):
     >>> r = Runner(config=rc)
     >>> r.run()
 
-    This class inherites all the initialization parameters of the `BaseConfig` parent class, plus:
+    This class inherits all the initialization parameters of the `BaseConfig` parent class, plus:
 
     :param BinaryIO _input: An optional file or file-like object for use as input in a streaming pipeline.
     :param BinaryIO _output: An optional file or file-like object for use as output in a streaming pipeline.

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -24,12 +24,12 @@ import json
 import logging
 import os
 import shlex
+import shutil
 import stat
 import tempfile
-import shutil
 
 from dataclasses import dataclass, field, fields
-from typing import Any
+from typing import Any, BinaryIO
 
 from ansible_runner import output
 from ansible_runner.config._base import BaseConfig, BaseExecutionMode, MetaValues
@@ -66,6 +66,9 @@ class RunnerConfig(BaseConfig):
     >>> r.run()
 
     """
+
+    _input: BinaryIO | None = field(metadata={MetaValues.TRANSMIT: False}, default=None)
+    _output: BinaryIO | None = field(metadata={MetaValues.TRANSMIT: False}, default=None)
 
     # 'binary' comes from the --binary CLI opt for an alternative ansible command path
     binary: str | None = None
@@ -110,7 +113,7 @@ class RunnerConfig(BaseConfig):
 
     @property
     def cmdline_args(self):
-        """ Alias for backward compatibility. """
+        """Alias for backward compatibility."""
         return self.cmdline
 
     @cmdline_args.setter
@@ -119,7 +122,7 @@ class RunnerConfig(BaseConfig):
 
     @property
     def directory_isolation_path(self):
-        """ Alias for backward compatibility. """
+        """Alias for backward compatibility."""
         return self.directory_isolation_base_path
 
     @directory_isolation_path.setter
@@ -128,8 +131,7 @@ class RunnerConfig(BaseConfig):
 
     @property
     def hosts(self):
-        """
-        Alias for backward compatibility.
+        """Alias for backward compatibility.
 
         dump_artifacts() makes reference to 'hosts' kwargs (API) value, even though it
         is undocumented as an API parameter to interface.run(). We make it equivalent
@@ -143,12 +145,30 @@ class RunnerConfig(BaseConfig):
 
     @property
     def extra_vars(self):
-        """ Alias for backward compatibility. """
+        """Alias for backward compatibility."""
         return self.extravars
 
     @extra_vars.setter
     def extra_vars(self, value):
         self.extravars = value
+
+    # Create internal aliases for '_input' and '_output' attributes since those are named like
+    # private attributes, yet they can be set from our public interfaces... go figure.
+    @property
+    def input(self):
+        return self._input
+
+    @input.setter
+    def input(self, value):
+        self._input = value
+
+    @property
+    def output(self):
+        return self._output
+
+    @output.setter
+    def output(self, value):
+        self._output = value
 
     def streamable_attributes(self) -> dict[str, Any]:
         """Get the set of streamable attributes that have a value that is different from the default.

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -25,7 +25,6 @@ import json
 import sys
 import threading
 import logging
-from dataclasses import asdict
 
 from ansible_runner import output
 from ansible_runner._internal._dump_artifacts import dump_artifacts
@@ -90,18 +89,15 @@ def init_runner(
         config.cancel_callback = signal_handler()
 
     if streamer == 'transmit':
-        kwargs = asdict(config)
-        stream_transmitter = Transmitter(only_transmit_kwargs, _output=_output, **kwargs)
+        stream_transmitter = Transmitter(config, only_transmit_kwargs, _output=_output)
         return stream_transmitter
 
     if streamer == 'worker':
-        kwargs = asdict(config)
-        stream_worker = Worker(_input=_input, _output=_output, **kwargs)
+        stream_worker = Worker(config, _input=_input, _output=_output)
         return stream_worker
 
     if streamer == 'process':
-        kwargs = asdict(config)
-        stream_processor = Processor(_input=_input, **kwargs)
+        stream_processor = Processor(config, _input=_input)
         return stream_processor
 
     if config.process_isolation:

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -221,7 +221,16 @@ def run(config: RunnerConfig | None = None,
     return r
 
 
-def run_async(**kwargs):
+def run_async(
+        config: RunnerConfig | None = None,
+        streamer: str = "",
+        debug: bool = False,
+        logfile: str = "",
+        ignore_logging: bool = True,
+        _input: io.FileIO | None = None,
+        _output: io.FileIO | None = None,
+        only_transmit_kwargs: bool = False,
+        **kwargs):
     '''
     Runs an Ansible Runner task in the background which will start immediately. Returns the thread object and a Runner object.
 
@@ -229,7 +238,19 @@ def run_async(**kwargs):
 
     :returns: A tuple containing a :py:class:`threading.Thread` object and a :py:class:`ansible_runner.runner.Runner` object
     '''
-    r = init_runner(**kwargs)
+
+    # Initialize logging
+    if not ignore_logging:
+        output.configure(debug, logfile)
+
+    if not config:
+        config = RunnerConfig(**kwargs)
+
+    r = init_runner(
+        config=config, streamer=streamer,
+        only_transmit_kwargs=only_transmit_kwargs,
+        _input=_input, _output=_output,
+    )
     runner_thread = threading.Thread(target=r.run)
     runner_thread.start()
     return runner_thread, r

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -67,19 +67,20 @@ def init_runner(
 
     if streamer:
         # undo any full paths that were dumped by dump_artifacts above in the streamer case
-        private_data_dir = config.private_data_dir
+        private_data_dir = config.private_data_dir or ""
         project_dir = os.path.join(private_data_dir, 'project')
 
         playbook_path = config.playbook or ''
-        if os.path.isabs(playbook_path) and playbook_path.startswith(project_dir):
+        if isinstance(playbook_path, str) and os.path.isabs(playbook_path) and playbook_path.startswith(project_dir):
             config.playbook = os.path.relpath(playbook_path, project_dir)
 
         inventory_path = config.inventory or ''
-        if os.path.isabs(inventory_path) and inventory_path.startswith(private_data_dir):
+        if isinstance(inventory_path, str) and os.path.isabs(inventory_path) and inventory_path.startswith(private_data_dir):
             config.inventory = os.path.relpath(inventory_path, private_data_dir)
 
-        envvars = config.envvars or {}
-        roles_path = envvars.get('ANSIBLE_ROLES_PATH') or ''
+        if config.envvars is None:
+            config.envvars = {}
+        roles_path = config.envvars.get('ANSIBLE_ROLES_PATH') or ''
         if os.path.isabs(roles_path) and roles_path.startswith(private_data_dir):
             config.envvars['ANSIBLE_ROLES_PATH'] = os.path.relpath(roles_path, private_data_dir)
 

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -19,7 +19,6 @@
 #
 from __future__ import annotations
 
-import io
 import os
 import json
 import sys
@@ -44,11 +43,7 @@ from ansible_runner.utils import (
 logging.getLogger('ansible-runner').addHandler(logging.NullHandler())
 
 
-def init_runner(
-        config: RunnerConfig,
-        streamer: str,
-        _input: io.FileIO | None = None,
-        _output: io.FileIO | None = None):
+def init_runner(config: RunnerConfig, streamer: str):
     '''
     Initialize the Runner() instance
 
@@ -88,15 +83,15 @@ def init_runner(
         config.cancel_callback = signal_handler()
 
     if streamer == 'transmit':
-        stream_transmitter = Transmitter(config, _output=_output)
+        stream_transmitter = Transmitter(config)
         return stream_transmitter
 
     if streamer == 'worker':
-        stream_worker = Worker(config, _input=_input, _output=_output)
+        stream_worker = Worker(config)
         return stream_worker
 
     if streamer == 'process':
-        stream_processor = Processor(config, _input=_input)
+        stream_processor = Processor(config)
         return stream_processor
 
     if config.process_isolation:
@@ -120,8 +115,6 @@ def run(config: RunnerConfig | None = None,
         debug: bool = False,
         logfile: str = "",
         ignore_logging: bool = True,
-        _input: io.FileIO | None = None,
-        _output: io.FileIO | None = None,
         **kwargs):
     '''
     Run an Ansible Runner task in the foreground and return a Runner object when complete.
@@ -169,8 +162,8 @@ def run(config: RunnerConfig | None = None,
                     (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
                     execution.
     :param str streamer: Optionally invoke ansible-runner as one of the steps in the streaming pipeline
-    :param io.FileIO _input: An optional file or file-like object for use as input in a streaming pipeline
-    :param io.FileIO _output: An optional file or file-like object for use as output in a streaming pipeline
+    :param typing.BinaryIO _input: An optional file or file-like object for use as input in a streaming pipeline
+    :param typing.BinaryIO _output: An optional file or file-like object for use as output in a streaming pipeline
     :param Callable event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
     :param Callable cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
     :param Callable finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
@@ -206,10 +199,7 @@ def run(config: RunnerConfig | None = None,
     if not config:
         config = RunnerConfig(**kwargs)
 
-    r = init_runner(
-        config=config, streamer=streamer,
-        _input=_input, _output=_output,
-    )
+    r = init_runner(config=config, streamer=streamer)
     r.run()
     return r
 
@@ -220,8 +210,6 @@ def run_async(
         debug: bool = False,
         logfile: str = "",
         ignore_logging: bool = True,
-        _input: io.FileIO | None = None,
-        _output: io.FileIO | None = None,
         **kwargs):
     '''
     Runs an Ansible Runner task in the background which will start immediately. Returns the thread object and a Runner object.
@@ -238,10 +226,7 @@ def run_async(
     if not config:
         config = RunnerConfig(**kwargs)
 
-    r = init_runner(
-        config=config, streamer=streamer,
-        _input=_input, _output=_output,
-    )
+    r = init_runner(config=config, streamer=streamer)
     runner_thread = threading.Thread(target=r.run)
     runner_thread.start()
     return runner_thread, r

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -47,7 +47,6 @@ logging.getLogger('ansible-runner').addHandler(logging.NullHandler())
 def init_runner(
         config: RunnerConfig,
         streamer: str,
-        only_transmit_kwargs: bool,
         _input: io.FileIO | None = None,
         _output: io.FileIO | None = None):
     '''
@@ -89,7 +88,7 @@ def init_runner(
         config.cancel_callback = signal_handler()
 
     if streamer == 'transmit':
-        stream_transmitter = Transmitter(config, only_transmit_kwargs, _output=_output)
+        stream_transmitter = Transmitter(config, _output=_output)
         return stream_transmitter
 
     if streamer == 'worker':
@@ -123,7 +122,6 @@ def run(config: RunnerConfig | None = None,
         ignore_logging: bool = True,
         _input: io.FileIO | None = None,
         _output: io.FileIO | None = None,
-        only_transmit_kwargs: bool = False,
         **kwargs):
     '''
     Run an Ansible Runner task in the foreground and return a Runner object when complete.
@@ -210,7 +208,6 @@ def run(config: RunnerConfig | None = None,
 
     r = init_runner(
         config=config, streamer=streamer,
-        only_transmit_kwargs=only_transmit_kwargs,
         _input=_input, _output=_output,
     )
     r.run()
@@ -225,7 +222,6 @@ def run_async(
         ignore_logging: bool = True,
         _input: io.FileIO | None = None,
         _output: io.FileIO | None = None,
-        only_transmit_kwargs: bool = False,
         **kwargs):
     '''
     Runs an Ansible Runner task in the background which will start immediately. Returns the thread object and a Runner object.
@@ -244,7 +240,6 @@ def run_async(
 
     r = init_runner(
         config=config, streamer=streamer,
-        only_transmit_kwargs=only_transmit_kwargs,
         _input=_input, _output=_output,
     )
     runner_thread = threading.Thread(target=r.run)

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -116,81 +116,37 @@ def run(config: RunnerConfig | None = None,
         logfile: str = "",
         ignore_logging: bool = True,
         **kwargs):
-    '''
-    Run an Ansible Runner task in the foreground and return a Runner object when complete.
+    """Run an Ansible Runner task in the foreground and return a Runner object when complete.
 
-    :param str private_data_dir: The directory containing all runner metadata needed to invoke the runner
-                             module. Output artifacts will also be stored here for later consumption.
-    :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
-                  the artifact directory holding the results of the invocation.
-    :param bool json_mode: Store event data in place of stdout on the console and in the stdout file
-    :param str or list playbook: The playbook (either a list or dictionary of plays, or as a path relative to
-                     ``private_data_dir/project``) that will be invoked by runner when executing Ansible.
-    :param str module: The module that will be invoked in ad-hoc mode by runner when executing Ansible.
-    :param str module_args: The module arguments that will be supplied to ad-hoc mode.
-    :param str host_pattern: The host pattern to match when running in ad-hoc mode.
-    :param str or dict or list inventory: Overrides the inventory directory/file (supplied at ``private_data_dir/inventory``) with
-        a specific host or list of hosts. This can take the form of:
+    This function may be called in two different formats, both of which are equivalent. The first uses only
+    keyword arguments and does NOT specify a value for the ``config`` parameter.
 
-            - Path to the inventory file in the ``private_data_dir/inventory`` directory or
-              an absolute path to the inventory file
-            - Native python dict supporting the YAML/json inventory structure
-            - A text INI formatted string
-            - A list of inventory sources, or an empty list to disable passing inventory
+    .. code-block:: python
 
-    :param str role: Name of the role to execute.
-    :param str or list roles_path: Directory or list of directories to assign to ANSIBLE_ROLES_PATH
-    :param dict envvars: Environment variables to be used when running Ansible. Environment variables will also be
-                    read from ``env/envvars`` in ``private_data_dir``
-    :param dict extravars: Extra variables to be passed to Ansible at runtime using ``-e``. Extra vars will also be
-                      read from ``env/extravars`` in ``private_data_dir``.
-    :param dict passwords: A dictionary containing password prompt patterns and response values used when processing output from
-                      Ansible. Passwords will also be read from ``env/passwords`` in ``private_data_dir``.
-    :param dict settings: A dictionary containing settings values for the ``ansible-runner`` runtime environment. These will also
-                     be read from ``env/settings`` in ``private_data_dir``.
-    :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
-    :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
-    :param bool suppress_env_files: Disable the writing of files into the ``env`` which may store sensitive information
-    :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
-    :param int forks: Control Ansible parallel concurrency
-    :param int verbosity: Control how verbose the output of ansible-playbook is
-    :param bool quiet: Disable all output
-    :param str artifact_dir: The path to the directory where artifacts should live, this defaults to 'artifacts' under the private data dir
-    :param str project_dir: The path to the playbook content, this defaults to 'project' within the private data dir
-    :param int rotate_artifacts: Keep at most n artifact directories, disable with a value of 0 which is the default
-    :param int timeout: The timeout value in seconds that will be passed to either ``pexpect`` of ``subprocess`` invocation
-                    (based on ``runner_mode`` selected) while executing command. It the timeout is triggered it will force cancel the
-                    execution.
-    :param str streamer: Optionally invoke ansible-runner as one of the steps in the streaming pipeline
-    :param typing.BinaryIO _input: An optional file or file-like object for use as input in a streaming pipeline
-    :param typing.BinaryIO _output: An optional file or file-like object for use as output in a streaming pipeline
-    :param Callable event_handler: An optional callback that will be invoked any time an event is received by Runner itself, return True to keep the event
-    :param Callable cancel_callback: An optional callback that can inform runner to cancel (returning True) or not (returning False)
-    :param Callable finished_callback: An optional callback that will be invoked at shutdown after process cleanup.
-    :param Callable status_handler: An optional callback that will be invoked any time the status changes (e.g...started, running, failed, successful, timeout)
-    :param Callable artifacts_handler: An optional callback that will be invoked at the end of the run to deal with the artifacts from the run.
-    :param bool process_isolation: Enable process isolation, using either a container engine (e.g. podman) or a sandbox (e.g. bwrap).
-    :param str process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
-    :param str process_isolation_path: Path that an isolated playbook run will use for staging. (default: /tmp)
-    :param str or list process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
-    :param str or list process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
-    :param str or list process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
-    :param str container_image: Container image to use when running an ansible task
-    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir. (default: None)
-    :param list container_options: List of container options to pass to execution engine.
-    :param str directory_isolation_base_path: An optional path will be used as the base path to create a temp directory, the project contents will be
-                                          copied to this location which will then be used as the working directory during playbook execution.
-    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param str fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
-    :param bool omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
-    :param bool only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
-    :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
-                                 value is set to 'True' it will raise 'AnsibleRunnerException' exception,
-                                 if set to 'False' it log a debug message and continue execution. Default value is 'False'
+        run(private_data_dir='/tmp/demo', playbook='test.yml')
+        run(private_data_dir='/tmp/streaming-demo', playbook='test.yml', streamer='transmit')
+
+    The second format uses a `RunnerConfig` object supplied in the ``config`` parameter for all available
+    run values. All other ``**kwarg`` keywords and their values are ignored.
+
+    .. code-block:: python
+
+        config = RunnerConfig(private_data_dir='/tmp/demo', playbook='test.yml')
+        run(config=config)
+
+        streaming_config = RunnerConfig(private_data_dir='/tmp/streaming-demo', playbook='test.yml')
+        run(config=streaming_config, streamer='transmit')
+
+    :param RunnerConfig config: A configuration object describing the run characteristics.
+    :param str streamer: Optionally invoke ansible-runner as one of the steps in the streaming pipeline.
+        Valid values are ``transmit``, ``worker``, or ``process``.
+    :param bool debug: If ``True``, debugging output from ansible-runner is enabled.
+    :param str logfile: Path to a file where logging output will be sent.
+    :param bool ignore_logging: If ``True``, ansible-runner log output will be disabled.
+    :param dict kwargs: Keyword arguments that match the parameters for a `RunnerConfig` object.
 
     :returns: A :py:class:`ansible_runner.runner.Runner` object, or a simple object containing ``rc`` if run remotely
-    '''
+    """
 
     # Initialize logging
     if not ignore_logging:

--- a/src/ansible_runner/output.py
+++ b/src/ansible_runner/output.py
@@ -64,7 +64,7 @@ def set_traceback(value: str) -> None:
     TRACEBACK_ENABLED = value.lower() == 'enable'
 
 
-def configure() -> None:
+def configure(debug: bool, logfile: str) -> None:
     '''
     Configures the logging facility
 
@@ -89,3 +89,7 @@ def configure() -> None:
         formatter = logging.Formatter('%(message)s')
         stdout_handler.setFormatter(formatter)
         _display_logger.addHandler(stdout_handler)
+
+    set_debug('enable' if debug is True else 'disable')
+    if logfile:
+        set_logfile(logfile)

--- a/src/ansible_runner/output.py
+++ b/src/ansible_runner/output.py
@@ -64,7 +64,7 @@ def set_traceback(value: str) -> None:
     TRACEBACK_ENABLED = value.lower() == 'enable'
 
 
-def configure(debug: bool, logfile: str) -> None:
+def configure(enable_debug: bool, logfile: str) -> None:
     '''
     Configures the logging facility
 
@@ -90,6 +90,6 @@ def configure(debug: bool, logfile: str) -> None:
         stdout_handler.setFormatter(formatter)
         _display_logger.addHandler(stdout_handler)
 
-    set_debug('enable' if debug is True else 'disable')
+    set_debug('enable' if enable_debug is True else 'disable')
     if logfile:
         set_logfile(logfile)

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -45,7 +45,7 @@ class Runner:
         # default runner mode to pexpect
         self.runner_mode = self.config.runner_mode if hasattr(self.config, 'runner_mode') else 'pexpect'
 
-        self.directory_isolation_path = self.config.directory_isolation_path if hasattr(self.config, 'directory_isolation_path') else None
+        self.directory_isolation_path = self.config.directory_isolation_base_path if hasattr(self.config, 'directory_isolation_path') else None
         self.directory_isolation_cleanup = self.config.directory_isolation_cleanup if hasattr(self.config, 'directory_isolation_cleanup') else None
         self.process_isolation = self.config.process_isolation if hasattr(self.config, 'process_isolation') else None
         self.process_isolation_path_actual = self.config.process_isolation_path_actual if hasattr(self.config, 'process_isolation_path_actual') else None

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -1,7 +1,6 @@
 from __future__ import annotations  # allow newer type syntax until 3.10 is our minimum
 
 import codecs
-import io
 import json
 import os
 import stat
@@ -13,6 +12,7 @@ import traceback
 from collections.abc import Mapping
 from functools import wraps
 from threading import Event, RLock, Thread
+from typing import BinaryIO
 
 import ansible_runner
 from ansible_runner.exceptions import ConfigurationError
@@ -38,7 +38,7 @@ class MockConfig:
 
 
 class Transmitter:
-    def __init__(self, only_transmit_kwargs: bool, _output: io.FileIO | None, **kwargs):
+    def __init__(self, only_transmit_kwargs: bool, _output: BinaryIO | None, **kwargs):
         if _output is None:
             _output = sys.stdout.buffer
         self._output = _output

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # allow newer type syntax until 3.10 is our minimum
 
 import codecs
+import io
 import json
 import os
 import stat
@@ -37,12 +38,12 @@ class MockConfig:
 
 
 class Transmitter:
-    def __init__(self, _output=None, **kwargs):
+    def __init__(self, only_transmit_kwargs: bool, _output: io.FileIO | None, **kwargs):
         if _output is None:
             _output = sys.stdout.buffer
         self._output = _output
-        self.private_data_dir = os.path.abspath(kwargs.pop('private_data_dir'))
-        self.only_transmit_kwargs = kwargs.pop('only_transmit_kwargs', False)
+        self.private_data_dir = os.path.abspath(kwargs['private_data_dir'])
+        self.only_transmit_kwargs = only_transmit_kwargs
         if 'keepalive_seconds' in kwargs:
             kwargs.pop('keepalive_seconds')  # don't confuse older runners with this Worker-only arg
 

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -11,7 +11,6 @@ import traceback
 from collections.abc import Mapping
 from functools import wraps
 from threading import Event, RLock, Thread
-from typing import BinaryIO
 
 import ansible_runner
 from ansible_runner.config.runner import RunnerConfig
@@ -37,10 +36,9 @@ class MockConfig:
 
 
 class Transmitter:
-    def __init__(self, config: RunnerConfig, _output: BinaryIO | None = None):
-        if _output is None:
-            _output = sys.stdout.buffer
-        self._output = _output
+    def __init__(self, config: RunnerConfig):
+        self._output = config.output if config.output else sys.stdout.buffer
+
         self.private_data_dir = os.path.abspath(config.private_data_dir) if config.private_data_dir else ""
         self.only_transmit_kwargs = config.only_transmit_kwargs
 
@@ -67,11 +65,9 @@ class Transmitter:
 
 
 class Worker:
-    def __init__(self, config: RunnerConfig, _input=None, _output=None):
-        if _input is None:
-            _input = sys.stdin.buffer
-        if _output is None:
-            _output = sys.stdout.buffer
+    def __init__(self, config: RunnerConfig):
+        self._input = config.input if config.input else sys.stdin.buffer
+        self._output = config.output if config.output else sys.stdout.buffer
 
         keepalive_seconds: float | int | None = config.keepalive_seconds
         if keepalive_seconds is None:  # if we didn't get an explicit int value, fall back to envvar
@@ -82,9 +78,6 @@ class Worker:
         self._keepalive_thread: Thread | None = None
         self._output_event = Event()
         self._output_lock = RLock()
-
-        self._input = _input
-        self._output = _output
 
         self.kwargs = config.streamable_attributes()
         self.job_kwargs = None
@@ -245,10 +238,8 @@ class Worker:
 
 
 class Processor:
-    def __init__(self, config: RunnerConfig, _input: BinaryIO | None = None):
-        if _input is None:
-            _input = sys.stdin.buffer
-        self._input = _input
+    def __init__(self, config: RunnerConfig):
+        self._input = config.input if config.input else sys.stdin.buffer
 
         self.quiet = config.quiet
 

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -37,12 +37,12 @@ class MockConfig:
 
 
 class Transmitter:
-    def __init__(self, config: RunnerConfig, only_transmit_kwargs: bool = False, _output: BinaryIO | None = None):
+    def __init__(self, config: RunnerConfig, _output: BinaryIO | None = None):
         if _output is None:
             _output = sys.stdout.buffer
         self._output = _output
         self.private_data_dir = os.path.abspath(config.private_data_dir) if config.private_data_dir else ""
-        self.only_transmit_kwargs = only_transmit_kwargs
+        self.only_transmit_kwargs = config.only_transmit_kwargs
 
         self.kwargs = config.streamable_attributes()
 

--- a/src/ansible_runner/utils/streaming.py
+++ b/src/ansible_runner/utils/streaming.py
@@ -1,6 +1,5 @@
 # pylint: disable=R0914
 
-import io
 import time
 import tempfile
 import zipfile
@@ -9,11 +8,12 @@ import json
 import sys
 import stat
 from pathlib import Path
+from typing import BinaryIO
 
 from .base64io import Base64IO
 
 
-def stream_dir(source_directory: str, stream: io.FileIO) -> None:
+def stream_dir(source_directory: str, stream: BinaryIO) -> None:
     with tempfile.NamedTemporaryFile() as tmp:
         with zipfile.ZipFile(
             tmp.name, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True, strict_timestamps=False
@@ -60,7 +60,7 @@ def stream_dir(source_directory: str, stream: io.FileIO) -> None:
                     encoded_target.write(line)
 
 
-def unstream_dir(stream: io.FileIO, length: int, target_directory: str) -> None:
+def unstream_dir(stream: BinaryIO, length: int, target_directory: str) -> None:
     # NOTE: caller needs to process exceptions
     with tempfile.NamedTemporaryFile() as tmp:
         with open(tmp.name, "wb") as target:

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -6,6 +6,7 @@ import yaml
 
 import pytest
 
+from ansible_runner import RunnerConfig
 from ansible_runner.interface import init_runner
 
 
@@ -29,12 +30,14 @@ def executor(tmp_path, request):
 
     inventory = 'localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"'
 
-    r = init_runner(
-        private_data_dir=private_data_dir,
+    rc = RunnerConfig(
+        private_data_dir=str(private_data_dir),
         inventory=inventory,
         envvars=envvars,
         playbook=yaml.safe_load(playbook)
     )
+
+    r = init_runner(rc, '', False)
 
     return r
 
@@ -355,12 +358,14 @@ def test_output_when_given_invalid_playbook(tmp_path):
     #
     # But no test validated it.  This does that.
     private_data_dir = str(tmp_path)
-    ex = init_runner(
+
+    rc = RunnerConfig(
         private_data_dir=private_data_dir,
         inventory='localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"',
         envvars={"ANSIBLE_DEPRECATION_WARNINGS": "False"},
         playbook=os.path.join(private_data_dir, 'fake_playbook.yml')
     )
+    ex = init_runner(rc, '', False)
 
     ex.run()
     with ex.stdout as f:
@@ -392,11 +397,12 @@ def test_output_when_given_non_playbook_script(tmp_path):
     with open(os.path.join(private_data_dir, "env", "settings"), 'w') as settings_file:
         settings_file.write("pexpect_timeout: 0.2")
 
-    ex = init_runner(
+    rc = RunnerConfig(
         private_data_dir=private_data_dir,
         inventory='localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"',
         envvars={"ANSIBLE_DEPRECATION_WARNINGS": "False"}
     )
+    ex = init_runner(rc, '', False)
 
     ex.run()
 

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -37,7 +37,7 @@ def executor(tmp_path, request):
         playbook=yaml.safe_load(playbook)
     )
 
-    r = init_runner(rc, '', False)
+    r = init_runner(rc, '')
 
     return r
 
@@ -365,7 +365,7 @@ def test_output_when_given_invalid_playbook(tmp_path):
         envvars={"ANSIBLE_DEPRECATION_WARNINGS": "False"},
         playbook=os.path.join(private_data_dir, 'fake_playbook.yml')
     )
-    ex = init_runner(rc, '', False)
+    ex = init_runner(rc, '')
 
     ex.run()
     with ex.stdout as f:
@@ -402,7 +402,7 @@ def test_output_when_given_non_playbook_script(tmp_path):
         inventory='localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"',
         envvars={"ANSIBLE_DEPRECATION_WARNINGS": "False"}
     )
-    ex = init_runner(rc, '', False)
+    ex = init_runner(rc, '')
 
     ex.run()
 

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -658,13 +658,12 @@ class TestRunAPIWithConfig:
         private_data_dir = project_fixtures / 'debug'
         outgoing_buffer = tmp_path / 'output'
         config = RunnerConfig(private_data_dir=str(private_data_dir),
-                              playbook='debug.yml')
+                              playbook='debug.yml',
+                              only_transmit_kwargs=True,
+                              )
 
         with outgoing_buffer.open("wb") as outfile:
-            run(config,
-                streamer='transmit',
-                only_transmit_kwargs=True,
-                _output=outfile)
+            run(config, streamer='transmit', _output=outfile)
 
         output_string = outgoing_buffer.read_text()
         data = output_string.split('\n')
@@ -682,7 +681,6 @@ class TestRunAPIWithConfig:
         with outgoing_buffer.open("wb") as outfile:
             run(config,
                 streamer='transmit',
-                only_transmit_kwargs=True,
                 _output=outfile)
 
         output_string = outgoing_buffer.read_text()

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -657,13 +657,14 @@ class TestRunAPIWithConfig:
         """Test the transmit process from the run() interface"""
         private_data_dir = project_fixtures / 'debug'
         outgoing_buffer = tmp_path / 'output'
-        config = RunnerConfig(private_data_dir=str(private_data_dir),
-                              playbook='debug.yml',
-                              only_transmit_kwargs=True,
-                              )
 
         with outgoing_buffer.open("wb") as outfile:
-            run(config, streamer='transmit', _output=outfile)
+            config = RunnerConfig(private_data_dir=str(private_data_dir),
+                                  playbook='debug.yml',
+                                  only_transmit_kwargs=True,
+                                  _output=outfile,
+                                  )
+            run(config, streamer='transmit')
 
         output_string = outgoing_buffer.read_text()
         data = output_string.split('\n')
@@ -676,12 +677,10 @@ class TestRunAPIWithConfig:
         The kwargs-style call sends an empty 'kwargs' dict in the case of no params.
         """
         outgoing_buffer = tmp_path / 'output'
-        config = RunnerConfig()
 
         with outgoing_buffer.open("wb") as outfile:
-            run(config,
-                streamer='transmit',
-                _output=outfile)
+            config = RunnerConfig(_output=outfile)
+            run(config, streamer='transmit')
 
         output_string = outgoing_buffer.read_text()
         data = output_string.split('\n')

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -1,8 +1,11 @@
+import json
 import os
 import shutil
 
 import pytest
 
+from ansible_runner.config.runner import RunnerConfig
+from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.interface import (
     get_ansible_config,
     get_inventory,
@@ -605,3 +608,84 @@ class TestRelativePvtDataDirPaths:
 
         assert r.status == 'successful'
         assert "No inventory was parsed" not in text
+
+
+class TestRunAPIWithConfig:
+    """Test advanced version of the run() interface using a RunnerConfig object"""
+
+    def test_run(self, project_fixtures, tmp_path):
+        """Test running a playbook from pvt data dir"""
+        private_data_dir = project_fixtures / 'debug'
+        config = RunnerConfig(private_data_dir=str(private_data_dir), playbook='debug.yml')
+        r = run(config)
+        assert r.status == 'successful'
+
+    def test_run_with_module(self):
+        """Test running a module adhoc-style"""
+        config = RunnerConfig(module='debug', host_pattern='localhost')
+        r = run(config)
+        assert r.status == 'successful'
+
+    def test_run_with_role(self, project_fixtures):
+        """Test running a role within a pvt data dir"""
+        private_data_dir = project_fixtures / 'debug'
+        config = RunnerConfig(private_data_dir=str(private_data_dir), role='hello_world')
+        res = run(config)
+        with res.stdout as f:
+            stdout = f.read()
+        assert res.rc == 0, stdout
+        assert 'Hello World!' in stdout
+
+    def test_run_empty(self):
+        """No params seems to trigger this same exception in the kwargs-only call"""
+        with pytest.raises(ConfigurationError, match="Runner playbook required when running ansible-playbook"):
+            run()
+
+    @pytest.mark.parametrize(
+        'playbook', (
+            [{'hosts': 'localhost', 'tasks': [{'ping': ''}]}],
+            {'hosts': 'localhost', 'tasks': [{'ping': ''}]},
+        )
+    )
+    def test_run_playbook_data(self, playbook, tmp_path):
+        """Test running a playbook sent as a data object"""
+        config = RunnerConfig(private_data_dir=str(tmp_path), playbook=playbook)
+        r = run(config)
+        assert r.status == 'successful'
+
+    def test_run_transmit(self, project_fixtures, tmp_path):
+        """Test the transmit process from the run() interface"""
+        private_data_dir = project_fixtures / 'debug'
+        outgoing_buffer = tmp_path / 'output'
+        config = RunnerConfig(private_data_dir=str(private_data_dir),
+                              playbook='debug.yml')
+
+        with outgoing_buffer.open("wb") as outfile:
+            run(config,
+                streamer='transmit',
+                only_transmit_kwargs=True,
+                _output=outfile)
+
+        output_string = outgoing_buffer.read_text()
+        data = output_string.split('\n')
+        assert data
+        assert json.loads(data[0]) == {"kwargs": {"playbook": "debug.yml"}}
+
+    def test_run_transmit_empty(self, tmp_path):
+        """Test the transmit process from the run() interface and an empty parameter set.
+
+        The kwargs-style call sends an empty 'kwargs' dict in the case of no params.
+        """
+        outgoing_buffer = tmp_path / 'output'
+        config = RunnerConfig()
+
+        with outgoing_buffer.open("wb") as outfile:
+            run(config,
+                streamer='transmit',
+                only_transmit_kwargs=True,
+                _output=outfile)
+
+        output_string = outgoing_buffer.read_text()
+        data = output_string.split('\n')
+        assert data
+        assert json.loads(data[0]) == {"kwargs": {}}

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -1,11 +1,8 @@
-import json
 import os
 import shutil
 
 import pytest
 
-from ansible_runner.config.runner import RunnerConfig
-from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.interface import (
     get_ansible_config,
     get_inventory,
@@ -608,81 +605,3 @@ class TestRelativePvtDataDirPaths:
 
         assert r.status == 'successful'
         assert "No inventory was parsed" not in text
-
-
-class TestRunAPIWithConfig:
-    """Test advanced version of the run() interface using a RunnerConfig object"""
-
-    def test_run(self, project_fixtures, tmp_path):
-        """Test running a playbook from pvt data dir"""
-        private_data_dir = project_fixtures / 'debug'
-        config = RunnerConfig(private_data_dir=str(private_data_dir), playbook='debug.yml')
-        r = run(config)
-        assert r.status == 'successful'
-
-    def test_run_with_module(self):
-        """Test running a module adhoc-style"""
-        config = RunnerConfig(module='debug', host_pattern='localhost')
-        r = run(config)
-        assert r.status == 'successful'
-
-    def test_run_with_role(self, project_fixtures):
-        """Test running a role within a pvt data dir"""
-        private_data_dir = project_fixtures / 'debug'
-        config = RunnerConfig(private_data_dir=str(private_data_dir), role='hello_world')
-        res = run(config)
-        with res.stdout as f:
-            stdout = f.read()
-        assert res.rc == 0, stdout
-        assert 'Hello World!' in stdout
-
-    def test_run_empty(self):
-        """No params seems to trigger this same exception in the kwargs-only call"""
-        with pytest.raises(ConfigurationError, match="Runner playbook required when running ansible-playbook"):
-            run()
-
-    @pytest.mark.parametrize(
-        'playbook', (
-            [{'hosts': 'localhost', 'tasks': [{'ping': ''}]}],
-            {'hosts': 'localhost', 'tasks': [{'ping': ''}]},
-        )
-    )
-    def test_run_playbook_data(self, playbook, tmp_path):
-        """Test running a playbook sent as a data object"""
-        config = RunnerConfig(private_data_dir=str(tmp_path), playbook=playbook)
-        r = run(config)
-        assert r.status == 'successful'
-
-    def test_run_transmit(self, project_fixtures, tmp_path):
-        """Test the transmit process from the run() interface"""
-        private_data_dir = project_fixtures / 'debug'
-        outgoing_buffer = tmp_path / 'output'
-
-        with outgoing_buffer.open("wb") as outfile:
-            config = RunnerConfig(private_data_dir=str(private_data_dir),
-                                  playbook='debug.yml',
-                                  only_transmit_kwargs=True,
-                                  _output=outfile,
-                                  )
-            run(config, streamer='transmit')
-
-        output_string = outgoing_buffer.read_text()
-        data = output_string.split('\n')
-        assert data
-        assert json.loads(data[0]) == {"kwargs": {"playbook": "debug.yml"}}
-
-    def test_run_transmit_empty(self, tmp_path):
-        """Test the transmit process from the run() interface and an empty parameter set.
-
-        The kwargs-style call sends an empty 'kwargs' dict in the case of no params.
-        """
-        outgoing_buffer = tmp_path / 'output'
-
-        with outgoing_buffer.open("wb") as outfile:
-            config = RunnerConfig(_output=outfile)
-            run(config, streamer='transmit')
-
-        output_string = outgoing_buffer.read_text()
-        data = output_string.split('\n')
-        assert data
-        assert json.loads(data[0]) == {"kwargs": {}}

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -271,7 +271,7 @@ def test_set_extra_vars(rc):
     rc.module = "debug"
     rc.module_args = "var=test_extra_vars"
     rc.host_pattern = "localhost"
-    rc.extra_vars = {'test_extra_vars': 'hello there'}
+    rc.extravars = {'test_extra_vars': 'hello there'}
     rc.prepare()
     runner = Runner(config=rc)
     runner.run()

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -142,6 +142,7 @@ class TestStreamingUsage:
             buffer.name = 'foo'
 
         status, rc = Transmitter(
+            only_transmit_kwargs=False,
             _output=outgoing_buffer, private_data_dir=project_fixtures / 'sleep',
             playbook='sleep.yml', extravars={'sleep_interval': 2}, verbosity=verbosity
         ).run()
@@ -341,7 +342,7 @@ def transmit_stream(project_fixtures, tmp_path):
 
     transmit_dir = project_fixtures / 'debug'
     with outgoing_buffer.open('wb') as f:
-        transmitter = Transmitter(_output=f, private_data_dir=transmit_dir, playbook='debug.yml')
+        transmitter = Transmitter(only_transmit_kwargs=False, _output=f, private_data_dir=transmit_dir, playbook='debug.yml')
         status, rc = transmitter.run()
 
         assert rc in (None, 0)

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -27,7 +27,7 @@ class TestStreamingUsage:
         self.status_data = status_data
 
     def get_job_kwargs(self, job_type):
-        """For this test scenaro, the ansible-runner interface kwargs"""
+        """For this test scenario, the ansible-runner interface kwargs"""
         if job_type == 'run':
             job_kwargs = {'playbook': 'debug.yml'}
         else:
@@ -75,7 +75,7 @@ class TestStreamingUsage:
         outgoing_buffer_file.touch()
         outgoing_buffer = outgoing_buffer_file.open('b+r')
 
-        config = RunnerConfig(private_data_dir=transmit_dir, **job_kwargs)
+        config = RunnerConfig(private_data_dir=str(transmit_dir), **job_kwargs)
         transmitter = Transmitter(config, _output=outgoing_buffer)
 
         for key, value in job_kwargs.items():
@@ -96,7 +96,7 @@ class TestStreamingUsage:
 
         outgoing_buffer.seek(0)
 
-        rc = RunnerConfig(private_data_dir=worker_dir)
+        rc = RunnerConfig(private_data_dir=str(worker_dir))
         worker = Worker(rc, _input=outgoing_buffer, _output=incoming_buffer)
         worker.run()
 
@@ -105,7 +105,7 @@ class TestStreamingUsage:
 
         incoming_buffer.seek(0)  # again, be kind, rewind
 
-        rc = RunnerConfig(private_data_dir=process_dir)
+        rc = RunnerConfig(private_data_dir=str(process_dir))
         processor = Processor(rc, _input=incoming_buffer)
         processor.run()
 
@@ -161,7 +161,7 @@ class TestStreamingUsage:
 
         worker_start_time = time.time()
 
-        rc = RunnerConfig(private_data_dir=worker_dir, keepalive_seconds=keepalive_setting)
+        rc = RunnerConfig(private_data_dir=str(worker_dir), keepalive_seconds=keepalive_setting)
         worker = Worker(rc, _input=outgoing_buffer, _output=incoming_buffer)
         worker.run()
 
@@ -172,7 +172,7 @@ class TestStreamingUsage:
         assert not worker._keepalive_thread.is_alive()  # make sure it's dead
 
         incoming_buffer.seek(0)
-        rc = RunnerConfig(private_data_dir=process_dir)
+        rc = RunnerConfig(private_data_dir=str(process_dir))
         Processor(rc, _input=incoming_buffer, ).run()
 
         stdout = self.get_stdout(process_dir)
@@ -352,7 +352,7 @@ def transmit_stream(project_fixtures, tmp_path):
     outgoing_buffer.touch()
 
     transmit_dir = project_fixtures / 'debug'
-    config = RunnerConfig(private_data_dir=transmit_dir, playbook='debug.yml')
+    config = RunnerConfig(private_data_dir=str(transmit_dir), playbook='debug.yml')
 
     with outgoing_buffer.open('wb') as f:
         transmitter = Transmitter(config, only_transmit_kwargs=False, _output=f)
@@ -372,7 +372,7 @@ def worker_stream(transmit_stream, tmp_path):  # pylint: disable=W0621
     worker_dir.mkdir()
     with transmit_stream.open('rb') as out:
         with ingoing_buffer.open('wb') as f:
-            config = RunnerConfig(private_data_dir=worker_dir)
+            config = RunnerConfig(private_data_dir=str(worker_dir))
             worker = Worker(config, _input=out, _output=f)
             status, rc = worker.run()
 
@@ -529,6 +529,6 @@ def test_unparsable_really_big_line_processor(tmp_path):
     ansible_runner.interface.run(
         streamer='process',
         _input=incoming_buffer,
-        private_data_dir=process_dir,
+        private_data_dir=str(process_dir),
         status_handler=status_receiver
     )

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -383,6 +383,25 @@ def worker_stream(transmit_stream, tmp_path):  # pylint: disable=W0621
             return ingoing_buffer
 
 
+def test_transmit_role(tmp_path, cli, project_fixtures):
+    """When transmitting a role job via CLI, expect only 'playbook' in the job arguments.
+
+    When we 'transmit' a role through the CLI command, we expect a playbook to be generated via
+    the role_manager(), which will in turn be transmitted as an artifact. No other parameters
+    are expected to be present.
+    """
+    outgoing_buffer = tmp_path / 'buffer'
+    outgoing_buffer.touch()
+
+    transmit_dir = project_fixtures / 'debug'
+
+    r = cli(['transmit', str(transmit_dir), '--role', 'hello_world'])
+    data = json.loads(r.stdout.split('\n')[0])
+    assert 'kwargs' in data
+    assert len(data['kwargs']) == 1
+    assert 'playbook' in data['kwargs']
+
+
 def test_worker_without_delete_no_dir(tmp_path, cli, transmit_stream):  # pylint: disable=W0621
     worker_dir = tmp_path / 'for_worker'
 

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -73,44 +73,42 @@ class TestStreamingUsage:
 
         outgoing_buffer_file = tmp_path / 'buffer_out'
         outgoing_buffer_file.touch()
-        outgoing_buffer = outgoing_buffer_file.open('b+r')
 
-        config = RunnerConfig(private_data_dir=str(transmit_dir), **job_kwargs)
-        transmitter = Transmitter(config, _output=outgoing_buffer)
+        with outgoing_buffer_file.open('b+r') as outgoing_buffer:
+            config = RunnerConfig(private_data_dir=str(transmit_dir), _output=outgoing_buffer, **job_kwargs)
+            transmitter = Transmitter(config)
 
-        for key, value in job_kwargs.items():
-            assert transmitter.kwargs.get(key, '') == value
+            for key, value in job_kwargs.items():
+                assert transmitter.kwargs.get(key, '') == value
 
-        status, rc = transmitter.run()
-        assert rc in (None, 0)
-        assert status == 'unstarted'
+            status, rc = transmitter.run()
+            assert rc in (None, 0)
+            assert status == 'unstarted'
 
-        outgoing_buffer.seek(0)
-        sent = outgoing_buffer.read()
-        assert sent  # should not be blank at least
-        assert b'zipfile' in sent
+            outgoing_buffer.seek(0)
+            sent = outgoing_buffer.read()
+            assert sent  # should not be blank at least
+            assert b'zipfile' in sent
 
-        incoming_buffer_file = tmp_path / 'buffer_in'
-        incoming_buffer_file.touch()
-        incoming_buffer = incoming_buffer_file.open('b+r')
+            incoming_buffer_file = tmp_path / 'buffer_in'
+            incoming_buffer_file.touch()
 
-        outgoing_buffer.seek(0)
+            with incoming_buffer_file.open('b+r') as incoming_buffer:
+                outgoing_buffer.seek(0)
 
-        rc = RunnerConfig(private_data_dir=str(worker_dir))
-        worker = Worker(rc, _input=outgoing_buffer, _output=incoming_buffer)
-        worker.run()
+                rc = RunnerConfig(private_data_dir=str(worker_dir), _input=outgoing_buffer, _output=incoming_buffer)
+                worker = Worker(rc)
+                worker.run()
 
-        outgoing_buffer.seek(0)
-        assert set(os.listdir(worker_dir)) == {'artifacts', 'inventory', 'project', 'env'}, outgoing_buffer.read()
+                outgoing_buffer.seek(0)
+                assert set(os.listdir(worker_dir)) == {'artifacts', 'inventory', 'project', 'env'}, outgoing_buffer.read()
 
-        incoming_buffer.seek(0)  # again, be kind, rewind
+                incoming_buffer.seek(0)  # again, be kind, rewind
 
-        rc = RunnerConfig(private_data_dir=str(process_dir))
-        processor = Processor(rc, _input=incoming_buffer)
-        processor.run()
+                rc = RunnerConfig(private_data_dir=str(process_dir), _input=incoming_buffer)
+                processor = Processor(rc)
+                processor.run()
 
-        outgoing_buffer.close()
-        incoming_buffer.close()
         self.check_artifacts(str(process_dir), job_type)
 
     @pytest.mark.parametrize("keepalive_setting", [
@@ -150,20 +148,19 @@ class TestStreamingUsage:
                               extravars={'sleep_interval': 2},
                               verbosity=verbosity,
                               only_transmit_kwargs=False,
+                              _output=outgoing_buffer,
                               )
 
-        status, rc = Transmitter(
-            config,
-            _output=outgoing_buffer,
-        ).run()
+        status, rc = Transmitter(config).run()
         assert rc in (None, 0)
         assert status == 'unstarted'
         outgoing_buffer.seek(0)
 
         worker_start_time = time.time()
 
-        rc = RunnerConfig(private_data_dir=str(worker_dir), keepalive_seconds=keepalive_setting)
-        worker = Worker(rc, _input=outgoing_buffer, _output=incoming_buffer)
+        rc = RunnerConfig(private_data_dir=str(worker_dir), keepalive_seconds=keepalive_setting,
+                          _input=outgoing_buffer, _output=incoming_buffer)
+        worker = Worker(rc)
         worker.run()
 
         assert time.time() - worker_start_time > 2.0  # task sleeps for 2 second
@@ -173,8 +170,8 @@ class TestStreamingUsage:
         assert not worker._keepalive_thread.is_alive()  # make sure it's dead
 
         incoming_buffer.seek(0)
-        rc = RunnerConfig(private_data_dir=str(process_dir))
-        Processor(rc, _input=incoming_buffer, ).run()
+        rc = RunnerConfig(private_data_dir=str(process_dir), _input=incoming_buffer)
+        Processor(rc).run()
 
         stdout = self.get_stdout(process_dir)
         assert 'Sleep for a specified interval' in stdout
@@ -353,13 +350,14 @@ def transmit_stream(project_fixtures, tmp_path):
     outgoing_buffer.touch()
 
     transmit_dir = project_fixtures / 'debug'
-    config = RunnerConfig(private_data_dir=str(transmit_dir),
-                          playbook='debug.yml',
-                          only_transmit_kwargs=False,
-                          )
 
     with outgoing_buffer.open('wb') as f:
-        transmitter = Transmitter(config, _output=f)
+        config = RunnerConfig(private_data_dir=str(transmit_dir),
+                              playbook='debug.yml',
+                              only_transmit_kwargs=False,
+                              _output=f,
+                              )
+        transmitter = Transmitter(config)
         status, rc = transmitter.run()
 
         assert rc in (None, 0)
@@ -376,8 +374,8 @@ def worker_stream(transmit_stream, tmp_path):  # pylint: disable=W0621
     worker_dir.mkdir()
     with transmit_stream.open('rb') as out:
         with ingoing_buffer.open('wb') as f:
-            config = RunnerConfig(private_data_dir=str(worker_dir))
-            worker = Worker(config, _input=out, _output=f)
+            config = RunnerConfig(private_data_dir=str(worker_dir), _input=out, _output=f)
+            worker = Worker(config)
             status, rc = worker.run()
 
             assert rc in (None, 0)

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -398,8 +398,9 @@ def test_transmit_role(tmp_path, cli, project_fixtures):
     r = cli(['transmit', str(transmit_dir), '--role', 'hello_world'])
     data = json.loads(r.stdout.split('\n')[0])
     assert 'kwargs' in data
-    assert len(data['kwargs']) == 1
+    assert len(data['kwargs']) == 2
     assert 'playbook' in data['kwargs']
+    assert 'ident' in data['kwargs']
 
 
 def test_worker_without_delete_no_dir(tmp_path, cli, transmit_stream):  # pylint: disable=W0621

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -148,11 +148,12 @@ class TestStreamingUsage:
         config = RunnerConfig(private_data_dir=project_fixtures / 'sleep',
                               playbook='sleep.yml',
                               extravars={'sleep_interval': 2},
-                              verbosity=verbosity)
+                              verbosity=verbosity,
+                              only_transmit_kwargs=False,
+                              )
 
         status, rc = Transmitter(
             config,
-            only_transmit_kwargs=False,
             _output=outgoing_buffer,
         ).run()
         assert rc in (None, 0)
@@ -352,10 +353,13 @@ def transmit_stream(project_fixtures, tmp_path):
     outgoing_buffer.touch()
 
     transmit_dir = project_fixtures / 'debug'
-    config = RunnerConfig(private_data_dir=str(transmit_dir), playbook='debug.yml')
+    config = RunnerConfig(private_data_dir=str(transmit_dir),
+                          playbook='debug.yml',
+                          only_transmit_kwargs=False,
+                          )
 
     with outgoing_buffer.open('wb') as f:
-        transmitter = Transmitter(config, only_transmit_kwargs=False, _output=f)
+        transmitter = Transmitter(config, _output=f)
         status, rc = transmitter.run()
 
         assert rc in (None, 0)

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import tempfile
 from functools import partial
 
 from test.utils.common import RSAKey
@@ -20,6 +21,19 @@ def load_file_side_effect(path, value, *args, **kwargs):
         if value:
             return value
     raise ConfigurationError
+
+
+def test_base_config_empty_pvt_data_dir():
+    """Make sure we create a pvt data dir even when not supplied"""
+    rc = BaseConfig()
+    tmpdir = tempfile.gettempdir()
+    assert tmpdir in rc.private_data_dir
+
+
+def test_base_config_invalid_pvt_data_dir():
+    """A ConfigurationError should be raised if we cannot create the requested pvt data dir"""
+    with pytest.raises(ConfigurationError, match="Unable to create private_data_dir"):
+        BaseConfig("/not/a/writable/path")
 
 
 def test_base_config_init_defaults(tmp_path):

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -159,7 +159,7 @@ def test_prepare_env_settings(mocker):
 def test_prepare_env_sshkey_defaults():
     rc = BaseConfig()
     rc.prepare_env()
-    assert rc.ssh_key_data is None
+    assert rc.ssh_key is None
 
 
 def test_prepare_env_sshkey(mocker):
@@ -171,7 +171,7 @@ def test_prepare_env_sshkey(mocker):
 
     mocker.patch.object(rc.loader, 'load_file', side_effect=sshkey_side_effect)
     rc.prepare_env()
-    assert rc.ssh_key_data == rsa_private_key_value
+    assert rc.ssh_key == rsa_private_key_value
 
 
 def test_prepare_env_defaults():
@@ -191,7 +191,7 @@ def test_prepare_env_ansible_vars(mocker, tmp_path):
 
     artifact_dir = tmp_path.joinpath('some_artifacts')
     rc = BaseConfig(artifact_dir=artifact_dir.as_posix())
-    rc.ssh_key_data = None
+    rc.ssh_key = None
     rc.env = {}
     rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
 
@@ -215,7 +215,7 @@ def test_prepare_with_ssh_key(mocker, tmp_path):
     rc.env = {}
     rc.execution_mode = BaseExecutionMode.ANSIBLE_COMMANDS
     rsa_key = RSAKey()
-    rc.ssh_key_data = rsa_key.private
+    rc.ssh_key = rsa_key.private
     rc.command = 'ansible-playbook'
     rc.cmdline_args = []
     rc.prepare_env()

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -749,9 +749,11 @@ def test_streamable_attributes_non_default(tmp_path):
                       keepalive_seconds=10,
                       host_pattern="hostA,",
                       json_mode=True,
+                      playbook=[],
                       verbosity=3)
 
     # Don't expect private_data_dir or keepalive_seconds since they are not streamable.
+    # Don't expect playbook since it is an empty value.
     assert rc.streamable_attributes() == {
         "host_pattern": "hostA,",
         "json_mode": True,

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -735,3 +735,25 @@ def test_containerization_settings(tmp_path, runtime, mocker):
         ['my_container', 'ansible-playbook', '-i', '/runner/inventory', 'main.yaml']
 
     assert expected_command_start == rc.command
+
+
+def test_streamable_attributes_all_defaults():
+    """Test that all default values return an empty dict."""
+    rc = RunnerConfig()
+    assert not rc.streamable_attributes()
+
+
+def test_streamable_attributes_non_default(tmp_path):
+    """Test that non-default, streamable values are returned."""
+    rc = RunnerConfig(private_data_dir=str(tmp_path),
+                      keepalive_seconds=10,
+                      host_pattern="hostA,",
+                      json_mode=True,
+                      verbosity=3)
+
+    # Don't expect private_data_dir or keepalive_seconds since they are not streamable.
+    assert rc.streamable_attributes() == {
+        "host_pattern": "hostA,",
+        "json_mode": True,
+        "verbosity": 3,
+    }

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -740,7 +740,9 @@ def test_containerization_settings(tmp_path, runtime, mocker):
 def test_streamable_attributes_all_defaults():
     """Test that all default values return an empty dict."""
     rc = RunnerConfig()
-    assert not rc.streamable_attributes()
+    attrs = rc.streamable_attributes()
+    assert len(attrs) == 1
+    assert 'ident' in attrs
 
 
 def test_streamable_attributes_non_default(tmp_path):
@@ -754,8 +756,10 @@ def test_streamable_attributes_non_default(tmp_path):
 
     # Don't expect private_data_dir or keepalive_seconds since they are not streamable.
     # Don't expect playbook since it is an empty value.
-    assert rc.streamable_attributes() == {
-        "host_pattern": "hostA,",
-        "json_mode": True,
-        "verbosity": 3,
-    }
+    attrs = rc.streamable_attributes()
+    assert attrs['host_pattern'] == 'hostA,'
+    assert attrs['json_mode']
+    assert attrs['verbosity'] == 3
+    assert 'private_data_dir' not in attrs
+    assert 'keepalive_seconds' not in attrs
+    assert 'playbook' not in attrs

--- a/test/unit/test_interface.py
+++ b/test/unit/test_interface.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ansible_runner import RunnerConfig
 from ansible_runner.interface import init_runner
 
 
@@ -7,18 +8,19 @@ def test_default_callback_set(mocker):
     mocker.patch('ansible_runner.interface.signal_handler', side_effect=AttributeError('Raised intentionally'))
 
     with pytest.raises(AttributeError, match='Raised intentionally'):
-        init_runner(ignore_logging=True)
+        init_runner(RunnerConfig(), "", False)
 
 
 def test_set_cancel_callback(mocker):
     mock_runner = mocker.patch('ansible_runner.interface.Runner', side_effect=AttributeError('Raised intentionally'))
-    mock_runner_config = mocker.patch('ansible_runner.interface.RunnerConfig')
-    mock_runner_config.prepare.return_value = None
+    mock_runner_config_prepare = mocker.patch('ansible_runner.interface.RunnerConfig.prepare')
+    mock_runner_config_prepare.return_value = None
 
     def custom_cancel_callback():
-        return 'custom'
+        return True
 
     with pytest.raises(AttributeError, match='Raised intentionally'):
-        init_runner(ignore_logging=True, cancel_callback=custom_cancel_callback)
+        rc = RunnerConfig(cancel_callback=custom_cancel_callback)
+        init_runner(rc, "", False)
 
     assert mock_runner.call_args.kwargs['cancel_callback'] is custom_cancel_callback

--- a/test/unit/test_interface.py
+++ b/test/unit/test_interface.py
@@ -8,7 +8,7 @@ def test_default_callback_set(mocker):
     mocker.patch('ansible_runner.interface.signal_handler', side_effect=AttributeError('Raised intentionally'))
 
     with pytest.raises(AttributeError, match='Raised intentionally'):
-        init_runner(RunnerConfig(), "", False)
+        init_runner(RunnerConfig(), "")
 
 
 def test_set_cancel_callback(mocker):
@@ -21,6 +21,6 @@ def test_set_cancel_callback(mocker):
 
     with pytest.raises(AttributeError, match='Raised intentionally'):
         rc = RunnerConfig(cancel_callback=custom_cancel_callback)
-        init_runner(rc, "", False)
+        init_runner(rc, "")
 
     assert mock_runner.call_args.kwargs['cancel_callback'] is custom_cancel_callback

--- a/test/unit/test_streaming.py
+++ b/test/unit/test_streaming.py
@@ -1,5 +1,6 @@
 import os
 
+from ansible_runner.config.runner import RunnerConfig
 from ansible_runner.streaming import Processor
 
 
@@ -10,7 +11,8 @@ class TestProcessor:
             'private_data_dir': str(tmp_path),
             'ident': 123,
         }
-        p = Processor(**kwargs)
+        rc = RunnerConfig(**kwargs)
+        p = Processor(rc)
         assert p.artifact_dir == os.path.join(kwargs['private_data_dir'],
                                               'artifacts',
                                               str(kwargs['ident']))

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import stat
 
-from ansible_runner.utils import dump_artifact
+from ansible_runner._internal._dump_artifacts import dump_artifact
 
 
 def test_artifact_permissions(tmp_path):


### PR DESCRIPTION
# Changes to Remote Job Execution Argument Streaming

## Reason For Change

Remote job execution involves a `Transmitter` node streaming the job keyword arguments as a JSON object to a `Worker` node. Adding new keyword arguments to the `interface.run()` or `interface.run_async()` methods can cause errors within the remote job streaming interface when an older `Worker` node receives the new, unrecognized keyword argument from a newer `Transmitter` node (worker/transmitter version mismatch).

For more background information on the streaming process, see [this page of the documentation](https://ansible.readthedocs.io/projects/runner/en/2.4.0/remote_jobs/).

Fixes #1324

## Solution

The total fix will require a multi-stage solution:

 - First stage of the solution (implemented in this PR) will have the `Transmitter` process stream only keyword arguments that are actually specified and have a value different from their default value. This does not fix the case when a new keyword argument is introduced and used with a non-default value, but does fix older `Worker` nodes from failing when the new keyword is not used since the new keyword will not be sent in the argument stream.
 - The second stage (not implemented here) will have the `Worker` process gracefully fail on unrecognized keywords.

## Change Details

- [x]  `RunnerConfig` object will become the main source for supplying job parameters instead of `kwargs`.
    - Turns the `BaseConfig` and `RunnerConfig` classes into dataclasses to allow us to properly define arguments, their data types, and their default values.
        - Since the `__init__()` method is now autogenerated, care is taken to keep the same name for a few class attributes that did not have the same name as their argument. This is done through the use of Python class `property` decorators. Internally, the attribute is referenced by the non-alias version.
    - By default, all `RunnerConfig` attributes are streamable to a `Worker`. Attributes that are NEVER streamable will have explicit dataclass metadata to mark it as such (example, `field(metadata={MetaValues.TRANSMIT: False})`).
- [x] `interface.run()` and `interface.run_async()` changed to accept a `RunnerConfig` object.
    - Can now be used in one of two ways:
        - Old-style: method takes only `kwargs` parameters; backwards compatible
        - New-style: method takes a `RunnerConfig` object and a few select parameters.
    - Non-public methods lower in the call hierarchy (`init_runner()`, `dump_artifacts()`, etc) are modified to allow for receiving a `RunnerConfig` object instead of keyword arguments.
- [x] `Transmitter` modified to query the `RunnerConfig` object to retrieve the keyword arguments to transmit.
- [x] Includes a new porting guide in the documentation describing the change.
    - Parameter docs for `interface.run()` method moved to `BaseConfig` and `RunnerConfig` docs.
## TODO

- [ ] Testing with Controller?