### PR TITLE
📦 Fix `setuptools-scm` warnings on git archival

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
+# do not include the `.git_archival.txt` file in sdist builds from repo source
+# this avoids setuptools-scm warnings on development builds
+exclude .git_archival.txt
 
-include README.md
-include LICENSE.md
+# furthermore do not include the `MANIFEST.in` file itself in sdist builds from
+# repo source to avoid the following setuptools warning on development builds:
+# warning: no previously-included files found matching '.git_archival.txt'
+exclude MANIFEST.in


### PR DESCRIPTION
Prior to this patch, `python -Im build` would emit warnings regarding `.git_archival.txt` having not been templated that look as follows:

```console
$ python -Im build -vv 2>&1 | grep -i warni
/tmp/build-env-m3vufmd9/lib/python3.14/site-packages/setuptools_scm/git.py:427: UserWarning: git archive did not support describe output
  warnings.warn("git archive did not support describe output")
/tmp/build-env-m3vufmd9/lib/python3.14/site-packages/setuptools_scm/git.py:445: UserWarning: unprocessed git archival found (no export subst applied)
  warnings.warn("unprocessed git archival found (no export subst applied)")
/tmp/build-env-m3vufmd9/lib/python3.14/site-packages/setuptools_scm/git.py:427: UserWarning: git archive did not support describe output
  warnings.warn("git archive did not support describe output")
/tmp/build-env-m3vufmd9/lib/python3.14/site-packages/setuptools_scm/git.py:445: UserWarning: unprocessed git archival found (no export subst applied)
  warnings.warn("unprocessed git archival found (no export subst applied)")
```

This change addressed that by excluding said file from sdists produced from within Git checkouts so the file only exists when exported into an archive. `MANIFEST.in` itself is excluded due to a cascading warning its presence introduces while fixing the original one.

ctx: https://github.com/jazzband/pip-tools/pull/2261#discussion_r2492999145