### PR TITLE
🧪 Cross-integrate coverage and test reports across envs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         xfail:
         - false
 
-    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@1bb961580e20073f66ccb9024f248357f8c8fecb  # yamllint disable-line rule:line-length
     with:
       cache-key-for-dependency-files:  # FIXME
       check-name: >-
@@ -114,7 +114,7 @@ jobs:
         xfail:
         - false
 
-    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@89de3c6be3cd179adf71e28aa4ac5bef60804209  # yamllint disable-line rule:line-length
+    uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@1bb961580e20073f66ccb9024f248357f8c8fecb  # yamllint disable-line rule:line-length
     with:
       cache-key-for-dependency-files:  # FIXME
       check-name: >-

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,12 @@ deps =
     {unit,integration}-devel: ansible-core @ https://github.com/ansible/ansible/archive/devel.tar.gz
     -r {toxinidir}/test/requirements.txt
 passenv =
+    CI
+    GITHUB_*
     HOME
     RUNNER_TEST_IMAGE_NAME
+    SSH_AUTH_SOCK
+    TERM
 usedevelop = True
 commands = pytest -vv -n auto {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,94 +42,14 @@ commands =
     mypy src/ansible_runner
     pylint src/ansible_runner test
 
-[testenv:unit{,-py310,-py311,-py312,-py313,-py314,-devel}]
-description = Run unit tests
+[testenv:{integration,unit}{,-py310,-py311,-py312,-py313,-py314,-devel}]
+description = Run {env:_TEST_TARGET_SUBDIR} tests
+set_env =
+  integration: _TEST_TARGET_SUBDIR=integration
+  unit: _TEST_TARGET_SUBDIR=unit
 commands =
   pytest \
-    test/unit \
-    -vv \
-    -n auto \
-    {[shared]pytest_cov_args} \
-    {posargs:--cov-report=html:{envtmpdir}{/}htmlcov{/}}
-commands_post =
-  -{envpython} \
-    {[python-cli-options]byte-errors} \
-    {[python-cli-options]max-isolation} \
-    {[python-cli-options]warnings-to-errors} \
-    -c \
-      'import atexit, os, sys; \
-      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
-      import coverage; \
-      gh_summary_fd = open(\
-        os.environ["GITHUB_STEP_SUMMARY"], encoding="utf-8", mode="a",\
-      ); \
-      atexit.register(gh_summary_fd.close); \
-      cov = coverage.Coverage(); \
-      cov.load(); \
-      cov.report(file=gh_summary_fd, output_format="markdown")'
-  {envpython} \
-    {[python-cli-options]byte-errors} \
-    {[python-cli-options]max-isolation} \
-    {[python-cli-options]warnings-to-errors} \
-    -c \
-      'import os, pathlib, sys; \
-      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
-      cov_report_arg_prefix = "--cov-report=xml:"; \
-      test_report_arg_prefix = "--junitxml="; \
-      cov_reports = [\
-        arg[len(cov_report_arg_prefix):] for arg in sys.argv \
-        if arg.startswith(cov_report_arg_prefix)\
-      ]; \
-      test_reports = [\
-        arg[len(test_report_arg_prefix):] for arg in sys.argv \
-        if arg.startswith(test_report_arg_prefix)\
-      ]; \
-      cov_report_file = cov_reports[-1] if cov_reports else None; \
-      test_report_file = test_reports[-1] if test_reports else None; \
-      gh_output_fd = open(\
-        os.environ["GITHUB_OUTPUT"], encoding="utf-8", mode="a",\
-      ); \
-      cov_report_file and \
-        print(f"cov-report-files={cov_report_file !s}", file=gh_output_fd); \
-      test_report_file and \
-        print(f"test-result-files={test_report_file !s}", file=gh_output_fd); \
-      print("codecov-flags=pytest", file=gh_output_fd); \
-      gh_output_fd.close()' \
-    {posargs}
-  # Print out the output coverage dir and a way to serve html:
-  {envpython} \
-    {[python-cli-options]byte-errors} \
-    {[python-cli-options]max-isolation} \
-    {[python-cli-options]warnings-to-errors} \
-    -c\
-      'import pathlib, shlex, sys; \
-      cov_html_report_arg_prefix = "--cov-report=html:"; \
-      cov_html_reports = [\
-        arg[len(cov_html_report_arg_prefix):] for arg in sys.argv \
-        if arg.startswith(cov_html_report_arg_prefix)\
-      ]; \
-      cov_html_reports or sys.exit(); \
-      cov_html_report_dir = pathlib.Path(cov_html_reports[-1]); \
-      index_file = cov_html_report_dir / "index.html";\
-      index_file.exists() or sys.exit(); \
-      html_url = f"file://\{index_file\}";\
-      browse_cmd = shlex.join(("python3", "-Im", "webbrowser", html_url)); \
-      serve_cmd = shlex.join((\
-        "python3", "-Im", "http.server", \
-        "--directory", str(cov_html_report_dir), "0", \
-      )); \
-      print(f"\nTo open the HTML coverage report, run\n\n\
-      \t\{browse_cmd !s\}\n");\
-      print(f"To serve \
-      the HTML coverage report with a local web server, use\n\n\
-      \t\{serve_cmd !s\}\n")' \
-    {posargs:--cov-report=html:{envtmpdir}{/}htmlcov{/}}
-
-[testenv:integration{,-py310,-py311,-py312,-py313,-py314,-devel}]
-description = Run integration tests
-commands =
-  pytest \
-    test/integration \
+    test/{env:_TEST_TARGET_SUBDIR} \
     -vv \
     -n auto \
     {[shared]pytest_cov_args} \

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,18 @@ requires =
     tox>4
     setuptools>=64
 
+
+[python-cli-options]
+byte-warnings = -b
+byte-errors = -bb
+max-isolation = -E -s -I
+some-isolation = -E -s
+warnings-to-errors = -Werror
+
+
 [shared]
-pytest_cov_args = --cov --cov-report html --cov-report term --cov-report xml
+pytest_cov_args = --cov --cov-report=term
+
 
 [testenv]
 description = Run tests with {basepython}
@@ -35,12 +45,168 @@ commands =
 [testenv:unit{,-py310,-py311,-py312,-py313,-py314,-devel}]
 description = Run unit tests
 commands =
-    pytest test/unit -vv -n auto {[shared]pytest_cov_args} {posargs}
+  pytest \
+    test/unit \
+    -vv \
+    -n auto \
+    {[shared]pytest_cov_args} \
+    {posargs:--cov-report=html:{envtmpdir}{/}htmlcov{/}}
+commands_post =
+  -{envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'import atexit, os, sys; \
+      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
+      import coverage; \
+      gh_summary_fd = open(\
+        os.environ["GITHUB_STEP_SUMMARY"], encoding="utf-8", mode="a",\
+      ); \
+      atexit.register(gh_summary_fd.close); \
+      cov = coverage.Coverage(); \
+      cov.load(); \
+      cov.report(file=gh_summary_fd, output_format="markdown")'
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'import os, pathlib, sys; \
+      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
+      cov_report_arg_prefix = "--cov-report=xml:"; \
+      test_report_arg_prefix = "--junitxml="; \
+      cov_reports = [\
+        arg[len(cov_report_arg_prefix):] for arg in sys.argv \
+        if arg.startswith(cov_report_arg_prefix)\
+      ]; \
+      test_reports = [\
+        arg[len(test_report_arg_prefix):] for arg in sys.argv \
+        if arg.startswith(test_report_arg_prefix)\
+      ]; \
+      cov_report_file = cov_reports[-1] if cov_reports else None; \
+      test_report_file = test_reports[-1] if test_reports else None; \
+      gh_output_fd = open(\
+        os.environ["GITHUB_OUTPUT"], encoding="utf-8", mode="a",\
+      ); \
+      cov_report_file and \
+        print(f"cov-report-files={cov_report_file !s}", file=gh_output_fd); \
+      test_report_file and \
+        print(f"test-result-files={test_report_file !s}", file=gh_output_fd); \
+      print("codecov-flags=pytest", file=gh_output_fd); \
+      gh_output_fd.close()' \
+    {posargs}
+  # Print out the output coverage dir and a way to serve html:
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c\
+      'import pathlib, shlex, sys; \
+      cov_html_report_arg_prefix = "--cov-report=html:"; \
+      cov_html_reports = [\
+        arg[len(cov_html_report_arg_prefix):] for arg in sys.argv \
+        if arg.startswith(cov_html_report_arg_prefix)\
+      ]; \
+      cov_html_reports or sys.exit(); \
+      cov_html_report_dir = pathlib.Path(cov_html_reports[-1]); \
+      index_file = cov_html_report_dir / "index.html";\
+      index_file.exists() or sys.exit(); \
+      html_url = f"file://\{index_file\}";\
+      browse_cmd = shlex.join(("python3", "-Im", "webbrowser", html_url)); \
+      serve_cmd = shlex.join((\
+        "python3", "-Im", "http.server", \
+        "--directory", str(cov_html_report_dir), "0", \
+      )); \
+      print(f"\nTo open the HTML coverage report, run\n\n\
+      \t\{browse_cmd !s\}\n");\
+      print(f"To serve \
+      the HTML coverage report with a local web server, use\n\n\
+      \t\{serve_cmd !s\}\n")' \
+    {posargs:--cov-report=html:{envtmpdir}{/}htmlcov{/}}
 
 [testenv:integration{,-py310,-py311,-py312,-py313,-py314,-devel}]
 description = Run integration tests
 commands =
-    pytest test/integration -vv -n auto {[shared]pytest_cov_args} {posargs}
+  pytest \
+    test/integration \
+    -vv \
+    -n auto \
+    {[shared]pytest_cov_args} \
+    {posargs:--cov-report=html:{envtmpdir}{/}htmlcov{/}}
+commands_post =
+  -{envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'import atexit, os, sys; \
+      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
+      import coverage; \
+      gh_summary_fd = open(\
+        os.environ["GITHUB_STEP_SUMMARY"], encoding="utf-8", mode="a",\
+      ); \
+      atexit.register(gh_summary_fd.close); \
+      cov = coverage.Coverage(); \
+      cov.load(); \
+      cov.report(file=gh_summary_fd, output_format="markdown")'
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c \
+      'import os, pathlib, sys; \
+      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
+      cov_report_arg_prefix = "--cov-report=xml:"; \
+      test_report_arg_prefix = "--junitxml="; \
+      cov_reports = [\
+        arg[len(cov_report_arg_prefix):] for arg in sys.argv \
+        if arg.startswith(cov_report_arg_prefix)\
+      ]; \
+      test_reports = [\
+        arg[len(test_report_arg_prefix):] for arg in sys.argv \
+        if arg.startswith(test_report_arg_prefix)\
+      ]; \
+      cov_report_file = cov_reports[-1] if cov_reports else None; \
+      test_report_file = test_reports[-1] if test_reports else None; \
+      gh_output_fd = open(\
+        os.environ["GITHUB_OUTPUT"], encoding="utf-8", mode="a",\
+      ); \
+      cov_report_file and \
+        print(f"cov-report-files={cov_report_file !s}", file=gh_output_fd); \
+      test_report_file and \
+        print(f"test-result-files={test_report_file !s}", file=gh_output_fd); \
+      print("codecov-flags=pytest", file=gh_output_fd); \
+      gh_output_fd.close()' \
+    {posargs}
+  # Print out the output coverage dir and a way to serve html:
+  {envpython} \
+    {[python-cli-options]byte-errors} \
+    {[python-cli-options]max-isolation} \
+    {[python-cli-options]warnings-to-errors} \
+    -c\
+      'import pathlib, shlex, sys; \
+      cov_html_report_arg_prefix = "--cov-report=html:"; \
+      cov_html_reports = [\
+        arg[len(cov_html_report_arg_prefix):] for arg in sys.argv \
+        if arg.startswith(cov_html_report_arg_prefix)\
+      ]; \
+      cov_html_reports or sys.exit(); \
+      cov_html_report_dir = pathlib.Path(cov_html_reports[-1]); \
+      index_file = cov_html_report_dir / "index.html";\
+      index_file.exists() or sys.exit(); \
+      html_url = f"file://\{index_file\}";\
+      browse_cmd = shlex.join(("python3", "-Im", "webbrowser", html_url)); \
+      serve_cmd = shlex.join((\
+        "python3", "-Im", "http.server", \
+        "--directory", str(cov_html_report_dir), "0", \
+      )); \
+      print(f"\nTo open the HTML coverage report, run\n\n\
+      \t\{browse_cmd !s\}\n");\
+      print(f"To serve \
+      the HTML coverage report with a local web server, use\n\n\
+      \t\{serve_cmd !s\}\n")' \
+    {posargs:--cov-report=html:{envtmpdir}{/}htmlcov{/}}
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
This patch produces an HTML report locally with hints regarding viewing it. Additionally, it integrates with showing a Markdown tables in the GitHub Actions CI/CD web interface and exposes an output for pointing to the Cobertura XML report that is now only produced in CI. It is not needed in local development/contribution environments.

GHA also shows test summary widgets on the test run summary pages.

As a part of the change, this PR ended up including adjustments to `tox.ini` and upgrading `reusable-tox.yml` to its latest revision.