### PR TITLE
Add process_isolation_hide_envvars to unset variables in the bwrap sandbox

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -155,10 +155,11 @@ The process isolation settings are meant to control the process isolation featur
 * ``process_isolation_hide_paths``: ``None`` Path or list of paths on the system that should be hidden from the playbook run.
 * ``process_isolation_show_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run.
 * ``process_isolation_ro_paths``: ``None`` Path or list of paths on the system that should be exposed to the playbook run as read-only.
+* ``process_isolation_hide_envvars``: ``None`` Name pattern, or list of name patterns, of environment variables to unset inside the isolated playbook run. Patterns use :mod:`fnmatch` syntax and are matched case-sensitively against the environment the run would otherwise inherit, so an application embedding **Runner** can keep its own credentials (for example ``*_TOKEN`` or ``DATABASE_URL``) out of the sandbox without having to sanitize its own process environment.
 * ``container_volume_mounts``: ``None`` List of volume mounts to use when running inside a container engine (Docker or Podman). This should be used instead of the ``process_isolation_*_paths`` options for container environments.
 
 .. note::
-   The path-specific process isolation settings (``process_isolation_hide_paths``, ``process_isolation_show_paths``, and ``process_isolation_ro_paths``) only apply when using ``bwrap`` (Bubblewrap). They are ignored when executing tasks inside container engines like Docker or Podman.
+   The path-specific process isolation settings (``process_isolation_hide_paths``, ``process_isolation_show_paths``, and ``process_isolation_ro_paths``) and ``process_isolation_hide_envvars`` only apply when using ``bwrap`` (Bubblewrap). They are ignored when executing tasks inside container engines like Docker or Podman.
 
 These settings instruct **Runner** to execute **Ansible** tasks inside a container environment.
 For information about building execution environments, see `ansible-builder <https://docs.ansible.com/projects/builder/en/latest/>`_.

--- a/src/ansible_runner/config/runner.py
+++ b/src/ansible_runner/config/runner.py
@@ -19,6 +19,7 @@
 
 # pylint: disable=W0201
 
+import fnmatch
 import json
 import logging
 import os
@@ -67,7 +68,8 @@ class RunnerConfig(BaseConfig):
                  module=None, module_args=None, verbosity=None, host_pattern=None, binary=None,
                  extravars=None, suppress_output_file=False, suppress_ansible_output=False, process_isolation_path=None,
                  process_isolation_hide_paths=None, process_isolation_show_paths=None,
-                 process_isolation_ro_paths=None, tags=None, skip_tags=None,
+                 process_isolation_ro_paths=None, process_isolation_hide_envvars=None,
+                 tags=None, skip_tags=None,
                  directory_isolation_base_path=None, forks=None, cmdline=None, omit_event_data=False,
                  only_failed_event_data=False, **kwargs):
 
@@ -89,6 +91,7 @@ class RunnerConfig(BaseConfig):
         self.process_isolation_hide_paths = process_isolation_hide_paths
         self.process_isolation_show_paths = process_isolation_show_paths
         self.process_isolation_ro_paths = process_isolation_ro_paths
+        self.process_isolation_hide_envvars = process_isolation_hide_envvars
         self.directory_isolation_path = directory_isolation_base_path
         self.verbosity = verbosity
         self.suppress_output_file = suppress_output_file
@@ -186,6 +189,7 @@ class RunnerConfig(BaseConfig):
         self.process_isolation_hide_paths = self.settings.get('process_isolation_hide_paths', self.process_isolation_hide_paths)
         self.process_isolation_show_paths = self.settings.get('process_isolation_show_paths', self.process_isolation_show_paths)
         self.process_isolation_ro_paths = self.settings.get('process_isolation_ro_paths', self.process_isolation_ro_paths)
+        self.process_isolation_hide_envvars = self.settings.get('process_isolation_hide_envvars', self.process_isolation_hide_envvars)
         self.directory_isolation_path = self.settings.get('directory_isolation_base_path', self.directory_isolation_path)
         self.directory_isolation_cleanup = bool(self.settings.get('directory_isolation_cleanup', True))
 
@@ -326,6 +330,24 @@ class RunnerConfig(BaseConfig):
 
         return path
 
+    def sandbox_hidden_envvars(self):
+        '''
+        Names of environment variables to unset inside the sandbox.
+
+        Each entry of ``process_isolation_hide_envvars`` is a :mod:`fnmatch`
+        pattern matched case-sensitively against the names in the environment
+        the command would otherwise inherit.
+        '''
+        patterns = self.process_isolation_hide_envvars
+        if not patterns:
+            return set()
+        if isinstance(patterns, str):
+            patterns = [patterns]
+        return {
+            name for name in (self.env or {})
+            if any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+        }
+
     def wrap_args_for_sandbox(self, args):
         '''
         Wrap existing command line with bwrap to restrict access to:
@@ -348,6 +370,9 @@ class RunnerConfig(BaseConfig):
             '--symlink', 'usr/lib', '/lib',
             '--symlink', 'usr/lib64', '/lib64',
         ])
+
+        for name in sorted(self.sandbox_hidden_envvars()):
+            new_args.extend(['--unsetenv', name])
 
         for path in sorted(set(self.process_isolation_hide_paths or [])):
             if not os.path.exists(path):

--- a/test/unit/config/test_runner.py
+++ b/test/unit/config/test_runner.py
@@ -555,6 +555,54 @@ def test_bwrap_process_isolation_defaults(mocker):
     ]
 
 
+def test_bwrap_process_isolation_hide_envvars(mocker, monkeypatch):
+    """Patterns in process_isolation_hide_envvars are unset inside the sandbox."""
+    mocker.patch('os.makedirs', return_value=True)
+    monkeypatch.setenv('APP_API_TOKEN', 'secret')
+    monkeypatch.setenv('DATABASE_URL', 'postgres://user:pw@localhost/db')
+    monkeypatch.setenv('KEEP_ME', 'value')
+
+    rc = RunnerConfig('/')
+    rc.artifact_dir = '/tmp/artifacts'
+    rc.playbook = 'main.yaml'
+    rc.command = 'ansible-playbook'
+    rc.process_isolation = True
+    rc.process_isolation_executable = 'bwrap'
+    rc.process_isolation_hide_envvars = ['*_TOKEN', 'DATABASE_URL']
+
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc.prepare()
+
+    assert '--unsetenv' in rc.command
+    unset = {rc.command[i + 1] for i, arg in enumerate(rc.command) if arg == '--unsetenv'}
+    assert unset == {'APP_API_TOKEN', 'DATABASE_URL'}
+    # The variable is only hidden from the sandbox, not from Runner itself.
+    assert rc.env['APP_API_TOKEN'] == 'secret'
+
+
+def test_bwrap_process_isolation_hide_envvars_accepts_a_string(mocker, monkeypatch):
+    mocker.patch('os.makedirs', return_value=True)
+    monkeypatch.setenv('APP_API_TOKEN', 'secret')
+
+    rc = RunnerConfig('/')
+    rc.artifact_dir = '/tmp/artifacts'
+    rc.playbook = 'main.yaml'
+    rc.command = 'ansible-playbook'
+    rc.process_isolation = True
+    rc.process_isolation_executable = 'bwrap'
+    rc.process_isolation_hide_envvars = '*_TOKEN'
+
+    path_exists = mocker.patch('os.path.exists')
+    path_exists.return_value = True
+
+    rc.prepare()
+
+    assert rc.command.count('--unsetenv') == 1
+    assert rc.command[rc.command.index('--unsetenv') + 1] == 'APP_API_TOKEN'
+
+
 def test_bwrap_process_isolation_and_directory_isolation(mocker, patch_private_data_dir, tmp_path):
     # pylint: disable=W0613
 


### PR DESCRIPTION
##### SUMMARY

When process isolation uses bwrap, the sandboxed command inherits the environment of the process that started Runner. For an application that embeds Runner as a library, that means every playbook run receives the application's own environment — database credentials, session signing keys, API tokens — even though nothing in the playbook asked for them, and even though the caller has carefully limited which paths the run can see.

Callers can already hide filesystem paths from a run (`process_isolation_hide_paths`). This adds the equivalent for the environment.

`process_isolation_hide_envvars` takes an `fnmatch` pattern, or a list of them, and emits `--unsetenv` for each matching variable in the environment the sandboxed command would otherwise inherit:

```python
ansible_runner.run(
    private_data_dir='/tmp/demo',
    playbook='site.yml',
    process_isolation=True,
    process_isolation_executable='bwrap',
    process_isolation_hide_envvars=['*_TOKEN', 'DATABASE_URL', 'DJANGO_SECRET_KEY'],
)
```

It defaults to `None`, so nothing changes for anyone who does not opt in. The variables also remain visible to Runner itself — only the sandboxed command loses them — so this does not interfere with variables Runner needs, nor with anything a caller deliberately passes through `envvars`.

Like the other `process_isolation_*` path settings, it applies to bwrap only; the docs note has been extended to say so. It is also settable through `env/settings`.

##### ORIGIN

The idea comes from a downstream patch the JumpServer project carries on a fork of this repository ([`8f9316545`](https://github.com/jumpserver-dev/ansible-runner/commit/8f9316545), by @w940853815 and ibuler, both credited as co-authors on the commit). That version strips every variable whose name contains one of `KEY`, `PASSWORD`, `TOKEN`, `SECRET`, `PASSWD`, `REDIS_` or `DB_`, unconditionally.

That is the right instinct but the wrong default for upstream: matching on `PASSWORD` as a substring would also drop `ANSIBLE_VAULT_PASSWORD_FILE`, and `KEY` would drop `AWS_SECRET_ACCESS_KEY` — including when a caller passed it deliberately. Making the patterns a caller-controlled setting keeps the capability while leaving the default behaviour untouched.

The fork carries a second change in the same commit, replacing `--symlink usr/lib /lib` with `--ro-bind /lib /lib`. That one is deliberately **not** included here: `--ro-bind` fails when the source does not exist, so it would break on systems without a real `/lib64`, and it is unrelated to the environment question.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`ansible_runner.config.runner`

##### ADDITIONAL INFORMATION

Two unit tests are added alongside the existing bwrap tests in `test/unit/config/test_runner.py`, covering a list of patterns and a bare string, and asserting that the hidden variable is still present in `rc.env`.

`test/unit/config/test_runner.py` on this branch: 40 passed, against 38 passed on unmodified `devel` in the same environment. `flake8` is clean on both changed files.
