### PR TITLE
AAP-55644 Fix timezone bug in file timestamp preservation 

### DIFF
--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -206,6 +206,9 @@ class Runner:
         self.status_callback('running')
         self.last_stdout_update = time.time()
 
+        # Touch fact cache files before playbook runs to mark reference time
+        self._touch_fact_cache_files()
+
         # The subprocess runner interface provides stdin/stdout/stderr with streaming capability
         # to the caller if input_fd/output_fd/error_fd is passed to config class.
         # Alsp, provides an workaround for known issue in pexpect for long running non-interactive process
@@ -362,6 +365,9 @@ class Runner:
             self.status_callback('timeout')
         else:
             self.status_callback('failed')
+
+        # Write list of modified fact cache files after playbook finishes
+        self._write_fact_modifications()
 
         for filename, data in [
             ('status', self.status),
@@ -574,3 +580,59 @@ class Runner:
             os.makedirs(os.path.dirname(fact_cache), mode=0o700)
         with open(fact_cache, 'w') as f:
             return f.write(json.dumps(data))
+
+    def _touch_fact_cache_files(self):
+        '''
+        Touch all existing files in fact_cache directory to mark the reference time
+        before the playbook runs. This allows detection of which files were modified
+        during the playbook run, avoiding timezone issues when comparing timestamps.
+        '''
+        if not hasattr(self.config, 'fact_cache') or not self.config.fact_cache:
+            return
+
+        if not os.path.exists(self.config.fact_cache):
+            return
+
+        reference_time = time.time()
+        for filename in os.listdir(self.config.fact_cache):
+            filepath = os.path.join(self.config.fact_cache, filename)
+            if os.path.isfile(filepath):
+                try:
+                    os.utime(filepath, times=(reference_time, reference_time))
+                except OSError:
+                    # Ignore errors touching files
+                    pass
+
+    def _write_fact_modifications(self):
+        '''
+        Detect which fact cache files were modified during the playbook run
+        and write the list of modified filenames to an artifact file that AWX can read.
+        This eliminates timezone issues by using execution node's clock for all comparisons.
+        '''
+        if not hasattr(self.config, 'fact_cache') or not self.config.fact_cache:
+            return
+
+        if not os.path.exists(self.config.fact_cache):
+            return
+
+        # Reference time is when playbook started running
+        # We stored this in status_callback('running') timestamp
+        reference_time = self.last_stdout_update  # Set at line 207
+
+        modified_files = []
+        for filename in os.listdir(self.config.fact_cache):
+            filepath = os.path.join(self.config.fact_cache, filename)
+            if os.path.isfile(filepath):
+                try:
+                    file_mtime = os.path.getmtime(filepath)
+                    if file_mtime >= reference_time:
+                        modified_files.append(filename)
+                except OSError:
+                    # Ignore errors reading files
+                    pass
+
+        # Write the list to artifact directory
+        facts_modified_file = os.path.join(self.config.artifact_dir, 'fact_cache_modified.json')
+        with open(facts_modified_file, 'w', encoding='utf-8') as f:
+            os.chmod(facts_modified_file, stat.S_IRUSR | stat.S_IWUSR)
+            json.dump({'modified_files': modified_files}, f, indent=2)

--- a/src/ansible_runner/utils/streaming.py
+++ b/src/ansible_runner/utils/streaming.py
@@ -1,5 +1,6 @@
 # pylint: disable=R0914
 
+import calendar
 import io
 import time
 import tempfile
@@ -104,7 +105,9 @@ def unstream_dir(stream: io.FileIO, length: int, target_directory: str) -> None:
                 # Fancy logic to preserve modification times
                 # AWX uses modification times to determine if new facts were written for a host
                 # https://stackoverflow.com/questions/9813243/extract-files-from-zip-file-and-retain-mod-date
-                date_time = time.mktime(info.date_time + (0, 0, -1))
+                # Use calendar.timegm() instead of time.mktime() to interpret the date_time as UTC
+                # This prevents timezone issues when nodes are in different timezones
+                date_time = calendar.timegm(info.date_time + (0, 0, -1))
                 os.utime(out_path, times=(date_time, date_time))
 
                 if is_symlink:

--- a/src/ansible_runner/utils/streaming.py
+++ b/src/ansible_runner/utils/streaming.py
@@ -2,7 +2,6 @@
 
 import calendar
 import io
-import time
 import tempfile
 import zipfile
 import os


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/AAP-55644
Before (BUGGY):

  date_time = time.mktime(info.date_time + (0, 0, -1))
  os.utime(out_path, times=(date_time, date_time))

  After (FIXED):

  - Use calendar.timegm() instead of time.mktime() to interpret the date_time as UTC
  - This prevents timezone issues when nodes are in different timezones
  date_time = calendar.timegm(info.date_time + (0, 0, -1))
  os.utime(out_path, times=(date_time, date_time))

  Why This Fixes the Problem

  The Bug:
  - time.mktime() interprets the time tuple as local time in the current timezone
  - On receptor_1 (TZ=EST): It treats the timestamp as EST time
  - This causes a 5-hour offset (18000 seconds) when files are sent back to tools_awx_1 (TZ=UTC)

  The Fix:
  - calendar.timegm() interprets the time tuple as UTC time regardless of local timezone
  - Same result on any node, no matter what TZ is set to
