### PR TITLE
Remove outdated skipif fixtures

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,12 +3,10 @@
 import shutil
 
 from pathlib import Path
-from packaging.version import Version
 
 import pytest
 
 from ansible_runner import defaults
-from ansible_runner.utils.importlib_compat import importlib_metadata
 
 
 CONTAINER_RUNTIMES = (
@@ -25,46 +23,6 @@ def mock_env_user(monkeypatch):
 @pytest.fixture(autouse=True)
 def change_save_path(tmp_path, mocker):
     mocker.patch.object(defaults, 'AUTO_CREATE_DIR', str(tmp_path))
-
-
-@pytest.fixture(scope='session')
-def is_pre_ansible211():
-    """
-    Check if the version of Ansible is less than 2.11.
-
-    CI tests with either ansible-core (>=2.11), ansible-base (==2.10), and ansible (<=2.9).
-    """
-
-    try:
-        if importlib_metadata.version("ansible-core"):
-            return False
-    except importlib_metadata.PackageNotFoundError:
-        # Must be ansible-base or ansible
-        pass
-    return True
-
-
-@pytest.fixture(scope='session')
-def skipif_pre_ansible211(is_pre_ansible211):
-    if is_pre_ansible211:
-        pytest.skip("Valid only on Ansible 2.11+")
-
-
-@pytest.fixture(scope="session")
-def is_pre_ansible212():
-    try:
-        base_version = importlib_metadata.version("ansible")
-        if Version(base_version) < Version("2.12"):
-            return True
-    except importlib_metadata.PackageNotFoundError:
-        pass
-    return False
-
-
-@pytest.fixture(scope="session")
-def skipif_pre_ansible212(is_pre_ansible212):
-    if is_pre_ansible212:
-        pytest.skip("Valid only on Ansible 2.12+")
 
 
 # TODO: determine if we want to add docker / podman

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -213,7 +213,7 @@ def test_callback_plugin_task_args_leak(executor, playbook):  # pylint: disable=
         },  # noqa
     ],
 )
-def test_resolved_actions(executor, playbook, skipif_pre_ansible212):  # pylint: disable=W0613,W0621
+def test_resolved_actions(executor, playbook):  # pylint: disable=W0613,W0621
     executor.run()
     events = list(executor.events)
 

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -438,7 +438,7 @@ def test_run_role(project_fixtures):
 
 
 # pylint: disable=W0613
-def test_get_role_list(project_fixtures, skipif_pre_ansible211):
+def test_get_role_list(project_fixtures):
     """
     Test get_role_list() running locally, specifying a playbook directory
     containing our test role.
@@ -459,7 +459,7 @@ def test_get_role_list(project_fixtures, skipif_pre_ansible211):
 
 
 @pytest.mark.test_all_runtimes
-def test_get_role_list_within_container(project_fixtures, runtime, skipif_pre_ansible211, container_image):
+def test_get_role_list_within_container(project_fixtures, runtime, container_image):
     """
     Test get_role_list() running in a container.
     """
@@ -482,7 +482,7 @@ def test_get_role_list_within_container(project_fixtures, runtime, skipif_pre_an
     assert resp == expected
 
 
-def test_get_role_argspec(project_fixtures, skipif_pre_ansible211):
+def test_get_role_argspec(project_fixtures):
     """
     Test get_role_argspec() running locally, specifying a playbook directory
     containing our test role.
@@ -518,7 +518,7 @@ def test_get_role_argspec(project_fixtures, skipif_pre_ansible211):
 
 
 @pytest.mark.test_all_runtimes
-def test_get_role_argspec_within_container(project_fixtures, runtime, skipif_pre_ansible211, container_image):
+def test_get_role_argspec_within_container(project_fixtures, runtime, container_image):
     """
     Test get_role_argspec() running inside a container. Since the test container
     does not currently contain any collections or roles, specify playbook_dir


### PR DESCRIPTION
These fixtures are for Ansible versions that are EOL, and we don't test against them.