### PR TITLE
Initial testing support for Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         - 3.11
         - 3.12
         - 3.13
+        - ~3.15.0-0
         runner-vm-os:
         - ubuntu-24.04
         toxenv:

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,4 +10,6 @@ addopts =
     --durations 10
     --durations-min 1
     --strict-markers
-    -Werror
+filterwarnings =
+    error
+    ignore:.*may lead to deadlocks in the child.*:DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ passenv =
 usedevelop = True
 commands = pytest -vv -n auto {posargs}
 
-[testenv:linters{,-py310,-py311,-py312,-py313,-py314}]
+[testenv:linters{,-py310,-py311,-py312,-py313,-py314,-py315}]
 description = Run code linters
 commands =
     flake8 --version
@@ -32,12 +32,12 @@ commands =
     mypy src/ansible_runner
     pylint src/ansible_runner test
 
-[testenv:unit{,-py310,-py311,-py312,-py313,-py314,-devel}]
+[testenv:unit{,-py310,-py311,-py312,-py313,-py314,-py315,-devel}]
 description = Run unit tests
 commands =
     pytest test/unit -vv -n auto {[shared]pytest_cov_args} {posargs}
 
-[testenv:integration{,-py310,-py311,-py312,-py313,-py314,-devel}]
+[testenv:integration{,-py310,-py311,-py312,-py313,-py314,-py315,-devel}]
 description = Run integration tests
 commands =
     pytest test/integration -vv -n auto {[shared]pytest_cov_args} {posargs}


### PR DESCRIPTION
- Add Python 3.15 to CI.
- Ignore a `DeprecationWarning` emitted from the use of `pexpect`.