### PR TITLE
feat: add option to mask potential secrents in env vars 

### DIFF
--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -875,7 +875,7 @@ def main(sys_args=None):
                 if vargs.get('suppress_env_print'):
                     suppress_env_print = vargs.get('suppress_env_print')
                 else:
-                    suppress_env_print = os.getenv('SUPPRESS_ENV_PRINT', 'False') == 'True'
+                    suppress_env_print = os.getenv('SUPPRESS_ENV_PRINT', 'False').lower() == 'true'
                 run_options = {
                     "private_data_dir": vargs.get('private_data_dir'),
                     "ident": vargs.get('ident'),

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -56,7 +56,6 @@ DEFAULT_RUNNER_BINARY = os.getenv('RUNNER_BINARY', None)
 DEFAULT_RUNNER_PLAYBOOK = os.getenv('RUNNER_PLAYBOOK', None)
 DEFAULT_RUNNER_ROLE = os.getenv('RUNNER_ROLE', None)
 DEFAULT_RUNNER_MODULE = os.getenv('RUNNER_MODULE', None)
-DEFAULT_RUNNER_SUPPRESS_ENV_PRINT = os.getenv('SUPPRESS_ENV_PRINT', None)
 DEFAULT_UUID = uuid4()
 
 DEFAULT_CLI_ARGS = {
@@ -628,6 +627,12 @@ def main(sys_args=None):
         dest="worker_info",
         action="store_true",
         help="show the execution node's Ansible Runner version along with its memory and CPU capacities"
+    )
+    worker_subparser.add_argument(
+        "--suppress-env-print",
+        dest="suppress_env_print",
+        action="store_true",
+        help="add flag to prevent the printing of env vars on stdout. Also set via SUPPRESS_ENV_PRINT"
     )
     worker_subparser.add_argument(
         "--delete",

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -633,7 +633,6 @@ def main(sys_args=None):
         "--suppress-env-print",
         dest="suppress_env_print",
         action="store_true",
-        default=DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
         help="add flag to prevent the printing of env vars on stdout. Also set via SUPPRESS_ENV_PRINT"
     )
     worker_subparser.add_argument(
@@ -874,6 +873,10 @@ def main(sys_args=None):
 
         with context:
             with role_manager(vargs) as vargs:
+                if vargs.get('suppress_env_print'):
+                    suppress_env_print = vargs.get('suppress_env_print')
+                else:
+                    suppress_env_print = os.getenv('SUPPRESS_ENV_PRINT', 'False') == 'True'
                 run_options = {
                     "private_data_dir": vargs.get('private_data_dir'),
                     "ident": vargs.get('ident'),
@@ -908,7 +911,7 @@ def main(sys_args=None):
                     "limit": vargs.get('limit'),
                     "streamer": streamer,
                     "suppress_env_files": vargs.get("suppress_env_files"),
-                    "suppress_env_print": vargs.get('suppress_env_print') if vargs.get('suppress_env_print') else DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
+                    "suppress_env_print": suppress_env_print,
                     "keepalive_seconds": vargs.get("keepalive_seconds"),
                 }
                 try:

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -56,6 +56,7 @@ DEFAULT_RUNNER_BINARY = os.getenv('RUNNER_BINARY', None)
 DEFAULT_RUNNER_PLAYBOOK = os.getenv('RUNNER_PLAYBOOK', None)
 DEFAULT_RUNNER_ROLE = os.getenv('RUNNER_ROLE', None)
 DEFAULT_RUNNER_MODULE = os.getenv('RUNNER_MODULE', None)
+DEFAULT_RUNNER_SUPPRESS_ENV_PRINT = os.getenv('SUPPRESS_ENV_PRINT', None)
 DEFAULT_UUID = uuid4()
 
 DEFAULT_CLI_ARGS = {
@@ -629,6 +630,13 @@ def main(sys_args=None):
         help="show the execution node's Ansible Runner version along with its memory and CPU capacities"
     )
     worker_subparser.add_argument(
+        "--suppress-env-print",
+        dest="suppress_env_print",
+        action="store_true",
+        default=DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
+        help="add flag to prevent the printing of env vars on stdout. Also set via SUPPRESS_ENV_PRINT"
+    )
+    worker_subparser.add_argument(
         "--delete",
         dest="delete_directory",
         action="store_true",
@@ -900,6 +908,7 @@ def main(sys_args=None):
                     "limit": vargs.get('limit'),
                     "streamer": streamer,
                     "suppress_env_files": vargs.get("suppress_env_files"),
+                    "suppress_env_print": vargs.get('suppress_env_print') if vargs.get('suppress_env_print') else DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
                     "keepalive_seconds": vargs.get("keepalive_seconds"),
                 }
                 try:

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -908,7 +908,7 @@ def main(sys_args=None):
                     "limit": vargs.get('limit'),
                     "streamer": streamer,
                     "suppress_env_files": vargs.get("suppress_env_files"),
-                    "suppress_env_print": [vargs.get('suppress_env_print')] if vargs.get('suppress_env_print') else DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
+                    "suppress_env_print": vargs.get('suppress_env_print') if vargs.get('suppress_env_print') else DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
                     "keepalive_seconds": vargs.get("keepalive_seconds"),
                 }
                 try:

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -56,6 +56,7 @@ DEFAULT_RUNNER_BINARY = os.getenv('RUNNER_BINARY', None)
 DEFAULT_RUNNER_PLAYBOOK = os.getenv('RUNNER_PLAYBOOK', None)
 DEFAULT_RUNNER_ROLE = os.getenv('RUNNER_ROLE', None)
 DEFAULT_RUNNER_MODULE = os.getenv('RUNNER_MODULE', None)
+DEFAULT_RUNNER_SUPPRESS_ENV_PRINT = os.getenv('SUPPRESS_ENV_PRINT', None)
 DEFAULT_UUID = uuid4()
 
 DEFAULT_CLI_ARGS = {
@@ -629,6 +630,13 @@ def main(sys_args=None):
         help="show the execution node's Ansible Runner version along with its memory and CPU capacities"
     )
     worker_subparser.add_argument(
+        "--suppress-env-print",
+        dest="suppress_env_print",
+        action="store_true",
+        default=DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
+        help="add flag to prevent the printing of env vars on stdout"
+    )
+    worker_subparser.add_argument(
         "--delete",
         dest="delete_directory",
         action="store_true",
@@ -900,6 +908,7 @@ def main(sys_args=None):
                     "limit": vargs.get('limit'),
                     "streamer": streamer,
                     "suppress_env_files": vargs.get("suppress_env_files"),
+                    "suppress_env_print": [vargs.get('suppress_env_print')] if vargs.get('suppress_env_print') else DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
                     "keepalive_seconds": vargs.get("keepalive_seconds"),
                 }
                 try:

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -634,7 +634,7 @@ def main(sys_args=None):
         dest="suppress_env_print",
         action="store_true",
         default=DEFAULT_RUNNER_SUPPRESS_ENV_PRINT,
-        help="add flag to prevent the printing of env vars on stdout"
+        help="add flag to prevent the printing of env vars on stdout. Also set via SUPPRESS_ENV_PRINT"
     )
     worker_subparser.add_argument(
         "--delete",

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -905,6 +905,7 @@ def main(sys_args=None):
                     "limit": vargs.get('limit'),
                     "streamer": streamer,
                     "suppress_env_files": vargs.get("suppress_env_files"),
+                    "suppress_env_print": suppress_env_print,
                     "keepalive_seconds": vargs.get("keepalive_seconds"),
                 }
                 try:

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -629,10 +629,10 @@ def main(sys_args=None):
         help="show the execution node's Ansible Runner version along with its memory and CPU capacities"
     )
     worker_subparser.add_argument(
-        "--suppress-env-print",
-        dest="suppress_env_print",
+        "--mask-secrets-in-env",
+        dest="mask_secrets_in_env",
         action="store_true",
-        help="add flag to prevent the printing of env vars on stdout. Also set via SUPPRESS_ENV_PRINT"
+        help="add flag to mask the printing of env vars on stdout that may contain secrets. Also set via MASK_SECRETS_IN_ENV"
     )
     worker_subparser.add_argument(
         "--delete",
@@ -872,10 +872,10 @@ def main(sys_args=None):
 
         with context:
             with role_manager(vargs) as vargs:
-                if vargs.get('suppress_env_print'):
-                    suppress_env_print = vargs.get('suppress_env_print')
+                if vargs.get('mask_secrets_in_env'):
+                    mask_secrets_in_env = vargs.get('mask_secrets_in_env')
                 else:
-                    suppress_env_print = os.getenv('SUPPRESS_ENV_PRINT', 'False').lower() == 'true'
+                    mask_secrets_in_env = os.getenv('MASK_SECRETS_IN_ENV', 'False') == 'True'
                 run_options = {
                     "private_data_dir": vargs.get('private_data_dir'),
                     "ident": vargs.get('ident'),
@@ -910,7 +910,7 @@ def main(sys_args=None):
                     "limit": vargs.get('limit'),
                     "streamer": streamer,
                     "suppress_env_files": vargs.get("suppress_env_files"),
-                    "suppress_env_print": suppress_env_print,
+                    "mask_secrets_in_env": mask_secrets_in_env,
                     "keepalive_seconds": vargs.get("keepalive_seconds"),
                 }
                 try:

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -88,7 +88,7 @@ class BaseConfig:
                  json_mode: bool = False,
                  check_job_event_data: bool = False,
                  suppress_env_files: bool = False,
-                 suppress_env_print: bool = False,
+                 mask_secrets_in_env: bool = False,
                  keepalive_seconds: int | None = None
                  ):
         # pylint: disable=W0613
@@ -119,7 +119,7 @@ class BaseConfig:
         self.timeout = timeout
         self.check_job_event_data = check_job_event_data
         self.suppress_env_files = suppress_env_files
-        self.suppress_env_print = suppress_env_print
+        self.mask_secrets_in_env = mask_secrets_in_env
 
         # ignore this for now since it's worker-specific and would just trip up old runners
         # self.keepalive_seconds = keepalive_seconds

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -88,6 +88,7 @@ class BaseConfig:
                  json_mode: bool = False,
                  check_job_event_data: bool = False,
                  suppress_env_files: bool = False,
+                 suppress_env_print: bool = False,
                  keepalive_seconds: int | None = None
                  ):
         # pylint: disable=W0613
@@ -118,6 +119,8 @@ class BaseConfig:
         self.timeout = timeout
         self.check_job_event_data = check_job_event_data
         self.suppress_env_files = suppress_env_files
+        self.suppress_env_print = suppress_env_print
+
         # ignore this for now since it's worker-specific and would just trip up old runners
         # self.keepalive_seconds = keepalive_seconds
 

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -169,7 +169,7 @@ def run(**kwargs):
     :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
     :param bool suppress_env_files: Disable the writing of files into the ``env`` which may store sensitive information
-    :param bool suppress_env_print: Disable the printing of env vars on stdout which may contain sensitive information
+    :param bool mask_secrets_in_env: Mask the printing of env vars on stdout which may contain sensitive information
     :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param int forks: Control Ansible parallel concurrency
     :param int verbosity: Control how verbose the output of ansible-playbook is

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -169,6 +169,7 @@ def run(**kwargs):
     :param str ssh_key: The ssh private key passed to ``ssh-agent`` as part of the ansible-playbook run.
     :param str cmdline: Command line options passed to Ansible read from ``env/cmdline`` in ``private_data_dir``
     :param bool suppress_env_files: Disable the writing of files into the ``env`` which may store sensitive information
+    :param bool suppress_env_print: Disable the printing of env vars on stdout which may contain sensitive information
     :param str limit: Matches ansible's ``--limit`` parameter to further constrain the inventory to be used
     :param int forks: Control Ansible parallel concurrency
     :param int verbosity: Control how verbose the output of ansible-playbook is

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -227,7 +227,7 @@ class Worker:
         self.status = status_data['status']
         printed_status_data = status_data.copy()
         if self.kwargs['suppress_env_print']:
-            printed_status_data.pop('env', None)
+            printed_status_data['env'] = "suppressed by condition"
         self._output.write(json.dumps(printed_status_data).encode('utf-8'))
         self._output.write(b'\n')
         self._output.flush()

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -225,7 +225,7 @@ class Worker:
     def status_handler(self, status_data, runner_config):
         # pylint: disable=W0613
         self.status = status_data['status']
-        printed_status_data = status_data
+        printed_status_data = status_data.copy()
         if self.kwargs['suppress_env_print']:
             printed_status_data.pop('env', None)
         self._output.write(json.dumps(printed_status_data).encode('utf-8'))

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -225,7 +225,12 @@ class Worker:
     def status_handler(self, status_data, runner_config):
         # pylint: disable=W0613
         self.status = status_data['status']
-        self._output.write(json.dumps(status_data).encode('utf-8'))
+        printed_status_data = status_data.copy()
+        if self.kwargs['suppress_env_print']:
+            suppressed_env = dict()
+            suppressed_env['SUPPRESS_ENV_PRINT'] = self.kwargs['suppress_env_print']
+            printed_status_data['env'] = suppressed_env
+        self._output.write(json.dumps(printed_status_data).encode('utf-8'))
         self._output.write(b'\n')
         self._output.flush()
 

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -227,7 +227,7 @@ class Worker:
         self.status = status_data['status']
         printed_status_data = status_data.copy()
         if self.kwargs['suppress_env_print']:
-            suppressed_env = dict()
+            suppressed_env = {}
             suppressed_env['SUPPRESS_ENV_PRINT'] = self.kwargs['suppress_env_print']
             printed_status_data['env'] = suppressed_env
         self._output.write(json.dumps(printed_status_data).encode('utf-8'))

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -225,6 +225,8 @@ class Worker:
     def status_handler(self, status_data, runner_config):
         # pylint: disable=W0613
         self.status = status_data['status']
+        if self.kwargs['suppress_env_print']:
+            status_data.pop('env', None)
         self._output.write(json.dumps(status_data).encode('utf-8'))
         self._output.write(b'\n')
         self._output.flush()

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -17,7 +17,7 @@ import ansible_runner
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.loader import ArtifactLoader
 import ansible_runner.plugins
-from ansible_runner.utils import register_for_cleanup
+from ansible_runner.utils import register_for_cleanup, build_safe_env
 from ansible_runner.utils.streaming import stream_dir, unstream_dir
 
 
@@ -226,10 +226,8 @@ class Worker:
         # pylint: disable=W0613
         self.status = status_data['status']
         printed_status_data = status_data.copy()
-        if 'suppress_env_print' in self.kwargs and self.kwargs['suppress_env_print']:
-            suppressed_env = {}
-            suppressed_env['SUPPRESS_ENV_PRINT'] = str(self.kwargs['suppress_env_print'])
-            printed_status_data['env'] = suppressed_env
+        if 'mask_secrets_in_env' in self.kwargs and self.kwargs['mask_secrets_in_env']:
+            printed_status_data['env'] = build_safe_env(status_data['env']) if 'env' in status_data else {}
         self._output.write(json.dumps(printed_status_data).encode('utf-8'))
         self._output.write(b'\n')
         self._output.flush()

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -226,7 +226,7 @@ class Worker:
         # pylint: disable=W0613
         self.status = status_data['status']
         printed_status_data = status_data.copy()
-        if self.kwargs['suppress_env_print']:
+        if 'suppress_env_print' in self.kwargs and self.kwargs['suppress_env_print']:
             suppressed_env = {}
             suppressed_env['SUPPRESS_ENV_PRINT'] = self.kwargs['suppress_env_print']
             printed_status_data['env'] = suppressed_env

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -225,9 +225,10 @@ class Worker:
     def status_handler(self, status_data, runner_config):
         # pylint: disable=W0613
         self.status = status_data['status']
+        printed_status_data = status_data
         if self.kwargs['suppress_env_print']:
-            status_data.pop('env', None)
-        self._output.write(json.dumps(status_data).encode('utf-8'))
+            printed_status_data.pop('env', None)
+        self._output.write(json.dumps(printed_status_data).encode('utf-8'))
         self._output.write(b'\n')
         self._output.flush()
 

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -228,7 +228,7 @@ class Worker:
         printed_status_data = status_data.copy()
         if 'suppress_env_print' in self.kwargs and self.kwargs['suppress_env_print']:
             suppressed_env = {}
-            suppressed_env['SUPPRESS_ENV_PRINT'] = self.kwargs['suppress_env_print']
+            suppressed_env['SUPPRESS_ENV_PRINT'] = str(self.kwargs['suppress_env_print'])
             printed_status_data['env'] = suppressed_env
         self._output.write(json.dumps(printed_status_data).encode('utf-8'))
         self._output.write(b'\n')

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -227,7 +227,9 @@ class Worker:
         self.status = status_data['status']
         printed_status_data = status_data.copy()
         if self.kwargs['suppress_env_print']:
-            printed_status_data['env'] = "suppressed by condition"
+            suppressed_env = dict()
+            suppressed_env['SUPPRESS_ENV_PRINT'] = self.kwargs['suppress_env_print']
+            printed_status_data['env'] = suppressed_env
         self._output.write(json.dumps(printed_status_data).encode('utf-8'))
         self._output.write(b'\n')
         self._output.flush()

--- a/src/ansible_runner/utils/__init__.py
+++ b/src/ansible_runner/utils/__init__.py
@@ -527,7 +527,7 @@ def build_safe_env(env):
     Build environment dictionary, hiding potentially sensitive information
     such as passwords or keys.
     """
-    hidden_re = re.compile(r'API|TOKEN|KEY|SECRET|PASS|PWD|CRED|AUTH', re.I)
+    hidden_re = re.compile(r'API|TOKEN|KEY|SECRET|PASS|PWD|CRED|AUTH|PAT', re.I)
     urlpass_re = re.compile(r'^.*?://[^:]+:(.*?)@.*?$')
     safe_env = dict(env)
     for k, v in safe_env.items():

--- a/src/ansible_runner/utils/__init__.py
+++ b/src/ansible_runner/utils/__init__.py
@@ -520,3 +520,23 @@ def signal_handler() -> Callable[[], bool] | None:
     signal.signal(signal.SIGINT, _handler)
 
     return signal_event.is_set
+
+
+def build_safe_env(env):
+    """
+    Build environment dictionary, hiding potentially sensitive information
+    such as passwords or keys.
+    """
+    hidden_re = re.compile(r'API|TOKEN|KEY|SECRET|PASS|PWD|CRED|AUTH', re.I)
+    urlpass_re = re.compile(r'^.*?://[^:]+:(.*?)@.*?$')
+    safe_env = dict(env)
+    for k, v in safe_env.items():
+        if k == 'AWS_ACCESS_KEY_ID':
+            continue
+        if k.startswith('ANSIBLE_') and not k.startswith('ANSIBLE_NET') and not k.startswith('ANSIBLE_GALAXY_SERVER'):
+            continue
+        if hidden_re.search(k):
+            safe_env[k] = '**********'
+        elif isinstance(type(v), str) and urlpass_re.match(v):
+            safe_env[k] = urlpass_re.sub('**********', v)
+    return safe_env

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -503,7 +503,7 @@ def test_unparsable_line_worker(tmp_path):
 def test_unparsable_really_big_line_processor(tmp_path):
     process_dir = tmp_path / 'for_process'
     process_dir.mkdir()
-    incoming_buffer = io.BytesIO(bytes(f'not-json-data with extra garbage:{"f"*10000}', encoding='utf-8'))
+    incoming_buffer = io.BytesIO(bytes(f'not-json-data with extra garbage:{"f" * 10000}', encoding='utf-8'))
 
     def status_receiver(status_data, runner_config):  # pylint: disable=W0613
         assert status_data['status'] == 'error'

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -519,13 +519,13 @@ def test_unparsable_really_big_line_processor(tmp_path):
     )
 
 
-@pytest.mark.parametrize("suppress", [True, False])
-def test_suppress_env_print(tmp_path, suppress):
+@pytest.mark.parametrize("mask", [True, False])
+def test_mask_secrets_in_env(tmp_path, mask):
     worker_dir = tmp_path / 'for_worker'
     worker_dir.mkdir()
     incoming_buffer = io.BytesIO(
-        b'{"kwargs": {"playbook": "debug.yml", "suppress_env_print": true}}\n{"eof": true}\n' if suppress
-        else b'{"kwargs": {"playbook": "debug.yml", "suppress_env_print": false}}\n{"eof": true}\n')
+        b'{"kwargs": {"playbook": "debug.yml", "mask_secrets_in_env": true}}\n{"eof": true}\n'
+        if mask else b'{"kwargs": {"playbook": "debug.yml", "mask_secrets_in_env": false}}\n{"eof": true}\n')
     outgoing_buffer = io.BytesIO()
 
     for buffer in (outgoing_buffer, incoming_buffer):
@@ -537,9 +537,9 @@ def test_suppress_env_print(tmp_path, suppress):
         _input=incoming_buffer,
         _output=outgoing_buffer,
         private_data_dir=worker_dir,
-        envvars={"SUPPRESS_ENV_PRINT": "False"}
+        envvars={"TEST_PASSWORD": "SUPERSECRETPASSWORD"}
     )
     outgoing_buffer.seek(0)
     sent = outgoing_buffer.readline()
     data = json.loads(sent)
-    assert data["env"]["SUPPRESS_ENV_PRINT"] == str(suppress)
+    assert data["env"]["TEST_PASSWORD"] == ('**********' if mask else "SUPERSECRETPASSWORD")

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -517,3 +517,29 @@ def test_unparsable_really_big_line_processor(tmp_path):
         private_data_dir=process_dir,
         status_handler=status_receiver
     )
+
+
+@pytest.mark.parametrize("suppress", [True, False])
+def test_suppress_env_print(tmp_path, suppress):
+    worker_dir = tmp_path / 'for_worker'
+    worker_dir.mkdir()
+    incoming_buffer = io.BytesIO(
+        b'{"kwargs": {"playbook": "debug.yml", "suppress_env_print": true}}\n{"eof": true}\n' if suppress
+        else b'{"kwargs": {"playbook": "debug.yml", "suppress_env_print": false}}\n{"eof": true}\n')
+    outgoing_buffer = io.BytesIO()
+
+    for buffer in (outgoing_buffer, incoming_buffer):
+        buffer.name = 'foo'
+
+    # Worker
+    run(
+        streamer='worker',
+        _input=incoming_buffer,
+        _output=outgoing_buffer,
+        private_data_dir=worker_dir,
+        envvars={"SUPPRESS_ENV_PRINT": "False"}
+    )
+    outgoing_buffer.seek(0)
+    sent = outgoing_buffer.readline()
+    data = json.loads(sent)
+    assert data["env"]["SUPPRESS_ENV_PRINT"] == str(suppress)


### PR DESCRIPTION
Ansible-Runner is used within AWX to run ansible-playbooks in transmit and worker mode.
Since AWX passes the contents (user + password) of some credential types (e.g. VMware vcenter) to the playbook as environment variables, these environment variables are written to stdout in `streaming.py`:
https://github.com/ansible/ansible-runner/blob/devel/src/ansible_runner/streaming.py#L228
`self._output.write(json.dumps(printed_status_data).encode('utf-8'))`
  
In environments such as Red Hat Openshift where global log forwarding to a log streaming server is enabled for all pods and their stdout, this immediately leads to the logging of sensitive data into log management.
This PR offers the possibility to suppress the logging of all environment variables by ansible-runner via CLI flag (`--suppress-env-print`) or environment variable (`SUPPRESS_ENV_PRINT`).
  
Due to the fact that awx uses a hard-coded CLI-call for the ansible-runner, it's important to allow log-suppressipon not only via CLI flag but also via environment variable. Otherwise, it would not be configurable:
https://github.com/ansible/awx/blob/devel/awx/main/tasks/receptor.py#L646
The suppress option can here be achieved via setting the environmet variable `SUPPRESS_ENV_PRINT=True` using the pod specification for the ansible-runner.