### PR TITLE
[CI][release_2.4] Update test requirements

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,10 +1,10 @@
 mypy==1.6.0
 pylint==3.0.1
-pytest==8.1.1
+pytest==8.4.2
 pytest-cov
 pytest-mock
 pytest-timeout
-pytest-xdist==2.5.0
+pytest-xdist==3.5.0
 types-pyyaml
 flake8==6.1.0
 yamllint==1.32.0


### PR DESCRIPTION
The older version of `pytest-xdist` was having issues with its requirements, so bumping that and `pytest`, but not beyond the versions in `devel` branch, or beyond the supported versions of Python.