### PR TITLE
ci: Remove tox Python factors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ passenv =
 usedevelop = True
 commands = pytest -vv -n auto {posargs}
 
-[testenv:linters{,-py310,-py311,-py312,-py313,-py314}]
+[testenv:linters]
 description = Run code linters
 commands =
     flake8 --version
@@ -46,7 +46,7 @@ commands =
     mypy src/ansible_runner
     pylint src/ansible_runner test
 
-[testenv:{integration,unit}{,-py310,-py311,-py312,-py313,-py314,-devel}]
+[testenv:{integration,unit}{,-devel}]
 description = Run {env:_TEST_TARGET_SUBDIR} tests
 set_env =
   integration: _TEST_TARGET_SUBDIR=integration


### PR DESCRIPTION
These don't seem to be necessary for our CI and make backport conflicts occur more frequently.