### PR TITLE
chore: Standard SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,43 @@
 # Security Policy
 
-## Reporting a Vulnerability
+## Reporting a security vulnerability
 
-For all security related bugs, email security@ansible.com instead of using this issue tracker and you will receive a prompt response.
+All security vulnerability reports MUST be submitted by email to: [security@ansible.com](mailto:security@ansible.com)
 
-For more information on the Ansible community's practices regarding responsible disclosure, see https://www.ansible.com/security
+Security vulnerabilities MUST NOT be reported through public channels such as GitHub issues, pull requests, the Ansible Forum, or social media.
+
+## What to include
+
+When submitting a vulnerability report, include the following:
+
+- **Title** (required): Clear, concise, descriptive summary.
+- **Impacted project** (required): Ideally a link to the GitHub project.
+- **Reporter details** (optional): Your name or handle and affiliation.
+- **Vulnerability description** (required): Technical details of the issue.
+- **Affected versions** (required): Known affected version(s), and ideally all affected versions.
+- **Reproduction steps** (required): Minimal example to reproduce the issue.
+- **Impact assessment** (required): Potential exploit scenarios and severity.
+- **Suggested fix** (optional): Proposed remediation, if any.
+- **Disclosure status** (required): Whether this has been shared with other parties or published and your plan for future sharing (e.g., at a conference).
+
+## Timeline
+
+- The Ansible Security Team aims to confirm receipt of vulnerability reports within one (1) business day.
+- Our goal is to assess the report, coordinate fix and disclosure as quickly as possible.
+- All confirmed vulnerabilities are addressed according to severity and impact.
+
+## Backports
+
+Generally, only the latest release of this project receives security updates.
+Earlier versions may receive critical fixes on a best-effort basis.
+
+## Ansible Security Policy
+
+For the complete Ansible Security Policy, including what qualifies as a reportable vulnerability, severity classification,
+the response process, coordinated disclosure, and the vulnerability management process, see [ansible.com/security](https://ansible.com/security).
+
+## EU Cyber Resilience Act: Open-Source Steward Statement
+
+This project is stewarded by **Red Hat, Inc.**, an open-source software steward as defined in Article 3(14) of the [EU Cyber Resilience Act (Regulation 2024/2847)](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng).
+
+Contact: [cra-steward@redhat.com](mailto:cra-steward@redhat.com)


### PR DESCRIPTION
## Summary

Add a standardised `SECURITY.md` so security reporting instructions are discoverable across all Ansible repositories.

The canonical source is [`ansible-community/project-template/SECURITY.md`](https://github.com/ansible-community/project-template/blob/main/SECURITY.md).

The file has already been reviewed

See [Forum Post](https://forum.ansible.com/t/cra-updating-security-md/46223) for context
