### PR TITLE
Update core integration tests for 2.19 release

### DIFF
--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,5 +1,5 @@
 # This is not fully compatible builder Dockerfile, but meets the needs of tests
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream10
 RUN dnf install -y python3-pip
 RUN python3 -m pip install ansible-core
 RUN mkdir -p /runner/{env,inventory,project,artifacts} /home/runner/.ansible/tmp

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -147,13 +147,8 @@ def container_image_devel(request, cli, tmp_path):  # pylint: disable=W0621
     branch = request.getfixturevalue('branch')
 
     DOCKERFILE = f"""
-FROM quay.io/centos/centos:stream9
-
-# Need python 3.11 minimum for devel
-RUN dnf install -y python3.11 python3.11-pip git
-RUN alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 0
-RUN python3 -m pip install git+https://github.com/ansible/ansible@{branch}
-
+FROM quay.io/centos/centos:stream10
+RUN python3 -m pip install 'ansible-core @ https://github.com/ansible/ansible/archive/{branch}.tar.gz'
 RUN mkdir -p /runner/{{env,inventory,project,artifacts}} /home/runner/.ansible/tmp
 RUN chmod -R 777 /runner /home/runner
 WORKDIR /runner

--- a/test/integration/test_core_integration.py
+++ b/test/integration/test_core_integration.py
@@ -7,8 +7,8 @@ from ansible_runner.interface import run
 TEST_BRANCHES = (
     'devel',
     'milestone',
-    'stable-2.18',   # current stable
-    'stable-2.17',   # stable - 1
+    'stable-2.19',   # current stable
+    'stable-2.18',   # stable - 1
 )
 
 

--- a/test/integration/test_interface.py
+++ b/test/integration/test_interface.py
@@ -464,14 +464,6 @@ def test_get_role_list_within_container(project_fixtures, runtime, container_ima
     Test get_role_list() running in a container.
     """
     pdir = str(project_fixtures / 'music')
-    expected = {
-        "Into_The_Mystic": {
-            "collection": "",
-            "entry_points": {
-                "main": "The main entry point for the Into_The_Mystic role."
-            }
-        }
-    }
     container_kwargs = {
         'process_isolation_executable': runtime,
         'process_isolation': True,
@@ -479,7 +471,9 @@ def test_get_role_list_within_container(project_fixtures, runtime, container_ima
     }
     resp, _ = get_role_list(private_data_dir=pdir, playbook_dir="/runner/project", **container_kwargs)
     assert isinstance(resp, dict)
-    assert resp == expected
+    assert 'Into_The_Mystic' in resp
+    assert 'entry_points' in resp['Into_The_Mystic']
+    assert 'main' in resp['Into_The_Mystic']['entry_points']
 
 
 def test_get_role_argspec(project_fixtures):


### PR DESCRIPTION
- Bumps latest and stable core test branches in `test_core_integration.py`.
- Core 2.19 bumped minimum python version to 3.12, so modify containers to use `centos:stream10` that has 3.12 installed by default.
- Change to use git archive when installing core branches.
- Fixes and hardens a role test for minor role argspec changes that happened in the more recent core version.