### PR TITLE
Remove references to Python < 3.10

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@
 Installing Ansible Runner
 =========================
 
-Ansible Runner requires Python >= 3.9 and is provided from several different locations depending on how you want to use it.
+Ansible Runner requires Python >= 3.10 and is provided from several different locations depending on how you want to use it.
 
 Using pip
 ---------

--- a/src/ansible_runner/utils/base64io.py
+++ b/src/ansible_runner/utils/base64io.py
@@ -13,6 +13,14 @@
 """Base64 stream with context manager support."""
 from __future__ import division
 
+from types import TracebackType
+from typing import (
+    AnyStr,
+    IO,
+    Optional,
+    Type,
+)
+
 import base64
 import io
 import logging
@@ -20,18 +28,6 @@ import string
 import math
 
 LOGGER_NAME = "base64io"
-
-try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
-    from types import TracebackType  # noqa pylint: disable=unused-import
-    from typing import (
-        IO,
-        AnyStr,
-        Optional,
-        Type,
-    )
-except ImportError:  # pragma: no cover
-    # We only actually need these imports when running the mypy checks
-    pass
 
 __all__ = ("Base64IO",)
 __version__ = "1.0.3"

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -182,7 +182,7 @@ class TestStreamingUsage:
                     if pending_payload_length:
                         # decode and check length to validate that we didn't trash the payload
                         # zap the mashed eof message from the end if present
-                        line = line.rsplit('{"eof": true}', 1)[0]  # FUTURE: change this to removesuffix for 3.9+
+                        line = line.removesuffix('{"eof": true}')
                         assert pending_payload_length == len(base64.b64decode(line))
                         pending_payload_length = 0  # back to normal
                         continue


### PR DESCRIPTION
Update documentation and code still referencing older versions of Python.