### PR TITLE
Restore original signal handlers in finished_callback

### DIFF
--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -289,7 +289,8 @@ def test_signal_handler(mocker):
     mocker.patch('ansible_runner.utils.threading.Event', MockEvent)
     mock_signal = mocker.patch('ansible_runner.utils.signal.signal')
 
-    assert signal_handler()() is False
+    callback, _ = signal_handler()
+    assert callback() is False
     assert mock_signal.call_args_list[0][0][0] == signal.SIGTERM
     assert mock_signal.call_args_list[1][0][0] == signal.SIGINT
 
@@ -300,7 +301,9 @@ def test_signal_handler_outside_main_thread(mocker):
     mocker.patch('ansible_runner.utils.threading.main_thread', return_value='thread0')
     mocker.patch('ansible_runner.utils.threading.current_thread', return_value='thread1')
 
-    assert signal_handler() is None
+    callback, original_handlers = signal_handler()
+    assert callback() is None
+    assert len(original_handlers) == 0
 
 
 def test_signal_handler_set(mocker):


### PR DESCRIPTION
The change in #862 added signal handlers for SIGINT and SIGTERM that may replace any existing SIGINT or SIGTERM handlers set by the process. Those existing handlers are not restored when the `ansible_runner.run` call finishes.

The solution here uses the `finished_callback` to restore the handlers. We're relying on the `finished_callback` actually getting called, which I'm not sure is a real guarantee. I'd be open to a solution that uses context managers or `try`-`finally` if we can figure out the right refactoring / where to put the `try`-`finally` semantics.

We are solving this problem today by using an `ExitStack` and a custom `cancel_callback` (that basically implements the same SIGINT/SIGTERM cancellation behavior as #862) that guarantees to restore the original handlers after the call completes.

---

TODOS

 - [ ] I wasn't sure where or how to write a test for the end-to-end signal restoring functionality. I found unit tests in `test/unit/test_interface.py` and `test/unit/utils/test_utils.py` that seem related, but wouldn't test the full "set and reset" behavior implemented here. Any pointers appreciated.
 - [ ] There is a TODO noted in the code that saving and restoring signal handlers set from outside Python, i.e. a C extension, is not possible. `signal.getsignal` returns `None` for these handlers. How does `ansible-runner` want to handle such a case? Options seem to be: (1) silently fail to restore (same behavior as today), (2) `raise` an exception (breaking change), or (3) allow the behavior to be configured.