### PR TITLE
Backports 2.4

### DIFF
--- a/src/ansible_runner/display_callback/callback/awx_display.py
+++ b/src/ansible_runner/display_callback/callback/awx_display.py
@@ -17,28 +17,36 @@
 
 # pylint: disable=W0212
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, annotations, division, print_function)
 
 # Python
 import json
 import stat
-import multiprocessing
 import threading
 import base64
 import functools
 import collections
 import contextlib
 import datetime
+import inspect
 import os
 import sys
+import types
+import typing as t
 import uuid
 from copy import copy
 
 # Ansible
+from ansible import __version__ as ansible_version_str
 from ansible import constants as C
 from ansible.plugins.callback import CallbackBase
 from ansible.plugins.loader import callback_loader
 from ansible.utils.display import Display
+
+try:
+    from ansible.utils.multiprocessing import context as multiprocessing_context
+except ImportError:
+    import multiprocessing as multiprocessing_context
 
 
 DOCUMENTATION = '''
@@ -67,6 +75,11 @@ else:
 DefaultCallbackModule: CallbackBase = callback_loader.get(default_stdout_callback).__class__
 
 CENSORED = "the output has been hidden due to the fact that 'no_log: true' was specified for this result"
+
+_ANSIBLE_VERSION = tuple(int(p) for p in ansible_version_str.split('.')[:2])
+_ANSIBLE_214 = _ANSIBLE_VERSION >= (2, 14)
+
+display = Display()
 
 
 def current_time():
@@ -127,7 +140,10 @@ class EventContext:
     '''
 
     def __init__(self):
-        self.display_lock = multiprocessing.RLock()
+        if _ANSIBLE_214:
+            self.display_lock = display._lock
+        else:
+            self.display_lock = multiprocessing_context.RLock()
         self._global_ctx = {}
         self._local = threading.local()
         if os.getenv('AWX_ISOLATED_DATA_DIR'):
@@ -247,6 +263,17 @@ class EventContext:
 event_context = EventContext()
 
 
+@functools.cache
+def _getsignature(f: t.Callable) -> inspect.Signature:
+    return inspect.signature(f)
+
+
+def _getcallargs(sig: inspect.Signature, *args, **kwargs) -> types.MappingProxyType:
+    ba = sig.bind(*args, **kwargs)
+    ba.apply_defaults()
+    return types.MappingProxyType(ba.arguments)
+
+
 def with_context(**context):
     global event_context  # pylint: disable=W0602
 
@@ -274,8 +301,10 @@ def with_verbosity(f):
 
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        host = args[2] if len(args) >= 3 else kwargs.get('host', None)
-        caplevel = args[3] if len(args) >= 4 else kwargs.get('caplevel', 2)
+        sig = _getsignature(f)
+        callargs = _getcallargs(sig, *args, **kwargs)
+        host = callargs.get('host')
+        caplevel = callargs.get('caplevel')
         context = {'verbose': True, 'verbosity': (caplevel + 1)}
         if host is not None:
             context['remote_addr'] = host
@@ -291,8 +320,14 @@ def display_with_context(f):
 
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        log_only = args[5] if len(args) >= 6 else kwargs.get('log_only', False)
-        stderr = args[3] if len(args) >= 4 else kwargs.get('stderr', False)
+        if _ANSIBLE_214 and multiprocessing_context.parent_process() is not None:
+            # core 2.14 and newer proxy display, return if we are in a fork
+            return f(*args, **kwargs)
+
+        sig = _getsignature(f)
+        callargs = _getcallargs(sig, *args, **kwargs)
+        log_only = callargs.get('log_only')
+        stderr = callargs.get('stderr')
         event_uuid = event_context.get().get('uuid', None)
         with event_context.display_lock:
             # If writing only to a log file or there is already an event UUID

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,12 +3,10 @@
 import shutil
 
 from pathlib import Path
-from packaging.version import Version
 
 import pytest
 
 from ansible_runner import defaults
-from ansible_runner.utils.importlib_compat import importlib_metadata
 
 
 CONTAINER_RUNTIMES = (
@@ -25,46 +23,6 @@ def mock_env_user(monkeypatch):
 @pytest.fixture(autouse=True)
 def change_save_path(tmp_path, mocker):
     mocker.patch.object(defaults, 'AUTO_CREATE_DIR', str(tmp_path))
-
-
-@pytest.fixture(scope='session')
-def is_pre_ansible211():
-    """
-    Check if the version of Ansible is less than 2.11.
-
-    CI tests with either ansible-core (>=2.11), ansible-base (==2.10), and ansible (<=2.9).
-    """
-
-    try:
-        if importlib_metadata.version("ansible-core"):
-            return False
-    except importlib_metadata.PackageNotFoundError:
-        # Must be ansible-base or ansible
-        pass
-    return True
-
-
-@pytest.fixture(scope='session')
-def skipif_pre_ansible211(is_pre_ansible211):
-    if is_pre_ansible211:
-        pytest.skip("Valid only on Ansible 2.11+")
-
-
-@pytest.fixture(scope="session")
-def is_pre_ansible212():
-    try:
-        base_version = importlib_metadata.version("ansible")
-        if Version(base_version) < Version("2.12"):
-            return True
-    except importlib_metadata.PackageNotFoundError:
-        pass
-    return False
-
-
-@pytest.fixture(scope="session")
-def skipif_pre_ansible212(is_pre_ansible212):
-    if is_pre_ansible212:
-        pytest.skip("Valid only on Ansible 2.12+")
 
 
 # TODO: determine if we want to add docker / podman

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -4,15 +4,38 @@ import subprocess
 import pathlib
 import random
 
+from functools import cache
 from string import ascii_lowercase
 
 import pexpect
 import pytest
 import yaml
+from packaging.version import parse as parse_version
 
 from ansible_runner.config.runner import RunnerConfig
+from ansible_runner.utils.importlib_compat import importlib_metadata
+
 
 here = pathlib.Path(__file__).parent
+
+
+@cache
+def get_ansible_version():
+    """Get the ansible version string."""
+    return importlib_metadata.version("ansible-core")
+
+
+@pytest.fixture(scope='session')
+def is_ansible_219_or_higher():
+    """Return True if ansible-core version is >= 2.19.0."""
+    version_str = get_ansible_version()
+    return parse_version(version_str) >= parse_version("2.19.0")
+
+
+@pytest.fixture(scope='session')
+def skipif_ansible_219_or_higher(is_ansible_219_or_higher):  # pylint: disable=W0621
+    if is_ansible_219_or_higher:
+        pytest.skip("Test skipped for ansible-core version 2.19.0 or higher")
 
 
 @pytest.fixture(scope='function')

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -213,7 +213,7 @@ def test_callback_plugin_task_args_leak(executor, playbook):  # pylint: disable=
         },  # noqa
     ],
 )
-def test_resolved_actions(executor, playbook, skipif_pre_ansible212):  # pylint: disable=W0613,W0621
+def test_resolved_actions(executor, playbook):  # pylint: disable=W0613,W0621
     executor.run()
     events = list(executor.events)
 

--- a/test/integration/test_display_callback.py
+++ b/test/integration/test_display_callback.py
@@ -213,7 +213,7 @@ def test_callback_plugin_task_args_leak(executor, playbook):  # pylint: disable=
         },  # noqa
     ],
 )
-def test_resolved_actions(executor, playbook):  # pylint: disable=W0613,W0621
+def test_resolved_actions(executor, playbook, skipif_ansible_219_or_higher):  # pylint: disable=W0613,W0621
     executor.run()
     events = list(executor.events)
 
@@ -365,8 +365,7 @@ def test_output_when_given_invalid_playbook(tmp_path):
     ex.run()
     with ex.stdout as f:
         stdout = f.read()
-    assert "ERROR! the playbook:" in stdout
-    assert "could not be found" in stdout
+    assert "fake_playbook.yml could not be found" in stdout
 
 
 def test_output_when_given_non_playbook_script(tmp_path):

--- a/test/integration/test_events.py
+++ b/test/integration/test_events.py
@@ -125,7 +125,7 @@ def test_playbook_on_stats_summary_fields(project_fixtures):
         assert runner_stats[stat]  # expected at least 1 host in each stat type
 
 
-def test_include_role_events(project_fixtures):
+def test_include_role_events(project_fixtures, skipif_ansible_219_or_higher):  # pylint: disable=W0613
     r = run(
         private_data_dir=str(project_fixtures / 'use_role'),
         playbook='use_role.yml'
@@ -142,7 +142,7 @@ def test_include_role_events(project_fixtures):
             assert event_data['resolved_action'] == 'ansible.builtin.debug'
 
 
-def test_include_role_from_collection_events(project_fixtures):
+def test_include_role_from_collection_events(project_fixtures, skipif_ansible_219_or_higher):  # pylint: disable=W0613
     r = run(
         private_data_dir=str(project_fixtures / 'collection_role'),
         playbook='use_role.yml'

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -438,7 +438,7 @@ def test_run_role(project_fixtures):
 
 
 # pylint: disable=W0613
-def test_get_role_list(project_fixtures, skipif_pre_ansible211):
+def test_get_role_list(project_fixtures):
     """
     Test get_role_list() running locally, specifying a playbook directory
     containing our test role.
@@ -459,7 +459,7 @@ def test_get_role_list(project_fixtures, skipif_pre_ansible211):
 
 
 @pytest.mark.test_all_runtimes
-def test_get_role_list_within_container(project_fixtures, runtime, skipif_pre_ansible211, container_image):
+def test_get_role_list_within_container(project_fixtures, runtime, container_image):
     """
     Test get_role_list() running in a container.
     """
@@ -482,7 +482,7 @@ def test_get_role_list_within_container(project_fixtures, runtime, skipif_pre_an
     assert resp == expected
 
 
-def test_get_role_argspec(project_fixtures, skipif_pre_ansible211):
+def test_get_role_argspec(project_fixtures):
     """
     Test get_role_argspec() running locally, specifying a playbook directory
     containing our test role.
@@ -518,7 +518,7 @@ def test_get_role_argspec(project_fixtures, skipif_pre_ansible211):
 
 
 @pytest.mark.test_all_runtimes
-def test_get_role_argspec_within_container(project_fixtures, runtime, skipif_pre_ansible211, container_image):
+def test_get_role_argspec_within_container(project_fixtures, runtime, container_image):
     """
     Test get_role_argspec() running inside a container. Since the test container
     does not currently contain any collections or roles, specify playbook_dir

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -233,7 +233,7 @@ def test_run_command_ansible_rotate_artifacts(rc):
     assert exitcode == 0
 
 
-def test_get_fact_cache(rc):
+def test_get_fact_cache(rc, skipif_ansible_219_or_higher):  # pylint: disable=W0613
     assert os.path.basename(rc.fact_cache) == 'fact_cache'
     rc.module = "setup"
     rc.host_pattern = "localhost"
@@ -249,7 +249,7 @@ def test_get_fact_cache(rc):
     assert data
 
 
-def test_set_fact_cache(rc):
+def test_set_fact_cache(rc, skipif_ansible_219_or_higher):  # pylint: disable=W0613
     assert os.path.basename(rc.fact_cache) == 'fact_cache'
     rc.module = "debug"
     rc.module_args = "var=message"

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -193,7 +193,7 @@ class TestStreamingUsage:
                 pytest.fail(f'unparseable JSON in output (likely corrupted by keepalive): {line}')
         else:
             # account for some wobble in the number of keepalives for artifact gather, etc
-            assert 1 <= incoming_data.count('"event": "keepalive"') < 5
+            assert 1 <= incoming_data.count('"event": "keepalive"') < 15
 
     @pytest.mark.parametrize("job_type", ['run', 'adhoc'])
     def test_remote_job_by_sockets(self, tmp_path, project_fixtures, job_type):

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -503,7 +503,7 @@ def test_unparsable_line_worker(tmp_path):
 def test_unparsable_really_big_line_processor(tmp_path):
     process_dir = tmp_path / 'for_process'
     process_dir.mkdir()
-    incoming_buffer = io.BytesIO(bytes(f'not-json-data with extra garbage:{"f"*10000}', encoding='utf-8'))
+    incoming_buffer = io.BytesIO(bytes(f'not-json-data with extra garbage:{"f" * 10000}', encoding='utf-8'))
 
     def status_receiver(status_data, runner_config):  # pylint: disable=W0613
         assert status_data['status'] == 'error'


### PR DESCRIPTION
Backports of:

- PR #1414 
- PR #1423 
- PR #1435 

This also contains an additional change to move the upper boundary of the keepalive setting test from 5 to 15. That was changed in a separate PR (adding Python 3.13 support) that is not being backported. That test (`test_keepalive_setting`) was being extremely flakey, necessitating the boundary expansion.