### PR TITLE
feat: improve eof log messages when streaming

### DIFF
--- a/src/ansible_runner/streaming.py
+++ b/src/ansible_runner/streaming.py
@@ -344,8 +344,26 @@ class Processor:
         while True:
             try:
                 line = self._input.readline()
+                if len(line) == 0:
+                    self.status_callback({
+                        'status': 'error',
+                        'job_explanation': (
+                            'Unexpected empty line encountered during worker stream. '
+                            'Worker did not produce events or streaming was aborted, check execution node health.'
+                        )
+                    })
+                    break
+            except (OSError) as exc:
+                self.status_callback({
+                    'status': 'error',
+                    'job_explanation': (
+                        f'Failed to read from worker stream. Error: {exc}'
+                    )
+                })
+                break
+            try:
                 data = json.loads(line)
-            except (json.decoder.JSONDecodeError, IOError) as exc:
+            except (json.decoder.JSONDecodeError) as exc:
                 self.status_callback({
                     'status': 'error',
                     'job_explanation': (

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -517,3 +517,42 @@ def test_unparsable_really_big_line_processor(tmp_path):
         private_data_dir=process_dir,
         status_handler=status_receiver
     )
+
+
+def test_error_on_empty_line_processor(tmp_path):
+    process_dir = tmp_path / 'for_process'
+    process_dir.mkdir()
+    incoming_buffer = io.BytesIO(b'')
+
+    def status_receiver(status_data, runner_config):  # pylint: disable=unused-argument
+        assert status_data['status'] == 'error'
+        assert (
+            'Unexpected empty line encountered during worker stream. '
+            'Worker did not produce events or streaming was aborted, check execution node health.'
+        ) in status_data['job_explanation']
+
+    run(
+        streamer='process',
+        _input=incoming_buffer,
+        private_data_dir=process_dir,
+        status_handler=status_receiver,
+    )
+
+
+def test_error_on_os_error_processor(tmp_path, mocker):
+    process_dir = tmp_path / 'for_process'
+    process_dir.mkdir()
+
+    incoming_buffer = mocker.Mock()
+    incoming_buffer.readline.side_effect = OSError("Simulated OS error")
+
+    def status_receiver(status_data, runner_config):  # pylint: disable=unused-argument
+        assert status_data['status'] == 'error'
+        assert 'Failed to read from worker stream. Error: Simulated OS error' in status_data['job_explanation']
+
+    run(
+        streamer='process',
+        _input=incoming_buffer,
+        private_data_dir=process_dir,
+        status_handler=status_receiver,
+    )


### PR DESCRIPTION
The reason of this change is to provide a meaningful error message whenever the streaming of logs gets aborted.

Multiple users have reported that a simple trace mentioning that an empty line is not valid JSON is not helpful to understand that in most cases, the infrastructure under the hood is experiencing problems.