### PR TITLE
Bump Ansible versions for test_core_integration tests (#1514)

### DIFF
--- a/test/integration/test_core_integration.py
+++ b/test/integration/test_core_integration.py
@@ -7,8 +7,8 @@ from ansible_runner.interface import run
 TEST_BRANCHES = (
     'devel',
     'milestone',
-    'stable-2.18',   # current stable
-    'stable-2.17',   # stable - 1
+    'stable-2.21',   # current stable
+    'stable-2.20',   # stable - 1
 )
 
 


### PR DESCRIPTION
Backport of PR #1514 

(cherry picked from commit 1a02e08291ca4a3ef30a0e36338dfd00c05eb016)