### PR TITLE
CI test fixes: add image prune retry (#1517)

### DIFF
--- a/src/ansible_runner/cleanup.py
+++ b/src/ansible_runner/cleanup.py
@@ -7,6 +7,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 from pathlib import Path
 from tempfile import gettempdir
@@ -179,10 +180,18 @@ def cleanup_images(images: list, runtime: str) -> int:
 
 
 def prune_images(runtime: str) -> bool:
-    """Run the prune images command and return changed status"""
-    stdout = run_command([runtime, 'image', 'prune', '-f'])
-    if not stdout or stdout == "Total reclaimed space: 0B":
-        return False
+    """
+    Run the prune images command.
+
+    Since stopped containers may not be removed immediately, just try again, a couple of seconds max.
+    """
+    for attempt in range(1, 5):
+        try:
+            run_command([runtime, 'image', 'prune', '-f'])
+        except RuntimeError:
+            if attempt == 4:
+                raise
+            time.sleep(.5)
     return True
 
 


### PR DESCRIPTION
Modified backport of PR #1517 

* add image prune retry

The `prune_images()` function was parsing command stdout to determine a True/False return value. That is fragile, and was broken, at least with Podman. Change to always return `True` to not break the API.

(cherry picked from commit 1f8dc37c00bed7a83bba285af522ba5a203a9c12)