### PR TITLE
CI test fixes: update Python for test container and add image prune retry

### DIFF
--- a/src/ansible_runner/cleanup.py
+++ b/src/ansible_runner/cleanup.py
@@ -179,23 +179,20 @@ def cleanup_images(images: list, runtime: str) -> int:
     return rm_ct
 
 
-def prune_images(runtime: str, retries: int = 1, retry_interval: float | int = .5) -> bool:
-    """Run the prune images command and return changed status"""
-    retries = max(retries, 0)
-    count = retries + 1
-    while True:
+def prune_images(runtime: str) -> bool:
+    """
+    Run the prune images command.
+
+    Since stopped containers may not be removed immediately, just try again, a couple of seconds max.
+    """
+    for attempt in range(1, 5):
         try:
-            stdout = run_command([runtime, 'image', 'prune', '-f'])
-            if not stdout or stdout == "Total reclaimed space: 0B":
-                return False
-            return True
-        except RuntimeError as e:
-            # Image pruning can fail if a container exists that used an image. Since stopped
-            # containers may not be removed immediately, we might need to just try again.
-            count -= 1
-            time.sleep(retry_interval)
-            if count == 0:
-                raise e
+            run_command([runtime, 'image', 'prune', '-f'])
+        except RuntimeError:
+            if attempt == 4:
+                raise
+            time.sleep(.5)
+    return True
 
 
 def run_cleanup(vargs: dict) -> None:

--- a/src/ansible_runner/cleanup.py
+++ b/src/ansible_runner/cleanup.py
@@ -7,6 +7,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 from pathlib import Path
 from tempfile import gettempdir
@@ -178,12 +179,23 @@ def cleanup_images(images: list, runtime: str) -> int:
     return rm_ct
 
 
-def prune_images(runtime: str) -> bool:
+def prune_images(runtime: str, retries: int = 1, retry_interval: float | int = .5) -> bool:
     """Run the prune images command and return changed status"""
-    stdout = run_command([runtime, 'image', 'prune', '-f'])
-    if not stdout or stdout == "Total reclaimed space: 0B":
-        return False
-    return True
+    retries = max(retries, 0)
+    count = retries + 1
+    while True:
+        try:
+            stdout = run_command([runtime, 'image', 'prune', '-f'])
+            if not stdout or stdout == "Total reclaimed space: 0B":
+                return False
+            return True
+        except RuntimeError as e:
+            # Image pruning can fail if a container exists that used an image. Since stopped
+            # containers may not be removed immediately, we might need to just try again.
+            count -= 1
+            time.sleep(retry_interval)
+            if count == 0:
+                raise e
 
 
 def run_cleanup(vargs: dict) -> None:

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -146,9 +146,11 @@ def container_image(request, cli, tmp_path):  # pylint: disable=W0621
 def container_image_devel(request, cli, tmp_path):  # pylint: disable=W0621
     branch = request.getfixturevalue('branch')
 
+    # ansible-core > 2.21 requires python 3.13 or higher
     DOCKERFILE = f"""
 FROM quay.io/centos/centos:stream10
-RUN dnf install -y python3-pip
+RUN dnf install -y python3.14 python3.14-pip
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.14 10
 RUN python3 -m pip install 'ansible-core @ https://github.com/ansible/ansible/archive/{branch}.tar.gz'
 RUN mkdir -p /runner/{{env,inventory,project,artifacts}} /home/runner/.ansible/tmp
 RUN chmod -R 777 /runner /home/runner


### PR DESCRIPTION
We haven't had a PR in a while, so tests have decayed:

- The `milestone` branch was failing `test_core_integration.py` tests because the version of Python in the test container image was 3.12, but 3.13 or higher is required.
- The `test_cleanup_images.py::test_cleanup_new_image` was failing `integration-devel` tests because `prune_image()` was failing due to a delay within Podman of cleaning up the stopped container. The change above seems to have exposed this clean up delay for $insertCrazyReasonHere, even though it passes in other integration tests, so build in a retry. Add retries, with a quick interval, for a better user experience. Re-raise the same `RuntimeError` exception after retries are exhausted to not break the API.