### PR TITLE
ci: Remove tox Python factors (#1542)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ passenv =
 usedevelop = True
 commands = pytest -vv -n auto {posargs}
 
-[testenv:linters{,-py39,-py310,-py311,-py312}]
+[testenv:linters]
 description = Run code linters
 commands =
     flake8 --version
@@ -48,7 +48,7 @@ commands =
     mypy src/ansible_runner
     pylint src/ansible_runner test
 
-[testenv:{integration,unit}{,-py39,-py310,-py311,-py312}]
+[testenv:{integration,unit}{,-devel}]
 description = Run {env:_TEST_TARGET_SUBDIR} tests
 set_env =
   integration: _TEST_TARGET_SUBDIR=integration


### PR DESCRIPTION
Backport of PR #1542 

These don't seem to be necessary for our CI and make backport conflicts occur more frequently.

(cherry picked from commit 8dcdadbd8e4a7591565bdf93c7372c157f0f08ce)