### PR TITLE
Add Python 3.14 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         runner-vm-os:
-        - ubuntu-22.04
+        - ubuntu-latest
         python-version:
         - >-
-          3.10
+          3.13
         toxenv:
         - linters
         - docs
@@ -106,8 +106,9 @@ jobs:
         - 3.11
         - >-
           3.10
+        - ~3.14.0-0
         runner-vm-os:
-        - ubuntu-22.04
+        - ubuntu-24.04
         toxenv:
         - integration
         - unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         runner-vm-os:
-        - ubuntu-latest
+        - ubuntu-24.04
         python-version:
         - >-
-          3.13
+          3.10
         toxenv:
         - linters
         - docs
@@ -154,8 +154,6 @@ jobs:
         'tox-uv == 1.25.0'
       xfail: >-
         ${{ fromJSON(matrix.xfail) }}
-      continue-on-error: >-
-        ${{ contains(matrix.python-version, '~') && true || false }}
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       runner-vm-os: >-
         ${{ matrix.runner-vm-os }}
       timeout-minutes: >-
-        ${{ matrix.toxenv == 'unit' && 2 || 4 }}
+        ${{ matrix.toxenv == 'unit' && 2 || 5 }}
       toxenv: >-
         ${{ matrix.toxenv }}
       tox-run-posargs: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,8 @@ jobs:
         'tox-uv == 1.25.0'
       xfail: >-
         ${{ fromJSON(matrix.xfail) }}
+      continue-on-error: >-
+        ${{ contains(matrix.python-version, '~') && true || false }}
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ disable = [
   "R0913",  # too-many-arguments
   "R0914",  # too-many-locals
   "R0915",  # too-many-statements
+  "R0917",  # too-many-positional-arguments
   "W0221",  # arguments-differ
   "W0511",  # fixme
   "W0603",  # global-statement

--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -275,7 +275,7 @@ def _getcallargs(sig: inspect.Signature, *args, **kwargs) -> types.MappingProxyT
 
 
 def with_context(**context):
-    global event_context  # pylint: disable=W0602
+    global event_context  # pylint: disable=W0602  # noqa: F824
 
     def wrap(f):
         @functools.wraps(f)
@@ -297,7 +297,7 @@ for attr in dir(Display):
 
 
 def with_verbosity(f):
-    global event_context  # pylint: disable=W0602
+    global event_context  # pylint: disable=W0602  # noqa: F824
 
     @functools.wraps(f)
     def wrapper(*args, **kwargs):

--- a/src/ansible_runner/utils/capacity.py
+++ b/src/ansible_runner/utils/capacity.py
@@ -14,6 +14,7 @@ def get_cpu_count() -> int:
 
 
 def get_mem_in_bytes() -> int | str:
+    mem_capacity = 0
     try:
         with open('/proc/meminfo') as f:
             mem = f.read()

--- a/test/integration/test___main__.py
+++ b/test/integration/test___main__.py
@@ -82,7 +82,7 @@ def test_cmdline_role(options, expected_playbook, tmp_path, mocker):
 
     rc = ansible_runner.__main__.main(command)
 
-    with open(tmp_path / 'play.yml') as f:
+    with open(tmp_path / 'play.yml', encoding='utf-8') as f:
         playbook = json.loads(f.read())
 
     assert rc == 1
@@ -121,7 +121,7 @@ def test_cmdline_playbook(tmp_path):
 
     assert ansible_runner.__main__.main() == 0
 
-    with open(playbook) as f:
+    with open(playbook, encoding='utf-8') as f:
         assert json.loads(f.read()) == play
 
 

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -48,7 +48,7 @@ def test_run_command_with_unicode(rc):
     status, exitcode = Runner(config=rc).run()
     assert status == 'successful'
     assert exitcode == 0
-    with open(os.path.join(rc.artifact_dir, 'command')) as f:
+    with open(os.path.join(rc.artifact_dir, 'command'), encoding='utf-8') as f:
         data = json.load(f)
         assert data.get('command') == ['echo', expected]
         assert 'cwd' in data

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -23,7 +23,7 @@ def test_password_prompt(rc):
     assert exitcode == 0
     # stdout file can be subject to a race condition
     for _ in iterate_timeout(30.0, 'stdout file to be written with 1234 in it', interval=0.2):
-        with open(os.path.join(rc.artifact_dir, 'stdout')) as f:
+        with open(os.path.join(rc.artifact_dir, 'stdout'), encoding='utf-8') as f:
             if '1234' in f.read():
                 break
 
@@ -33,7 +33,7 @@ def test_run_command(rc):
     status, exitcode = Runner(config=rc).run()
     assert status == 'successful'
     assert exitcode == 0
-    with open(os.path.join(rc.artifact_dir, 'command')) as f:
+    with open(os.path.join(rc.artifact_dir, 'command'), encoding='utf-8') as f:
         data = json.load(f)
         assert data.get('command') == ['sleep', '1']
         assert 'cwd' in data
@@ -277,7 +277,7 @@ def test_set_extra_vars(rc):
     runner.run()
     # stdout file can be subject to a race condition
     for _ in iterate_timeout(30.0, 'stdout file to be written with "hello there" in it', interval=0.2):
-        with open(os.path.join(rc.artifact_dir, 'stdout')) as f:
+        with open(os.path.join(rc.artifact_dir, 'stdout'), encoding='utf-8') as f:
             if 'hello there' in f.read():
                 break
 

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -40,7 +40,7 @@ class TestStreamingUsage:
         events_dir = os.path.join(process_dir, 'artifacts', 'job_events')
         events = []
         for file in os.listdir(events_dir):
-            with open(os.path.join(events_dir, file), 'r') as f:
+            with open(os.path.join(events_dir, file), 'r', encoding='utf-8') as f:
                 if file in ('status', 'rc'):
                     continue
                 content = f.read()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,11 +1,11 @@
-mypy==1.6.0
-pylint==3.0.1
-pytest==8.1.1
+mypy==1.15.0
+pylint==3.3.7
+pytest==8.3.4
 pytest-cov
 pytest-mock
 pytest-timeout
-pytest-xdist==2.5.0
+pytest-xdist==3.5.0
 types-pyyaml
-flake8==6.1.0
-yamllint==1.32.0
+flake8==7.2.0
+yamllint==1.37.1
 cryptography

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = linters
+env_list =
+    linters
+    unit
+    integration
 requires =
     tox>4
     setuptools>=64
@@ -9,11 +12,8 @@ pytest_cov_args = --cov --cov-report html --cov-report term --cov-report xml
 
 [testenv]
 description = Run tests with {basepython}
-deps = py{,3,39,310,311,312,313,314}: ansible-core
-       integration{,-py39,-py310,-py311,-py312,-py313,-py314}: ansible-core
-                                                               build
-                                                               -r {toxinidir}/test/requirements.txt
-       linters: ansible-core
+deps = ansible-core
+       -r {toxinidir}/test/requirements.txt
 passenv =
     HOME
     RUNNER_TEST_IMAGE_NAME
@@ -37,6 +37,9 @@ commands =
 
 [testenv:integration{,-py39,-py310,-py311,-py312,-py313,-py314}]
 description = Run integration tests
+deps =
+    build
+    {[testenv]deps}
 commands =
     pytest test/integration -vv -n auto {[shared]pytest_cov_args} {posargs}
 
@@ -48,9 +51,8 @@ commands =
 
 [testenv:clean]
 description = Erase docs and coverage artifacts
-deps =
 skip_install = True
-allow_external = /bin/sh
+allowlist_externals = /bin/sh
 commands =
     /bin/sh -c "rm -rf {toxinidir}/test/coverage/*"
     /bin/sh -c "rm -rf {toxinidir}/docs/{_,}build"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linters, ansible{27, 28, 29, -base}
+envlist = linters
 requires =
     tox>4
     setuptools>=64
@@ -9,14 +9,10 @@ pytest_cov_args = --cov --cov-report html --cov-report term --cov-report xml
 
 [testenv]
 description = Run tests with {basepython}
-deps = ansible27: ansible<2.8
-       ansible28: ansible<2.9
-       ansible29: ansible<2.10
-       ansible-base: ansible-base
-       py{,3,39,310,311,312,313}: ansible-core
-       integration{,-py39,-py310,-py311,-py312,-py313}: ansible-core
-                                                        build
-                                                        -r {toxinidir}/test/requirements.txt
+deps = py{,3,39,310,311,312,313,314}: ansible-core
+       integration{,-py39,-py310,-py311,-py312,-py313,-py314}: ansible-core
+                                                               build
+                                                               -r {toxinidir}/test/requirements.txt
        linters: ansible-core
 passenv =
     HOME
@@ -24,7 +20,7 @@ passenv =
 usedevelop = True
 commands = pytest -vv -n auto {posargs}
 
-[testenv:linters{,-py39,-py310,-py311,-py312,-py313}]
+[testenv:linters{,-py39,-py310,-py311,-py312,-py313,-py314}]
 description = Run code linters
 commands =
     flake8 --version
@@ -34,12 +30,12 @@ commands =
     mypy src/ansible_runner
     pylint src/ansible_runner test
 
-[testenv:unit{,-py39,-py310,-py311,-py312,-py313}]
+[testenv:unit{,-py39,-py310,-py311,-py312,-py313,-py314}]
 description = Run unit tests
 commands =
     pytest test/unit -vv -n auto {[shared]pytest_cov_args} {posargs}
 
-[testenv:integration{,-py39,-py310,-py311,-py312,-py313}]
+[testenv:integration{,-py39,-py310,-py311,-py312,-py313,-py314}]
 description = Run integration tests
 commands =
     pytest test/integration -vv -n auto {[shared]pytest_cov_args} {posargs}


### PR DESCRIPTION
- Adds testing for Python 3.14
- Simplifies and corrects `tox.ini`
- Bump integration test timeout to 5 minutes
- Bumps testing Python requirements
- Bumps GH runner versions
- Addresses some linting errors from updated tooling
- Makes sure tests open utf-8-written files for reading using utf-8