### PR TITLE
Update for Python 3.14 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,12 @@ jobs:
         # NOTE: The latest and the lowest supported Pythons are prioritized
         # NOTE: to improve the responsiveness. It's nice to see the most
         # NOTE: important results first.
-        - 3.13
+        - 3.14
         - >-
           3.10
-        - 3.12
         - 3.11
-        - ~3.14.0-0
+        - 3.12
+        - 3.13
         runner-vm-os:
         - ubuntu-24.04
         toxenv:
@@ -171,7 +171,7 @@ jobs:
         }}
       matrix:
         python-version:
-        - 3.13
+        - 3.14
         runner-vm-os:
         - ubuntu-24.04
         toxenv:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Systems Administration",


### PR DESCRIPTION
Update for official Python 3.14 release. Also change `ansible-core` devel branch tests to use 3.14.