### PR TITLE
[PR #1425/827f5f65 backport][release_2.3] 🧪 Use `reusable-tox.yml` @ `tox-dev/workflow`

### DIFF
--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-src-checkout/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-src-checkout/action.yml
@@ -1,0 +1,48 @@
+---
+
+inputs:
+  calling-job-context:
+    description: A JSON with the calling job inputs
+    type: string
+  job-dependencies-context:
+    default: >-
+      {}
+    description: >-
+      The `$ {{ needs }}` context passed from the calling workflow
+      encoded as a JSON string. The caller is expected to form this
+      input as follows:
+      `job-dependencies-context: $ {{ toJSON(needs) }}`.
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Build a wheel
+    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    run: python3 -Im pip wheel --no-deps --wheel-dir=dist/ .
+    shell: bash
+
+  - name: Build a runner test container via docker
+    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    run: >-
+      docker build
+      --build-arg "WHEEL=$(basename dist/ansible_runner*.whl)"
+      --rm=true
+      -t 'ansible-runner-gha${{ github.run_id }}-event-test'
+      --file=test/integration/Dockerfile
+      dist/
+    shell: bash
+
+  - name: Build a runner test container via podman
+    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    run: >-
+      podman build
+      --build-arg "WHEEL=$(basename dist/ansible_runner*.whl)"
+      --rm=true
+      -t ansible-runner-gha${{ github.run_id }}-event-test
+      --file=test/integration/Dockerfile
+      dist/
+    shell: bash
+
+...

--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/prepare-for-tox-run/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/prepare-for-tox-run/action.yml
@@ -1,0 +1,30 @@
+---
+
+inputs:
+  calling-job-context:
+    description: A JSON with the calling job inputs
+    type: string
+  job-dependencies-context:
+    default: >-
+      {}
+    description: >-
+      The `$ {{ needs }}` context passed from the calling workflow
+      encoded as a JSON string. The caller is expected to form this
+      input as follows:
+      `job-dependencies-context: $ {{ toJSON(needs) }}`.
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+  - name: Set the runner container image reference for testing
+    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    env:
+      RUNNER_TEST_IMAGE_NAME: ansible-runner-gha${{ github.run_id }}-event-test
+    run: >-
+      echo RUNNER_TEST_IMAGE_NAME="${RUNNER_TEST_IMAGE_NAME}"
+      | tee -a "${GITHUB_ENV}"
+    shell: bash
+
+...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,123 +5,171 @@ on:
   push:
 
 
+env:
+  UPSTREAM_REPOSITORY_ID: >-
+    119996807
+
+
 jobs:
+  pre-setup:
+    name: ⚙️ Pre-set global build settings
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 1
+
+    defaults:
+      run:
+        shell: python
+
+    outputs:
+      # NOTE: These aren't env vars because the `${{ env }}` context is
+      # NOTE: inaccessible when passing inputs to reusable workflows.
+      upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
+      is-debug-mode: ${{ runner.debug == '1' && false || true }}
+
+    steps:
+    - name: No-op so that the computations can happen in the outputs
+      if: fromJSON(false)
+      run: |
+        print('No-op')
+
   sanity:
-    name: ${{ matrix.test.name }}
-    runs-on: ubuntu-20.04
-    container:
-      image: quay.io/ansible/ansible-runner-test-container:2.0.0
-      env:
-        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
-        PY_COLORS: 1
-        TOXENV: ${{ matrix.test.tox_env }}
+    name: 🧹 Linters${{ '' }}  # nest jobs under the same sidebar category
+    needs:
+    - pre-setup
 
     strategy:
       fail-fast: false
       matrix:
-        test:
-          - name: Lint
-            tox_env: linters
+        runner-vm-os:
+        - ubuntu-22.04
+        python-version:
+        - >-
+          3.10
+        toxenv:
+        - linters
+        - docs
+        xfail:
+        - false
 
-          - name: Docs
-            tox_env: docs
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    with:
+      cache-key-for-dependency-files:  # FIXME
+      check-name: >-
+        ${{ matrix.toxenv }}
+        under 🐍${{ matrix.python-version }}
+      checkout-src-git-fetch-depth: 0
+      python-version: >-
+        ${{ matrix.python-version }}
+      require-successful-codecov-uploads: >-
+        ${{
+          toJSON(
+          needs.pre-setup.outputs.upstream-repository-id
+          == github.repository_id
+          )
+        }}
+      runner-vm-os: >-
+        ${{ matrix.runner-vm-os }}
+      timeout-minutes: 2
+      toxenv: >-
+        ${{ matrix.toxenv }}
+      tox-tool-deps: >-
+        'tox == 4.25.0'
+        'tox-uv == 1.25.0'
+      xfail: >-
+        ${{ fromJSON(matrix.xfail) }}
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  tests:
+    name: 🧪 Tests${{ '' }}  # nest jobs under the same sidebar category
 
-      - name: Create tox environment
-        run: tox --notest
-
-      - name: Run tests
-        run: tox
-
-
-  integration:
-    runs-on: ubuntu-20.04
-    name: Integration - ${{ matrix.py_version.name }}
-
-    env:
-      TOXENV: ${{ matrix.py_version.tox_env }}
-      PY_COLORS: 1
-
-    strategy:
-      fail-fast: false
-      matrix:
-        py_version:
-          - name: '3.8'
-            tox_env: integration-py38
-
-          - name: '3.9'
-            tox_env: integration-py39
-
-          - name: '3.10'
-            tox_env: integration-py310
-
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Python ${{ matrix.py_version.name }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.py_version.name }}
-
-      - name: Install tox
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install "tox<4.0.0"
-
-      - name: Create tox environment
-        run: |
-          tox --notest
-
-      - name: Run integration tests
-        run: |
-          docker build --rm=true -t quay.io/ansible/ansible-runner:devel -t quay.io/ansible/ansible-runner:latest .
-          podman build --rm=true -t quay.io/ansible/ansible-runner:devel -t quay.io/ansible/ansible-runner:latest .
-          tox
-
-      - name: Upload coverage report
-        run: |
-          curl --silent --show-error --output codecov https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/linux/codecov
-          chmod +x codecov
-          ./codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
-
-
-  unit:
-    name: Unit - ${{ matrix.py_version.name}}
-    runs-on: ubuntu-20.04
-    container:
-      image: quay.io/ansible/ansible-runner-test-container:2.0.0
-      env:
-        PIP_CACHE_DIR: ${{ runner.temp }}/.cache/pip
-        TOXENV: ${{ matrix.py_version.tox_env }}
-        PY_COLORS: 1
+    needs:
+    - pre-setup  # transitive, for accessing settings
 
     strategy:
-      fail-fast: false
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
       matrix:
-        py_version:
-          - name: '3.8'
-            tox_env: unit-py38
+        python-version:
+        # NOTE: The latest and the lowest supported Pythons are prioritized
+        # NOTE: to improve the responsiveness. It's nice to see the most
+        # NOTE: important results first.
+        - 3.11
+        - 3.8
+        - >-
+          3.10
+        - 3.9
+        runner-vm-os:
+        - ubuntu-22.04
+        toxenv:
+        - integration
+        - unit
+        xfail:
+        - false
 
-          - name: '3.9'
-            tox_env: unit-py39
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    with:
+      cache-key-for-dependency-files:  # FIXME
+      check-name: >-
+        ${{ matrix.toxenv }}
+        under 🐍${{ matrix.python-version }}
+      job-dependencies-context: >-  # context for hooks
+        ${{ toJSON(needs) }}
+      python-version: >-
+        ${{ matrix.python-version }}
+      require-successful-codecov-uploads: >-
+        ${{
+          toJSON(
+          needs.pre-setup.outputs.upstream-repository-id
+          == github.repository_id
+          )
+        }}
+      runner-vm-os: >-
+        ${{ matrix.runner-vm-os }}
+      timeout-minutes: >-
+        ${{ matrix.toxenv == 'unit' && 2 || 4 }}
+      toxenv: >-
+        ${{ matrix.toxenv }}
+      tox-run-posargs: >-
+        --cov-report=xml:.tox/.tmp/.test-results/pytest-${{
+          matrix.python-version
+        }}/cobertura.xml
+        --junitxml=.tox/.tmp/.test-results/pytest-${{
+          matrix.python-version
+        }}/test.xml
+      tox-rerun-posargs: >-
+        --no-cov
+        -vvvvv
+        --lf
+      tox-tool-deps: >-
+        'tox == 4.25.0'
+        'tox-uv == 1.25.0'
+      xfail: >-
+        ${{ fromJSON(matrix.xfail) }}
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-          - name: '3.10'
-            tox_env: unit-py310
+  check:  # This job does nothing and is only used for the branch protection
+    name: ✅ All tests passed
+    if: always()
+
+    needs:
+    - pre-setup  # transitive, for accessing settings
+    - sanity
+    - tests
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 1
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Create tox environment
-        run: tox --notest
-
-      - name: Run tests
-        run: tox
-
-      - name: Upload coverage report
-        run: codecov --file test/coverage/reports/coverage.xml --flags {{ matrix.py_version.tox_env }}
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.yamllint
+++ b/.yamllint
@@ -12,6 +12,8 @@ rules:
     level: error
   comments:
     min-spaces-from-content: 1 # prettier compatibility
+  indentation:
+    indent-sequences: consistent
   line-length: disable
   document-start: disable
   truthy:

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps = ansible27: ansible<2.8
        integration{,-py38,-py39,-py310}: ansible-core
        -r {toxinidir}/requirements.txt
        -r {toxinidir}/test/requirements.txt
+       linters: ansible-core
 passenv = HOME
 usedevelop = True
 commands = pytest {posargs}
@@ -27,11 +28,13 @@ commands=
 
 [testenv:unit{,-py38,-py39,-py310}]
 description = Run unit tests
-commands = pytest {posargs:test/unit}
+commands =
+    pytest test/unit {posargs}
 
 [testenv:integration{,-py38,-py39,-py310}]
 description = Run integration tests
-commands = pytest {posargs:test/integration}
+commands =
+    pytest test/integration {posargs}
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
**This is a backport of PR #1425 as merged into devel (827f5f6574096fff86c3cdfd83fa6cebd57bcf22).**

Merge pull request #1425 from webknjaz/maintenance/ci-shape-reuse

(cherry picked from commit 827f5f6574096fff86c3cdfd83fa6cebd57bcf22)