### PR TITLE
Python 3.14 compat: replace codecs.open with open

### DIFF
--- a/src/ansible_runner/loader.py
+++ b/src/ansible_runner/loader.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import os
 import json
-import codecs
 
 from typing import Any, Dict
 from yaml import safe_load, YAMLError
@@ -90,7 +89,7 @@ class ArtifactLoader:
         try:
             if not os.path.exists(path):
                 raise ConfigurationError(f"specified path does not exist {path}")
-            with codecs.open(path, encoding='utf-8') as f:
+            with open(path, encoding='utf-8') as f:
                 data = f.read()
 
             return data

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -6,7 +6,6 @@ import errno
 import signal
 from subprocess import Popen, PIPE, CalledProcessError, TimeoutExpired, run as run_subprocess
 import shutil
-import codecs
 import collections
 import datetime
 import logging
@@ -68,7 +67,7 @@ class Runner:
             try:
                 event_data.update({'runner_ident': str(self.config.ident)})
                 try:
-                    with codecs.open(partial_filename, 'r', encoding='utf-8') as read_file:
+                    with open(partial_filename, 'r', encoding='utf-8') as read_file:
                         partial_event_data = json.load(read_file)
                     event_data.update(partial_event_data)
                     if self.remove_partials:
@@ -92,7 +91,7 @@ class Runner:
                     ansible_runner.plugins[plugin].event_handler(self.config, event_data)
                 if should_write:
                     temporary_filename = full_filename + '.tmp'
-                    with codecs.open(temporary_filename, 'w', encoding='utf-8') as write_file:
+                    with open(temporary_filename, 'w', encoding='utf-8') as write_file:
                         os.chmod(temporary_filename, stat.S_IRUSR | stat.S_IWUSR)
                         json.dump(event_data, write_file)
                     os.rename(temporary_filename, full_filename)
@@ -136,7 +135,7 @@ class Runner:
             os.mkdir(job_events_path, 0o700)
 
         command = self.config.command
-        with codecs.open(command_filename, 'w', encoding='utf-8') as f:
+        with open(command_filename, 'w', encoding='utf-8') as f:
             os.chmod(command_filename, stat.S_IRUSR | stat.S_IWUSR)
             json.dump(
                 {'command': command,
@@ -156,8 +155,8 @@ class Runner:
             stdout_filename = os.path.join(self.config.artifact_dir, 'stdout')
             stderr_filename = os.path.join(self.config.artifact_dir, 'stderr')
             os.close(os.open(stdout_filename, os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR))
-            stdout_handle = codecs.open(stdout_filename, 'w', encoding='utf-8')
-            stderr_handle = codecs.open(stderr_filename, 'w', encoding='utf-8')
+            stdout_handle = open(stdout_filename, 'w', encoding='utf-8')
+            stderr_handle = open(stderr_filename, 'w', encoding='utf-8')
         else:
             stdout_handle = None
             stderr_handle = None

--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # allow newer type syntax until 3.10 is our minimum
 
-import codecs
 import json
 import os
 import stat
@@ -326,7 +325,7 @@ class Processor:
         for plugin in ansible_runner.plugins:
             ansible_runner.plugins[plugin].event_handler(self.config, event_data)
         if should_write:
-            with codecs.open(full_filename, 'w', encoding='utf-8') as write_file:
+            with open(full_filename, 'w', encoding='utf-8') as write_file:
                 os.chmod(full_filename, stat.S_IRUSR | stat.S_IWUSR)
                 json.dump(event_data, write_file)
 

--- a/src/ansible_runner/utils/__init__.py
+++ b/src/ansible_runner/utils/__init__.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import pwd
 from shlex import quote
 import uuid
-import codecs
 import atexit
 import signal
 
@@ -268,7 +267,7 @@ def collect_new_events(event_path: str, old_events: dict) -> Iterator[tuple[dict
                 dir_events_actual.append(each_file)
     dir_events_actual.sort(key=lambda filenm: int(filenm.split("-", 1)[0]))
     for event_file in dir_events_actual:
-        with codecs.open(os.path.join(event_path, event_file), 'r', encoding='utf-8') as event_file_actual:
+        with open(os.path.join(event_path, event_file), 'r', encoding='utf-8') as event_file_actual:
             try:
                 event = json.load(event_file_actual)
             except ValueError:

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -117,7 +117,7 @@ def test_load_file_type_check(loader, mocker, tmp_path):
 
 
 def test_get_contents_ok(loader, mocker):
-    mock_open = mocker.patch('codecs.open')
+    mock_open = mocker.patch('builtins.open')
 
     handler = BytesIO()
     handler.write(b"test string")

--- a/test/unit/test_runner.py
+++ b/test/unit/test_runner.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=W0621
 
-import codecs
 import datetime
 import os
 import sys
@@ -93,7 +92,7 @@ def test_env_vars(rc, value):
     status, exitcode = Runner(config=rc).run()
     assert status == 'successful'
     assert exitcode == 0
-    with codecs.open(os.path.join(rc.artifact_dir, 'stdout'), 'r', encoding='utf-8') as f:
+    with open(os.path.join(rc.artifact_dir, 'stdout'), 'r', encoding='utf-8') as f:
         assert value in f.read()
 
 
@@ -113,7 +112,7 @@ def test_event_callback_interface_has_ident(rc, mocker):
     rc.ident = "testident"
     runner = Runner(config=rc, remove_partials=False)
     runner.event_handler = mocker.Mock()
-    mocker.patch('codecs.open', mocker.mock_open(read_data=json.dumps({"event": "test"})))
+    mocker.patch('builtins.open', mocker.mock_open(read_data=json.dumps({"event": "test"})))
     chmod = mocker.patch('os.chmod', mocker.Mock())
     mocker.patch('os.mkdir', mocker.Mock())
 


### PR DESCRIPTION
Python 3.14 deprecates codecs.open:
https://docs.python.org/3.14/whatsnew/3.14.html#deprecated This makes the tests fail, because we get a bunch of warnings about the deprecation and I guess the tests are set to fail on warnings.

It's never been recommended to use codecs.open on Python 3. It was the "right way" to open text content on Python 2 for a bit, but when Python 3 came around, io.open was supposed to be used to be agnostic between 2 and 3. Since ansible-runner only targets 3 nowadays, let's just use open.