### PR TITLE
Remove fact cache API

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Examples of this could include:
    intro
    install
    community
+   porting_guides/porting_guide
    external_interface
    standalone
    python_interface

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -141,8 +141,6 @@ The **settings** file is a little different than the other files provided in thi
 
 * ``suppress_output_file``: ``False`` Allow output from ansible to not be streamed to the ``stdout`` or ``stderr`` files inside of the artifacts directory.
 * ``suppress_ansible_output``: ``False`` Allow output from ansible to not be printed to the screen.
-* ``fact_cache``: ``'fact_cache'`` The directory relative to ``artifacts`` where ``jsonfile`` fact caching will be stored.  Defaults to ``fact_cache``.  This is ignored if ``fact_cache_type`` is different than ``jsonfile``.
-* ``fact_cache_type``: ``'jsonfile'`` The type of fact cache to use.  Defaults to ``jsonfile``.
 
 Process Isolation Settings for Runner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,8 +213,6 @@ The artifact directory itself contains a particular structure that provides a lo
     .
     ├── artifacts
     │   └── 37f639a3-1f4f-4acb-abee-ea1898013a25
-    │       ├── fact_cache
-    │       │   └── localhost
     │       ├── job_events
     │       │   ├── 1-34437b34-addd-45ae-819a-4d8c9711e191.json
     │       │   ├── 2-8c164553-8573-b1e0-76e1-000000000006.json

--- a/docs/porting_guides/porting_guide.rst
+++ b/docs/porting_guides/porting_guide.rst
@@ -1,0 +1,12 @@
+*****************************
+Ansible Runner Porting Guides
+*****************************
+
+This section lists porting guides that contain useful information to consider when upgrading to newer
+versions of Ansible Runner.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   porting_guide_v2.5

--- a/docs/porting_guides/porting_guide_v2.5.rst
+++ b/docs/porting_guides/porting_guide_v2.5.rst
@@ -1,0 +1,37 @@
+********************************
+Ansible Runner 2.5 Porting Guide
+********************************
+
+This section discusses the behavioral changes between Ansible Runner version 2.4 and version 2.5.
+
+API Changes
+===========
+
+Fact Cache API Removal
+-----------------------
+
+Ansible Runner previously provided APIs for setting and reading values from the Ansible fact cache. However, this
+functionality relied on internal implementation details of the fact cache that were never part of Ansible's public
+API. With the release of ``ansible-core`` version 2.19, changes to the fact cache implementation broke this
+functionality in Ansible Runner.
+
+Since the fact cache APIs in Ansible Runner depended on undocumented behavior, they have been removed in version 2.5.
+This change affects the following interface functions, where the ``fact_cache`` and ``fact_cache_type`` parameters
+have been removed:
+
+  - `interface.run()`
+  - `interface.run_async()`
+  - `interface.run_command()`
+  - `interface.run_command_async()`
+  - `interface.get_ansible_config()`
+  - `interface.get_inventory()`
+  - `interface.get_plugin_docs()`
+  - `interface.get_plugin_docs_async()`
+  - `interface.get_plugin_list()`
+  - `interface.get_role_argspec()`
+  - `interface.get_role_list()`
+
+Additionally, the following methods have been removed from the ``runner.Runner`` class:
+
+  - ``set_fact_cache()``
+  - ``get_fact_cache()``

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -165,11 +165,6 @@ will return an open file handle containing the ``stderr`` of the **Ansible** pro
 ----------------------
 :meth:`ansible_runner.runner.Runner.host_events` is a method that, given a hostname, will return a list of only **Ansible** event data executed on that Host.
 
-``Runner.get_fact_cache``
--------------------------
-
-:meth:`ansible_runner.runner.Runner.get_fact_cache` is a method that, given a hostname, will return a dictionary containing the `Facts <https://docs.ansible.com/projects/ansible/latest/user_guide/playbooks_variables.html#variables-discovered-from-systems-facts>`_ stored for that host during execution.
-
 ``Runner.event_handler``
 ------------------------
 

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -71,8 +71,6 @@ class BaseConfig:
                  settings=None,
                  project_dir: str | None = None,
                  artifact_dir: str | None = None,
-                 fact_cache_type: str = 'jsonfile',
-                 fact_cache=None,
                  process_isolation: bool = False,
                  process_isolation_executable: str | None = None,
                  container_image: str = "",
@@ -149,9 +147,6 @@ class BaseConfig:
             self.project_dir = project_dir
 
         self.rotate_artifacts = rotate_artifacts
-        self.fact_cache_type = fact_cache_type
-        self.fact_cache = os.path.join(self.artifact_dir, fact_cache or 'fact_cache') if self.fact_cache_type == 'jsonfile' else None
-
         self.loader = ArtifactLoader(self.private_data_dir)
 
         if self.host_cwd:
@@ -249,8 +244,6 @@ class BaseConfig:
 
             artifact_dir = os.path.join("/runner/artifacts", self.ident)
             self.env['AWX_ISOLATED_DATA_DIR'] = artifact_dir
-            if self.fact_cache_type == 'jsonfile':
-                self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = os.path.join(artifact_dir, 'fact_cache')
 
         else:
             # seed env with existing shell env
@@ -281,13 +274,6 @@ class BaseConfig:
 
         self.suppress_output_file = self.settings.get('suppress_output_file', False)
         self.suppress_ansible_output = self.settings.get('suppress_ansible_output', self.quiet)
-
-        if 'fact_cache' in self.settings:
-            if 'fact_cache_type' in self.settings:
-                if self.settings['fact_cache_type'] == 'jsonfile':
-                    self.fact_cache = os.path.join(self.artifact_dir, self.settings['fact_cache'])
-            else:
-                self.fact_cache = os.path.join(self.artifact_dir, self.settings['fact_cache'])
 
         # Use local callback directory
         if self.containerized:
@@ -326,11 +312,6 @@ class BaseConfig:
             self.env['ANSIBLE_HOST_KEY_CHECKING'] = 'False'
         if not self.containerized:
             self.env['AWX_ISOLATED_DATA_DIR'] = self.artifact_dir
-
-        if self.fact_cache_type == 'jsonfile':
-            self.env['ANSIBLE_CACHE_PLUGIN'] = 'jsonfile'
-            if not self.containerized:
-                self.env['ANSIBLE_CACHE_PLUGIN_CONNECTION'] = self.fact_cache
 
         # Pexpect will error with non-string envvars types, so we ensure string types
         self.env = {str(k): str(v) for k, v in self.env.items()}

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -197,13 +197,6 @@ class RunnerConfig(BaseConfig):
             else:
                 self.cwd = self.project_dir
 
-        if 'fact_cache' in self.settings:
-            if 'fact_cache_type' in self.settings:
-                if self.settings['fact_cache_type'] == 'jsonfile':
-                    self.fact_cache = os.path.join(self.artifact_dir, self.settings['fact_cache'])
-            else:
-                self.fact_cache = os.path.join(self.artifact_dir, self.settings['fact_cache'])
-
         if self.roles_path:
             if isinstance(self.roles_path, list):
                 self.env['ANSIBLE_ROLES_PATH'] = ':'.join(self.roles_path)

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -198,9 +198,6 @@ def run(**kwargs):
     :param list container_options: List of container options to pass to execution engine.
     :param str directory_isolation_base_path: An optional path will be used as the base path to create a temp directory, the project contents will be
                                           copied to this location which will then be used as the working directory during playbook execution.
-    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param str fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param bool omit_event_data: Omits extra ansible event data from event payload (stdout and event still included)
     :param bool only_failed_event_data: Omits extra ansible event data unless it's a failed event (stdout and event still included)
     :param bool check_job_event_data: Check if job events data is completely generated. If event data is not completely generated and if
@@ -290,9 +287,6 @@ def run_command(executable_cmd, cmdline_args=None, **kwargs):
     :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir:labels. (default: None)
     :param list container_options: List of container options to pass to execution engine.
     :param str container_workdir: The working directory within the container.
-    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param str fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param str private_data_dir: The directory containing all runner metadata needed to invoke the runner
                              module. Output artifacts will also be stored here for later consumption.
     :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
@@ -394,9 +388,6 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :param container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir:labels. (default: None)
     :param container_options: List of container options to pass to execution engine.
     :param container_workdir: The working directory within the container.
-    :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param private_data_dir: The directory containing all runner metadata needed to invoke the runner
                              module. Output artifacts will also be stored here for later consumption.
     :param ident: The run identifier for this invocation of Runner. Will be used to create and name
@@ -424,8 +415,6 @@ def get_plugin_docs(plugin_names, plugin_type=None, response_format=None, snippe
     :type private_data_dir: str
     :type project_dir: str
     :type artifact_dir: str
-    :type fact_cache_type: str
-    :type fact_cache: str
     :type process_isolation: bool
     :type process_isolation_executable: str
     :type container_image: str
@@ -512,9 +501,6 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :param container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir:labels. (default: None)
     :param container_options: List of container options to pass to execution engine.
     :param container_workdir: The working directory within the container.
-    :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param private_data_dir: The directory containing all runner metadata needed to invoke the runner
                              module. Output artifacts will also be stored here for later consumption.
     :param ident: The run identifier for this invocation of Runner. Will be used to create and name
@@ -541,8 +527,6 @@ def get_plugin_list(list_files=None, response_format=None, plugin_type=None, pla
     :type private_data_dir: str
     :type project_dir: str
     :type artifact_dir: str
-    :type fact_cache_type: str
-    :type fact_cache: str
     :type process_isolation: bool
     :type process_isolation_executable: str
     :type container_image: str
@@ -633,9 +617,6 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :param container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir:labels. (default: None)
     :param container_options: List of container options to pass to execution engine.
     :param container_workdir: The working directory within the container.
-    :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param private_data_dir: The directory containing all runner metadata needed to invoke the runner
                              module. Output artifacts will also be stored here for later consumption.
     :param ident: The run identifier for this invocation of Runner. Will be used to create and name
@@ -665,8 +646,6 @@ def get_inventory(action, inventories, response_format=None, host=None, playbook
     :type private_data_dir: str
     :type project_dir: str
     :type artifact_dir: str
-    :type fact_cache_type: str
-    :type fact_cache: str
     :type process_isolation: bool
     :type process_isolation_executable: str
     :type container_image: str
@@ -748,9 +727,6 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :param container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir:labels. (default: None)
     :param container_options: List of container options to pass to execution engine.
     :param container_workdir: The working directory within the container.
-    :param fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param private_data_dir: The directory containing all runner metadata needed to invoke the runner
                              module. Output artifacts will also be stored here for later consumption.
     :param ident: The run identifier for this invocation of Runner. Will be used to create and name
@@ -774,8 +750,6 @@ def get_ansible_config(action, config_file=None, only_changed=None, **kwargs):
     :type private_data_dir: str
     :type project_dir: str
     :type artifact_dir: str
-    :type fact_cache_type: str
-    :type fact_cache: str
     :type process_isolation: bool
     :type process_isolation_executable: str
     :type container_image: str
@@ -853,9 +827,6 @@ def get_role_list(collection=None, playbook_dir=None, **kwargs):
     :param list container_volume_mounts: List of bind mounts in the form ``host_dir:/container_dir:labels``. (default: None)
     :param list container_options: List of container options to pass to execution engine.
     :param str container_workdir: The working directory within the container.
-    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param str fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param str private_data_dir: The directory containing all runner metadata needed to invoke the runner
         module. Output artifacts will also be stored here for later consumption.
     :param str ident: The run identifier for this invocation of Runner. Will be used to create and name
@@ -931,9 +902,6 @@ def get_role_argspec(role, collection=None, playbook_dir=None, **kwargs):
     :param list container_volume_mounts: List of bind mounts in the form ``host_dir:/container_dir:labels``. (default: None)
     :param list container_options: List of container options to pass to execution engine.
     :param str container_workdir: The working directory within the container.
-    :param str fact_cache: A string that will be used as the name for the subdirectory of the fact cache in artifacts directory.
-                       This is only used for 'jsonfile' type fact caches.
-    :param str fact_cache_type: A string of the type of fact cache to use.  Defaults to 'jsonfile'.
     :param str private_data_dir: The directory containing all runner metadata needed to invoke the runner
         module. Output artifacts will also be stored here for later consumption.
     :param str ident: The run identifier for this invocation of Runner. Will be used to create and name

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -550,27 +550,3 @@ class Runner:
             os.remove(pidfile)
         except (TypeError, OSError):
             pass
-
-    def get_fact_cache(self, host):
-        '''
-        Get the entire fact cache only if the fact_cache_type is 'jsonfile'
-        '''
-        if self.config.fact_cache_type != 'jsonfile':
-            raise Exception('Unsupported fact cache type.  Only "jsonfile" is supported for reading and writing facts from ansible-runner')
-        fact_cache = os.path.join(self.config.fact_cache, host)
-        if os.path.exists(fact_cache):
-            with open(fact_cache) as f:
-                return json.loads(f.read())
-        return {}
-
-    def set_fact_cache(self, host, data):
-        '''
-        Set the entire fact cache data only if the fact_cache_type is 'jsonfile'
-        '''
-        if self.config.fact_cache_type != 'jsonfile':
-            raise Exception('Unsupported fact cache type.  Only "jsonfile" is supported for reading and writing facts from ansible-runner')
-        fact_cache = os.path.join(self.config.fact_cache, host)
-        if not os.path.exists(os.path.dirname(fact_cache)):
-            os.makedirs(os.path.dirname(fact_cache), mode=0o700)
-        with open(fact_cache, 'w') as f:
-            return f.write(json.dumps(data))

--- a/test/integration/test_runner.py
+++ b/test/integration/test_runner.py
@@ -233,40 +233,6 @@ def test_run_command_ansible_rotate_artifacts(rc):
     assert exitcode == 0
 
 
-def test_get_fact_cache(rc, skipif_ansible_219_or_higher):  # pylint: disable=W0613
-    assert os.path.basename(rc.fact_cache) == 'fact_cache'
-    rc.module = "setup"
-    rc.host_pattern = "localhost"
-    rc.prepare()
-    runner = Runner(config=rc)
-    status, exitcode = runner.run()
-    assert status == 'successful'
-    assert exitcode == 0
-    print(rc.cwd)
-    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache'))
-    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache', 'localhost'))
-    data = runner.get_fact_cache('localhost')
-    assert data
-
-
-def test_set_fact_cache(rc, skipif_ansible_219_or_higher):  # pylint: disable=W0613
-    assert os.path.basename(rc.fact_cache) == 'fact_cache'
-    rc.module = "debug"
-    rc.module_args = "var=message"
-    rc.host_pattern = "localhost"
-    rc.prepare()
-    runner = Runner(config=rc)
-    runner.set_fact_cache('localhost', {'message': 'hello there'})
-    status, exitcode = runner.run()
-    assert status == 'successful'
-    assert exitcode == 0
-    print(rc.cwd)
-    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache'))
-    assert os.path.exists(os.path.join(rc.artifact_dir, 'fact_cache', 'localhost'))
-    data = runner.get_fact_cache('localhost')
-    assert data['message'] == 'hello there'
-
-
 def test_set_extra_vars(rc):
     rc.module = "debug"
     rc.module_args = "var=test_extra_vars"

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -27,7 +27,6 @@ def test_base_config_init_defaults(tmp_path):
     assert rc.private_data_dir == tmp_path.as_posix()
     assert rc.ident is not None
     assert rc.process_isolation is False
-    assert rc.fact_cache_type == 'jsonfile'
     assert rc.json_mode is False
     assert rc.quiet is False
     assert rc.quiet is False


### PR DESCRIPTION
* Removes fact cache API functionality
* Adds porting guides to the documentation, with a new guide for unreleased 2.5 version.