### PR TITLE
[ci]: Fix container usage in tests

### DIFF
--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-src-checkout/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-src-checkout/action.yml
@@ -19,12 +19,16 @@ runs:
   using: composite
   steps:
   - name: Build a wheel
-    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    if: >-
+      contains(fromJSON('["integration", "integration-devel"]'),
+      fromJSON(inputs.calling-job-context).toxenv)
     run: python3 -Im pip wheel --no-deps --wheel-dir=dist/ .
     shell: bash
 
   - name: Build a runner test container via docker
-    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    if: >-
+      contains(fromJSON('["integration", "integration-devel"]'),
+      fromJSON(inputs.calling-job-context).toxenv)
     run: >-
       docker build
       --build-arg "WHEEL=$(basename dist/ansible_runner*.whl)"
@@ -35,7 +39,9 @@ runs:
     shell: bash
 
   - name: Build a runner test container via podman
-    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    if: >-
+      contains(fromJSON('["integration", "integration-devel"]'),
+      fromJSON(inputs.calling-job-context).toxenv)
     run: >-
       podman build
       --build-arg "WHEEL=$(basename dist/ansible_runner*.whl)"

--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/prepare-for-tox-run/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/prepare-for-tox-run/action.yml
@@ -19,7 +19,9 @@ runs:
   using: composite
   steps:
   - name: Set the runner container image reference for testing
-    if: fromJSON(inputs.calling-job-context).toxenv == 'integration'
+    if: >-
+      contains(fromJSON('["integration", "integration-devel"]'),
+      fromJSON(inputs.calling-job-context).toxenv)
     env:
       RUNNER_TEST_IMAGE_NAME: ansible-runner-gha${{ github.run_id }}-event-test
     run: >-

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -144,6 +144,11 @@ def container_image(request, cli, tmp_path):  # pylint: disable=W0621
 
 @pytest.fixture
 def container_image_devel(request, cli, tmp_path):  # pylint: disable=W0621
+    """
+    Unlike the `container_image` fixture, we do not honor RUNNER_TEST_IMAGE_NAME here because
+    we want to make sure we always use the inline Dockerfile which is specific to the tests
+    in test_core_integration.py.
+    """
     branch = request.getfixturevalue('branch')
 
     # ansible-core > 2.21 requires python 3.13 or higher
@@ -167,10 +172,6 @@ CMD ["ansible", "--version"]
     except Exception:
         # Test func doesn't use containerized
         pass
-
-    if (env_image_name := os.getenv('RUNNER_TEST_IMAGE_NAME')):
-        yield env_image_name
-        return
 
     runtime = request.getfixturevalue('runtime')
     dockerfile_path = tmp_path / 'Dockerfile'


### PR DESCRIPTION
The `integration-devel` tests were not taking advantage of the pre-built container image that is specified by RUNNER_TEST_IMAGE_NAME, so it was not being reused.

The `container_image_devel` test fixture, meant for the Ansible core integration tests, wasn't properly being used because it was still honoring RUNNER_TEST_IMAGE_NAME. We had a mixed testing state where these tests DO work correctly for `integration-devel` since it wasn't receiving that env var, but for the other `integration` tests, they were not functioning correctly. This set of changes should make the testing world right again.