### PR TITLE
Make rotate_artifacts accessible from env/settings

### DIFF
--- a/demo/env/settings
+++ b/demo/env/settings
@@ -2,3 +2,4 @@
 idle_timeout: 600
 job_timeout: 3600
 pexpect_timeout: 10
+rotate_artifacts: 2

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -81,7 +81,7 @@ class BaseConfig:
                  container_workdir: str | None = None,
                  container_auth_data=None,
                  ident: str | None = None,
-                 rotate_artifacts: int = 0,
+                 rotate_artifacts: int | None = None,
                  timeout: int | None = None,
                  ssh_key: str | None = None,
                  quiet: bool = False,
@@ -110,7 +110,7 @@ class BaseConfig:
         self.container_options = container_options
 
         # runner params
-        self.rotate_artifacts = rotate_artifacts
+        self.rotate_artifacts = rotate_artifacts if rotate_artifacts is not None else 0
         self.quiet = quiet
         self.json_mode = json_mode
         self.passwords = passwords
@@ -148,7 +148,6 @@ class BaseConfig:
         else:
             self.project_dir = project_dir
 
-        self.rotate_artifacts = rotate_artifacts
         self.fact_cache_type = fact_cache_type
         self.fact_cache = os.path.join(self.artifact_dir, fact_cache or 'fact_cache') if self.fact_cache_type == 'jsonfile' else None
 
@@ -227,6 +226,8 @@ class BaseConfig:
         self.container_volume_mounts = self.settings.get('container_volume_mounts', self.container_volume_mounts)
         self.container_options = self.settings.get('container_options', self.container_options)
         self.container_auth_data = self.settings.get('container_auth_data', self.container_auth_data)
+
+        self.rotate_artifacts = self.settings.get('rotate_artifacts', self.rotate_artifacts)
 
         if self.containerized:
             if not self.container_image:


### PR DESCRIPTION
Related to #1415

Make `rotate_artifacts` accessible from the settings file.

* Modify `src/ansible_runner/config/_base.py`:
  - Retrieve `rotate_artifacts` from `settings` dictionary in `prepare_env` method.
  - Set `rotate_artifacts` in `__init__` method only if not provided in `settings` dictionary.
  - Ensure `rotate_artifacts` is set to 0 if not provided in command line or settings file.
  - Make `rotate_artifacts` default to 0 in `__init__` method.
  - Set `rotate_artifacts` from command line if provided.

* Modify `demo/env/settings`:
  - Add `rotate_artifacts` option to the settings file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ansible/ansible-runner/pull/1417?shareId=b4cd0f0e-8105-4ed0-b110-c7f379e7df3f).