### PR TITLE
Deprecate bwrap and fact cache APIs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Examples of this could include:
    intro
    install
    community
+   porting_guides/porting_guide
    external_interface
    standalone
    python_interface

--- a/docs/porting_guides/porting_guide.rst
+++ b/docs/porting_guides/porting_guide.rst
@@ -1,0 +1,12 @@
+*****************************
+Ansible Runner Porting Guides
+*****************************
+
+This section lists porting guides that contain useful information to consider when upgrading to newer
+versions of Ansible Runner.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   porting_guide_v2.5

--- a/docs/porting_guides/porting_guide_v2.5.rst
+++ b/docs/porting_guides/porting_guide_v2.5.rst
@@ -1,0 +1,29 @@
+********************************
+Ansible Runner 2.5 Porting Guide
+********************************
+
+This section discusses the behavioral changes between Ansible Runner version 2.4 and version 2.5.
+
+Deprecations
+============
+
+The following features are being deprecated in this version of Ansible Runner. They will be removed
+in a future version.
+
+API Deprecations
+----------------
+
+The following methods of the :class:`Runner <ansible_runner.runner.Runner>` class are being deprecated:
+
+* ``get_fact_cache()``
+* ``set_fact_cache()``
+
+These methods depended on the internal workings of how fact caching was stored. The storage details were
+changed in ``ansible-core`` version ``2.19``, so these methods will not work correctly using that version
+or above. Because of this, these methods are slotted for removal.
+
+Bubblewrap
+----------
+
+Support of ``bubblewrap`` (or ``bwrap``) for process isolation is being deprecated. This has been superseded by
+the use of Execution Environments.

--- a/docs/porting_guides/porting_guide_v2.5.rst
+++ b/docs/porting_guides/porting_guide_v2.5.rst
@@ -25,5 +25,5 @@ or above. Because of this, these methods are slotted for removal.
 Bubblewrap
 ----------
 
-Support of ``bubblewrap`` (or ``bwrap``) for process isolation is being deprecated. This has been superseded by
-the use of Execution Environments.
+Support of ``bubblewrap`` (or ``bwrap``) for process isolation is being deprecated.
+This has been superseded by the use of Execution Environments.

--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -207,6 +207,8 @@ received.
 ``Runner.get_fact_cache``
 -------------------------
 
+.. warning:: Deprecated in version 2.5. Does not work with ansible-core 2.19 and above.
+
 :meth:`ansible_runner.runner.Runner.get_fact_cache` is a method that, given a hostname, will return a dictionary containing the `Facts <https://docs.ansible.com/projects/ansible/latest/user_guide/playbooks_variables.html#variables-discovered-from-systems-facts>`_ stored for that host during execution.
 
 .. _runner.event_handler:

--- a/src/ansible_runner/config/_base.py
+++ b/src/ansible_runner/config/_base.py
@@ -37,7 +37,7 @@ from typing import Any
 import pexpect
 
 from ansible_runner import defaults
-from ansible_runner.output import debug
+from ansible_runner.output import debug, deprecated
 from ansible_runner.exceptions import ConfigurationError
 from ansible_runner.defaults import registry_auth_prefix
 from ansible_runner.loader import ArtifactLoader
@@ -161,6 +161,11 @@ class BaseConfig:
             self.cwd = os.getcwd()
 
         os.makedirs(self.artifact_dir, exist_ok=True, mode=0o700)
+
+        if self.process_isolation_executable == "bwrap":
+            deprecated("Support for bubblewrap is deprecated.",
+                       help_text="Use 'docker' or 'podman' instead.",
+                       version="2.6")
 
     _CONTAINER_ENGINES = ('docker', 'podman')
 

--- a/src/ansible_runner/output.py
+++ b/src/ansible_runner/output.py
@@ -32,6 +32,14 @@ def display(msg: str, log_only: bool = False) -> None:
     _debug_logger.log(10, msg)
 
 
+def deprecated(msg: str, help_text: str | None = None, version: str | None = None) -> None:
+    if help_text:
+        msg += f"\n    {help_text}"
+    if version:
+        msg += f"\n    This feature will be removed in version {version} of ansible-runner."
+    display(f"[DEPRECATION WARNING]: {msg}")
+
+
 def debug(msg: str) -> None:
     if DEBUG_ENABLED:
         if isinstance(msg, Exception):

--- a/src/ansible_runner/runner.py
+++ b/src/ansible_runner/runner.py
@@ -14,7 +14,7 @@ import traceback
 import pexpect
 
 import ansible_runner.plugins
-from ansible_runner.output import debug
+from ansible_runner.output import debug, deprecated
 
 from .utils import OutputEventFilter, cleanup_artifact_dir, ensure_str, collect_new_events
 from .exceptions import CallbackError, AnsibleRunnerException
@@ -555,6 +555,14 @@ class Runner:
         '''
         Get the entire fact cache only if the fact_cache_type is 'jsonfile'
         '''
+
+        # NOTE: Best-effort notification. This method cannot be called via the CLI and can only be called
+        # through programmatic use, so this deprecation warning may or may not be logged, depending on caller
+        # logging configuration.
+        deprecated("The get_fact_cache() method is deprecated.",
+                   help_text="See issue https://github.com/ansible/ansible-runner/issues/1441",
+                   version="2.6")
+
         if self.config.fact_cache_type != 'jsonfile':
             raise Exception('Unsupported fact cache type.  Only "jsonfile" is supported for reading and writing facts from ansible-runner')
         fact_cache = os.path.join(self.config.fact_cache, host)
@@ -567,6 +575,14 @@ class Runner:
         '''
         Set the entire fact cache data only if the fact_cache_type is 'jsonfile'
         '''
+
+        # NOTE: Best-effort notification. This method cannot be called via the CLI and can only be called
+        # through programmatic use, so this deprecation warning may or may not be logged, depending on caller
+        # logging configuration.
+        deprecated("The set_fact_cache() method is deprecated.",
+                   help_text="See issue https://github.com/ansible/ansible-runner/issues/1441",
+                   version="2.6")
+
         if self.config.fact_cache_type != 'jsonfile':
             raise Exception('Unsupported fact cache type.  Only "jsonfile" is supported for reading and writing facts from ansible-runner')
         fact_cache = os.path.join(self.config.fact_cache, host)

--- a/test/unit/config/test__base.py
+++ b/test/unit/config/test__base.py
@@ -369,3 +369,22 @@ def test_containerization_unsafe_write_setting(tmp_path, runtime, mocker):
     }
 
     assert rc.env.get('ANSIBLE_UNSAFE_WRITES') == expected[runtime]
+
+
+def test_bwrap_deprecation_log_message(tmp_path, caplog):
+    """The deprecation must emit an appropriate message to the ansible-runner.display logger."""
+    with caplog.at_level(10, logger='ansible-runner.display'):
+        BaseConfig(private_data_dir=tmp_path.as_posix(), process_isolation_executable='bwrap')
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        m.startswith('[DEPRECATION WARNING]: Support for bubblewrap is deprecated.')
+        for m in messages
+    ), messages
+
+
+def test_no_bwrap_deprecation_by_default(tmp_path, mocker):
+    """The deprecation must not fire when bwrap is not the process isolation executable."""
+    mock_deprecated = mocker.patch('ansible_runner.config._base.deprecated')
+    BaseConfig(private_data_dir=tmp_path.as_posix())
+    mock_deprecated.assert_not_called()


### PR DESCRIPTION
Deprecate features in `2.5` that we want to remove in the `2.6` release.

- Bubblewrap feature is completely untested, an older artifact of the time before EEs.
- Fact cache APIs do not work since Ansible 2.19 (https://github.com/ansible/ansible-runner/issues/1441)

This will produce the following logging messages, if configured for logging:

```
[DEPRECATION WARNING]: The get_fact_cache() method is deprecated.
    See issue https://github.com/ansible/ansible-runner/issues/1441
    This feature will be removed in version 2.6 of ansible-runner.

[DEPRECATION WARNING]: Support for bubblewrap is deprecated.
    Use 'docker' or 'podman' instead.
    This feature will be removed in version 2.6 of ansible-runner.
```