### PR TITLE
Modify volume mount behavior when source does not exist

### DIFF
--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -568,10 +568,7 @@ class BaseConfig:
             for mapping in self.container_volume_mounts:
                 volume_mounts = mapping.split(':', 2)
                 self._ensure_path_safe_to_mount(volume_mounts[0])
-                labels = None
-                if len(volume_mounts) == 3:
-                    labels = f":{volume_mounts[2]}"
-                self._update_volume_mount_paths(new_args, volume_mounts[0], dst_mount_path=volume_mounts[1], labels=labels)
+                new_args.extend(["-v", mapping])
 
         # Reference the file with list of keys to pass into container
         # this file will be written in ansible_runner.runner

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -400,12 +400,14 @@ class BaseConfig:
         if src_mount_path is None:
             return
 
-        # ensure source is abs
+        # ensure source is absolute path
+        # this means that users will not be able to pass in podman|docker volumes such as volume1:/dest/dir:Z
+        # only directories can be mounted
         src_path = os.path.abspath(os.path.expanduser(os.path.expandvars(src_mount_path)))
         if not os.path.exists(src_path):
             debug(f"Source volume mount path does not exist: {src_path}")
         if os.path.isfile(src_path):
-            debug(f"Source volume mount path '{src_path}' is a file, will resolve to parent directory: {os.path.dirname(src_path)}")
+            debug(f"Source volume mount is a file, resolving to parent directory: {os.path.dirname(src_path)}")
             src_path = os.path.dirname(src_path)
 
         # set dest src (if None) relative to workdir(not absolute) or provided

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -397,18 +397,13 @@ class BaseConfig:
                                    dst_mount_path: str | None = None,
                                    labels: str | None = None
                                    ) -> None:
-        if src_mount_path is None:
+
+        if src_mount_path is None or not os.path.exists(src_mount_path):
+            logger.debug("Source volume mount path does not exist: %s", src_mount_path)
             return
 
-        # ensure source is absolute path
-        # this means that users will not be able to pass in podman|docker volumes such as volume1:/dest/dir:Z
-        # only directories can be mounted
+        # ensure source is abs
         src_path = os.path.abspath(os.path.expanduser(os.path.expandvars(src_mount_path)))
-        if not os.path.exists(src_path):
-            debug(f"Source volume mount path does not exist: {src_path}")
-        if os.path.isfile(src_path):
-            debug(f"Source volume mount is a file, resolving to parent directory: {os.path.dirname(src_path)}")
-            src_path = os.path.dirname(src_path)
 
         # set dest src (if None) relative to workdir(not absolute) or provided
         if dst_mount_path is None:
@@ -422,14 +417,19 @@ class BaseConfig:
         else:
             dst_path = os.path.abspath(os.path.expanduser(os.path.expandvars(dst_mount_path)))
 
+        # ensure each is a directory not file, use src for dest
+        # because dest doesn't exist locally
+        src_dir = src_path if os.path.isdir(src_path) else os.path.dirname(src_path)
+        dst_dir = dst_path if os.path.isdir(src_path) else os.path.dirname(dst_path)
+
+        # always ensure a trailing slash
+        src_dir = os.path.join(src_dir, "")
+        dst_dir = os.path.join(dst_dir, "")
+
         # ensure the src and dest are safe mount points
         # after stripping off the file and resolving
-        self._ensure_path_safe_to_mount(src_path)
-        self._ensure_path_safe_to_mount(dst_path)
-
-        # ensure that paths have a trailing slash
-        src_dir = os.path.join(src_path, "")
-        dst_dir = os.path.join(dst_path, "")
+        self._ensure_path_safe_to_mount(src_dir)
+        self._ensure_path_safe_to_mount(dst_dir)
 
         # format the src dest str
         volume_mount_path = f"{src_dir}:{dst_dir}"

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -402,8 +402,8 @@ class BaseConfig:
 
         # ensure source is abs
         src_path = os.path.abspath(os.path.expanduser(os.path.expandvars(src_mount_path)))
-        if os.path.exists(src_path):
-            debug(f"Source volume mount path does not exist: {src_mount_path}")
+        if not os.path.exists(src_path):
+            debug(f"Source volume mount path does not exist: {src_path}")
         if os.path.isfile(src_path):
             debug(f"Source volume mount path '{src_path}' is a file, will resolve to parent directory: {os.path.dirname(src_path)}")
             src_path = os.path.dirname(src_path)

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -402,7 +402,7 @@ class BaseConfig:
 
         # ensure source is abs
         src_path = os.path.abspath(os.path.expanduser(os.path.expandvars(src_mount_path)))
-        if os.path.exists(src_mount_path):
+        if os.path.exists(src_path):
             debug(f"Source volume mount path does not exist: {src_mount_path}")
         if os.path.isfile(src_path):
             debug(f"Source volume mount path '{src_path}' is a file, will resolve to parent directory: {os.path.dirname(src_path)}")

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -397,12 +397,13 @@ class BaseConfig:
                                    dst_mount_path: str | None = None,
                                    labels: str | None = None
                                    ) -> None:
+        if src_mount_path is None:
+            return
+
         # ensure source is abs
         src_path = os.path.abspath(os.path.expanduser(os.path.expandvars(src_mount_path)))
-
-        if src_mount_path is None or not os.path.exists(src_mount_path):
+        if os.path.exists(src_mount_path):
             debug(f"Source volume mount path does not exist: {src_mount_path}")
-
         if os.path.isfile(src_path):
             debug(f"Source volume mount path '{src_path}' is a file, will resolve to parent directory: {os.path.dirname(src_path)}")
             src_path = os.path.dirname(src_path)

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -397,13 +397,15 @@ class BaseConfig:
                                    dst_mount_path: str | None = None,
                                    labels: str | None = None
                                    ) -> None:
-
-        if src_mount_path is None or not os.path.exists(src_mount_path):
-            logger.debug("Source volume mount path does not exist: %s", src_mount_path)
-            return
-
         # ensure source is abs
         src_path = os.path.abspath(os.path.expanduser(os.path.expandvars(src_mount_path)))
+
+        if src_mount_path is None or not os.path.exists(src_mount_path):
+            debug(f"Source volume mount path does not exist: {src_mount_path}")
+
+        if os.path.isfile(src_path):
+            debug(f"Source volume mount path '{src_path}' is a file, will resolve to parent directory: {os.path.dirname(src_path)}")
+            src_path = os.path.dirname(src_path)
 
         # set dest src (if None) relative to workdir(not absolute) or provided
         if dst_mount_path is None:
@@ -417,19 +419,14 @@ class BaseConfig:
         else:
             dst_path = os.path.abspath(os.path.expanduser(os.path.expandvars(dst_mount_path)))
 
-        # ensure each is a directory not file, use src for dest
-        # because dest doesn't exist locally
-        src_dir = src_path if os.path.isdir(src_path) else os.path.dirname(src_path)
-        dst_dir = dst_path if os.path.isdir(src_path) else os.path.dirname(dst_path)
-
-        # always ensure a trailing slash
-        src_dir = os.path.join(src_dir, "")
-        dst_dir = os.path.join(dst_dir, "")
-
         # ensure the src and dest are safe mount points
         # after stripping off the file and resolving
-        self._ensure_path_safe_to_mount(src_dir)
-        self._ensure_path_safe_to_mount(dst_dir)
+        self._ensure_path_safe_to_mount(src_path)
+        self._ensure_path_safe_to_mount(dst_path)
+
+        # ensure that paths have a trailing slash
+        src_dir = os.path.join(src_path, "")
+        dst_dir = os.path.join(dst_path, "")
 
         # format the src dest str
         volume_mount_path = f"{src_dir}:{dst_dir}"

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -318,7 +318,7 @@ def test_containerization_settings(tmp_path, runtime, mocker):
         '--workdir',
         '/runner/project',
         '-v', f'{str(tmp_path)}/.ssh/:/home/runner/.ssh/',
-        '-v', f'{str(tmp_path)}/.ssh/:/root/.ssh/',
+        '-v', f'{str(tmp_path)}/.ssh/:/root/.ssh/'
     ]
 
     if os.path.exists('/etc/ssh/ssh_known_hosts'):
@@ -330,6 +330,8 @@ def test_containerization_settings(tmp_path, runtime, mocker):
     expected_command_start.extend([
         '-v', f'{rc.private_data_dir}/artifacts/:/runner/artifacts/:Z',
         '-v', f'{rc.private_data_dir}/:/runner/:Z',
+        '-v', '/host1:/container1',
+        '-v', 'host2:/container2',
         '--env-file', f'{rc.artifact_dir}/env.list',
     ])
 

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -276,7 +276,7 @@ def test_container_volume_mounting_with_Z(tmp_path, mocker):
     for i, entry in enumerate(new_args):
         if entry == '-v':
             mount = new_args[i + 1]
-            if mount.endswith('project_path/:Z'):
+            if mount.endswith('project_path:Z'):
                 break
     else:
         raise Exception(f'Could not find expected mount, args: {new_args}')

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -728,7 +728,7 @@ def test_containerization_settings(tmp_path, runtime, mocker):
 
     expected_command_start = [runtime, 'run', '--rm', '--tty', '--interactive', '--workdir', '/runner/project'] + \
         ['-v', f'{rc.private_data_dir}/:/runner/:Z'] + \
-        ['-v', '/host1/:/container1/', '-v', '/host2/:/container2/'] + \
+        ['-v', '/host1:/container1', '-v', '/host2:/container2'] + \
         ['--env-file', f'{rc.artifact_dir}/env.list'] + \
         extra_container_args + \
         ['--name', 'ansible_runner_foo'] + \

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -684,7 +684,7 @@ def test_container_volume_mounting_with_Z(mocker, tmp_path):
     for i, entry in enumerate(new_args):
         if entry == '-v':
             mount = new_args[i + 1]
-            if mount.endswith(':/tmp/project_path/:Z'):
+            if mount.endswith(':/tmp/project_path:Z'):
                 break
     else:
         raise Exception(f'Could not find expected mount, args: {new_args}')


### PR DESCRIPTION
ansible-runner will ignore adding the mountpoint to the '-v` argument list if the source path does not exist. Instead it should respect whatever the user is passing to the '--container-volume-mount' option. The exception would be if the user tried to pass a file as the source path; ansible-runner should resolve the file's parent directory.