### PR TITLE
docs: clarify container volume mounts vs bwrap isolation paths

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -155,6 +155,10 @@ The process isolation settings are meant to control the process isolation featur
 * ``process_isolation_hide_paths``: ``None`` Path or list of paths on the system that should be hidden from the playbook run.
 * ``process_isolation_show_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run.
 * ``process_isolation_ro_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run as read-only.
+* ``container_volume_mounts``: ``None`` List of volume mounts to use when running inside a container engine (Docker or Podman). This should be used instead of the ``process_isolation_*_paths`` options for container environments.
+
+.. note::
+   The path-specific process isolation settings (``process_isolation_hide_paths``, ``process_isolation_show_paths``, and ``process_isolation_ro_paths``) only apply when using ``bwrap`` (Bubblewrap). They are ignored when executing tasks inside container engines like Docker or Podman.
 
 These settings instruct **Runner** to execute **Ansible** tasks inside a container environment.
 For information about building execution environments, see `ansible-builder <https://docs.ansible.com/projects/builder/en/latest/>`_.

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -190,11 +190,15 @@ def run(**kwargs):
     :param bool process_isolation: Enable process isolation, using either a container engine (e.g. podman) or a sandbox (e.g. bwrap).
     :param str process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param str process_isolation_path: Path that an isolated playbook run will use for staging. (default: /tmp)
-    :param str or list process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run. (Only applies to bwrap)
-    :param str or list process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run. (Only applies to bwrap)
-    :param str or list process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only. (Only applies to bwrap)
+    :param str or list process_isolation_hide_paths: A path or list of paths on the system that should be hidden
+        from the playbook run. (Only applies to bwrap)
+    :param str or list process_isolation_show_paths: A path or list of paths on the system that should be exposed
+        to the playbook run. (Only applies to bwrap)
+    :param str or list process_isolation_ro_paths: A path or list of paths on the system that should be exposed
+        to the playbook run as read-only. (Only applies to bwrap)
     :param str container_image: Container image to use when running an ansible task
-    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir'. This should be used instead of process_isolation_*_paths for container engines like Docker or Podman. (default: None)
+    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir'. This should be
+        used instead of process_isolation_*_paths for container engines like Docker or Podman. (default: None)
     :param list container_options: List of container options to pass to execution engine.
     :param str directory_isolation_base_path: An optional path will be used as the base path to create a temp directory, the project contents will be
                                           copied to this location which will then be used as the working directory during playbook execution.

--- a/src/ansible_runner/interface.py
+++ b/src/ansible_runner/interface.py
@@ -190,11 +190,11 @@ def run(**kwargs):
     :param bool process_isolation: Enable process isolation, using either a container engine (e.g. podman) or a sandbox (e.g. bwrap).
     :param str process_isolation_executable: Process isolation executable or container engine used to isolate execution. (default: podman)
     :param str process_isolation_path: Path that an isolated playbook run will use for staging. (default: /tmp)
-    :param str or list process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run.
-    :param str or list process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run.
-    :param str or list process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only.
+    :param str or list process_isolation_hide_paths: A path or list of paths on the system that should be hidden from the playbook run. (Only applies to bwrap)
+    :param str or list process_isolation_show_paths: A path or list of paths on the system that should be exposed to the playbook run. (Only applies to bwrap)
+    :param str or list process_isolation_ro_paths: A path or list of paths on the system that should be exposed to the playbook run as read-only. (Only applies to bwrap)
     :param str container_image: Container image to use when running an ansible task
-    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir. (default: None)
+    :param list container_volume_mounts: List of bind mounts in the form 'host_dir:/container_dir'. This should be used instead of process_isolation_*_paths for container engines like Docker or Podman. (default: None)
     :param list container_options: List of container options to pass to execution engine.
     :param str directory_isolation_base_path: An optional path will be used as the base path to create a temp directory, the project contents will be
                                           copied to this location which will then be used as the working directory during playbook execution.


### PR DESCRIPTION
### Summary
Fixes #757

This PR updates the documentation and API docstrings to clarify the distinction between process isolation paths and container volume mounts. 

Previously, the documentation implied that `process_isolation_*_paths` applied universally, which caused confusion for users running execution environments in Docker or Podman. 

### Changes made
* **`docs/intro.rst`**: Added a note clarifying that `process_isolation_hide_paths`, `process_isolation_show_paths`, and `process_isolation_ro_paths` only apply when using `bwrap`. Explicitly documented `container_volume_mounts` as the required alternative for container engines.
* **`src/ansible_runner/interface.py`**: Updated the `:param` docstrings to reflect this exact same distinction so developers referencing the Python API have the correct context. Also fixed a missing closing quote on the `container_volume_mounts` example string.