### PR TITLE
docs: add GitHub repository link to community page

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -27,3 +27,10 @@ Search by categories and tags to find interesting topics or start a new one; sub
 * `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
 
 See `Navigating the Ansible forum <https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39>`_ for some practical advice on finding your way around.
+
+Source Code
+-----------
+
+The ansible-runner source code is hosted on GitHub. Contributions, bug reports, and feature requests are welcome!
+
+* `GitHub Repository <https://github.com/ansible/ansible-runner>`_: Browse the source code, open issues, or submit pull requests.


### PR DESCRIPTION
## Summary
adds a link to the github repo in the community docs page since there wasn't one before

## Test plan
- ran local docs build to verify rst syntax
- checked that the new section fits with existing community page structure

fixes #1474