### PR TITLE
Remove wheel building from CI (#1443)

### DIFF
--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,11 +1,9 @@
 # This is not fully compatible builder Dockerfile, but meets the needs of tests
 FROM quay.io/centos/centos:stream9
-ARG WHEEL
-COPY $WHEEL /$WHEEL
 RUN dnf install -y python3-pip
-RUN python3 -m pip install /$WHEEL ansible-core
+RUN python3 -m pip install ansible-core
 RUN mkdir -p /runner/{env,inventory,project,artifacts} /home/runner/.ansible/tmp
 RUN chmod -R 777 /runner /home/runner
 WORKDIR /runner
 ENV HOME=/home/runner
-CMD ["ansible-runner", "run", "/runner"]
+CMD ["ansible", "--version"]

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -123,14 +123,6 @@ def container_image(request, cli, tmp_path):  # pylint: disable=W0621
         yield env_image_name
         return
 
-    cli(
-        ['pyproject-build', '-w', '-o', str(tmp_path)],
-        cwd=here.parent.parent,
-        bare=True,
-    )
-
-    wheel = next(tmp_path.glob('*.whl'))  # pylint: disable=R1708
-
     runtime = request.getfixturevalue('runtime')
     dockerfile_path = tmp_path / 'Dockerfile'
     dockerfile_path.write_text(
@@ -140,7 +132,7 @@ def container_image(request, cli, tmp_path):  # pylint: disable=W0621
     image_name = f'ansible-runner-{random_string}-event-test'
 
     cli(
-        [runtime, 'build', '--build-arg', f'WHEEL={wheel.name}', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)],
+        [runtime, 'build', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)],
         bare=True,
     )
     yield image_name
@@ -156,19 +148,17 @@ def container_image_devel(request, cli, tmp_path):  # pylint: disable=W0621
 
     DOCKERFILE = f"""
 FROM quay.io/centos/centos:stream9
-ARG WHEEL
-COPY $WHEEL /$WHEEL
 
 # Need python 3.11 minimum for devel
 RUN dnf install -y python3.11 python3.11-pip git
 RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 0
-RUN python3 -m pip install /$WHEEL git+https://github.com/ansible/ansible@{branch}
+RUN python3 -m pip install git+https://github.com/ansible/ansible@{branch}
 
 RUN mkdir -p /runner/{{env,inventory,project,artifacts}} /home/runner/.ansible/tmp
 RUN chmod -R 777 /runner /home/runner
 WORKDIR /runner
 ENV HOME=/home/runner
-CMD ["ansible-runner", "run", "/runner"]
+CMD ["ansible", "--version"]
 """
 
     try:
@@ -184,14 +174,6 @@ CMD ["ansible-runner", "run", "/runner"]
         yield env_image_name
         return
 
-    cli(
-        ['pyproject-build', '-w', '-o', str(tmp_path)],
-        cwd=here.parent.parent,
-        bare=True,
-    )
-
-    wheel = next(tmp_path.glob('*.whl'))  # pylint: disable=R1708
-
     runtime = request.getfixturevalue('runtime')
     dockerfile_path = tmp_path / 'Dockerfile'
     dockerfile_path.write_text(DOCKERFILE)
@@ -199,7 +181,7 @@ CMD ["ansible-runner", "run", "/runner"]
     image_name = f'ansible-runner-{random_string}-event-test'
 
     cli(
-        [runtime, 'build', '--build-arg', f'WHEEL={wheel.name}', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)],
+        [runtime, 'build', '--rm=true', '-t', image_name, '-f', str(dockerfile_path), str(tmp_path)],
         bare=True,
     )
     yield image_name


### PR DESCRIPTION
A wheel of the runner repo is built so that it can be installed into test containers. However, this isn't needed since only the ansible command (ansible-playbook) is executed.

(cherry picked from commit d5b8e1bef04ee7b2ed117fb4d4d0167af0b020ae)