### PR TITLE
Add non-voting tests against ansible-core devel branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,72 @@ jobs:
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
+  devel-tests:
+    name: 🧪 Devel-Tests${{ '' }}
+
+    needs:
+    - pre-setup
+
+    strategy:
+      fail-fast: >-  # ${{ runner.debug }} is unavailable in this context
+        ${{
+          fromJSON(needs.pre-setup.outputs.is-debug-mode)
+          && false
+          || true
+        }}
+      matrix:
+        python-version:
+        - 3.13
+        runner-vm-os:
+        - ubuntu-24.04
+        toxenv:
+        - unit-devel
+        - integration-devel
+        xfail:
+        - true
+
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    with:
+      cache-key-for-dependency-files:  # FIXME
+      check-name: >-
+        ${{ matrix.toxenv }}
+        under 🐍${{ matrix.python-version }}
+      job-dependencies-context: >-  # context for hooks
+        ${{ toJSON(needs) }}
+      python-version: >-
+        ${{ matrix.python-version }}
+      require-successful-codecov-uploads: >-
+        ${{
+          toJSON(
+          needs.pre-setup.outputs.upstream-repository-id
+          == github.repository_id
+          )
+        }}
+      runner-vm-os: >-
+        ${{ matrix.runner-vm-os }}
+      timeout-minutes: >-
+        ${{ matrix.toxenv == 'unit-devel' && 2 || 5 }}
+      toxenv: >-
+        ${{ matrix.toxenv }}
+      tox-run-posargs: >-
+        --cov-report=xml:.tox/.tmp/.test-results/pytest-${{
+          matrix.python-version
+        }}/cobertura.xml
+        --junitxml=.tox/.tmp/.test-results/pytest-${{
+          matrix.python-version
+        }}/test.xml
+      tox-rerun-posargs: >-
+        --no-cov
+        -vvvvv
+        --lf
+      tox-tool-deps: >-
+        'tox == 4.25.0'
+        'tox-uv == 1.25.0'
+      xfail: >-
+        ${{ fromJSON(matrix.xfail) }}
+    secrets:
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
   check:  # This job does nothing and is only used for the branch protection
     name: ✅ All tests passed
     if: always()
@@ -164,6 +230,7 @@ jobs:
     - pre-setup  # transitive, for accessing settings
     - sanity
     - tests
+    - devel-tests
 
     runs-on: ubuntu-latest
 
@@ -174,3 +241,4 @@ jobs:
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
+        allowed-failures: devel-tests

--- a/test/integration/test_core_integration.py
+++ b/test/integration/test_core_integration.py
@@ -5,7 +5,6 @@ from ansible_runner.interface import run
 
 
 TEST_BRANCHES = (
-    'devel',
     'milestone',
     'stable-2.19',   # current stable
     'stable-2.18',   # stable - 1

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,10 @@ pytest_cov_args = --cov --cov-report html --cov-report term --cov-report xml
 
 [testenv]
 description = Run tests with {basepython}
-deps = ansible-core
-       -r {toxinidir}/test/requirements.txt
+deps =
+    !devel: ansible-core
+    {unit,integration}-devel: ansible-core @ https://github.com/ansible/ansible/archive/devel.tar.gz
+    -r {toxinidir}/test/requirements.txt
 passenv =
     HOME
     RUNNER_TEST_IMAGE_NAME
@@ -30,15 +32,13 @@ commands =
     mypy src/ansible_runner
     pylint src/ansible_runner test
 
-[testenv:unit{,-py310,-py311,-py312,-py313,-py314}]
+[testenv:unit{,-py310,-py311,-py312,-py313,-py314,-devel}]
 description = Run unit tests
 commands =
     pytest test/unit -vv -n auto {[shared]pytest_cov_args} {posargs}
 
-[testenv:integration{,-py310,-py311,-py312,-py313,-py314}]
+[testenv:integration{,-py310,-py311,-py312,-py313,-py314,-devel}]
 description = Run integration tests
-deps =
-    {[testenv]deps}
 commands =
     pytest test/integration -vv -n auto {[shared]pytest_cov_args} {posargs}
 
@@ -51,6 +51,7 @@ commands =
 [testenv:clean]
 description = Erase docs and coverage artifacts
 skip_install = True
+base =
 allowlist_externals = /bin/sh
 commands =
     /bin/sh -c "rm -rf {toxinidir}/test/coverage/*"


### PR DESCRIPTION
New unit and integration tests using `devel` branch of `ansible-core`.