### PR TITLE
Bump integration tests for ansible-core 2.18 release

### DIFF
--- a/test/integration/test_core_integration.py
+++ b/test/integration/test_core_integration.py
@@ -7,8 +7,8 @@ from ansible_runner.interface import run
 TEST_BRANCHES = (
     'devel',
     'milestone',
-    'stable-2.17',   # current stable
-    'stable-2.16',   # stable - 1
+    'stable-2.18',   # current stable
+    'stable-2.17',   # stable - 1
 )
 
 

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -325,7 +325,7 @@ def test_callback_plugin_records_notify_events(executor, playbook):  # pylint: d
   connection: local
   hosts: all
   vars:
-    - pw: SENSITIVE
+    pw: SENSITIVE
   tasks:
     - uri:
         url: https://example.org


### PR DESCRIPTION
- Bump integration tests for ansible-core 2.18 release.
- Fixes a test using a deprecated form of `vars` formatting.