### PR TITLE
utils: handle FileExistsError

### DIFF
--- a/src/ansible_runner/utils/__init__.py
+++ b/src/ansible_runner/utils/__init__.py
@@ -417,7 +417,11 @@ def open_fifo_write(path: str, data: str | bytes) -> None:
     This blocks the thread until an external process (such as ssh-agent)
     reads data from the pipe.
     '''
-    os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        os.mkfifo(path, stat.S_IRUSR | stat.S_IWUSR)
+    except FileExistsError:
+        # Use existing path
+        pass
     # If the data is a string instead of bytes, convert it before writing the fifo
     if isinstance(data, str):
         data = data.encode()

--- a/test/unit/utils/test_fifo_pipe.py
+++ b/test/unit/utils/test_fifo_pipe.py
@@ -25,3 +25,18 @@ def test_fifo_write_string(tmp_path):
         assert results == data
     finally:
         remove(path)
+
+
+def test_fifo_write_string_with_existing_file(tmp_path):
+    path = tmp_path / "string_test"
+    data = "string"
+    # Create a fifo
+    open_fifo_write(path, data)
+    try:
+        # Use an existing fifo path
+        open_fifo_write(path, data)
+        with open(path, 'r') as f:
+            results = f.read()
+        assert results == data * 2
+    finally:
+        remove(path)


### PR DESCRIPTION
##### SUMMARY

* In open_fifo_write, use existing FIFO file path if already exists

Fixes: #407

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


