### PR TITLE
fix: make rotate_artifacts accessible from settings file

### DIFF
--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -281,6 +281,7 @@ class BaseConfig:
 
         self.suppress_output_file = self.settings.get('suppress_output_file', False)
         self.suppress_ansible_output = self.settings.get('suppress_ansible_output', self.quiet)
+        self.rotate_artifacts = self.settings.get('rotate_artifacts', self.rotate_artifacts)
 
         if 'fact_cache' in self.settings:
             if 'fact_cache_type' in self.settings:


### PR DESCRIPTION
fixes #1415

added rotate_artifacts to the settings loading section so it can be configured via the settings file, matching the pattern used by other config options like suppress_output_file and container_options.

now you can set rotate_artifacts in your settings file and it'll work as expected.