### PR TITLE
fix: Count bytes actually read in unstream_dir and ensure decoding handles quantum boundaries

### DIFF
--- a/src/ansible_runner/utils/base64io.py
+++ b/src/ansible_runner/utils/base64io.py
@@ -76,6 +76,7 @@ class Base64IO(io.IOBase):
         """
         # set before the attr check as we may reach close() after that check fails
         self.__read_buffer = b""
+        self.__encoded_read_buffer = b""
         self.__write_buffer = b""
 
         required_attrs = ("read", "write", "close", "closed", "flush")
@@ -241,14 +242,38 @@ class Base64IO(io.IOBase):
             # Calculate number of encoded bytes that must be read to get b raw bytes.
             _bytes_to_read = int((b - len(self.__read_buffer)) * 4 / 3)
             _bytes_to_read = int(math.ceil(_bytes_to_read / 4.0) * 4.0)
+            # Encoded bytes held back from the previous read count towards that, so
+            # that we never pull more off the wrapped stream than the caller needs.
+            _bytes_to_read = max(_bytes_to_read - len(self.__encoded_read_buffer), 0)
 
         # Read encoded bytes from wrapped stream.
-        data = _to_bytes(self.__wrapped.read(_bytes_to_read))
+        _read_data = _to_bytes(self.__wrapped.read(_bytes_to_read))
         # Remove whitespace from read data and attempt to read more data to get the desired
         # number of bytes.
 
-        if any(char in data for char in string.whitespace.encode("utf-8")):
-            data = self._read_additional_data_removing_whitespace(data, _bytes_to_read)
+        if any(char in _read_data for char in string.whitespace.encode("utf-8")):
+            _read_data = self._read_additional_data_removing_whitespace(_read_data, _bytes_to_read)
+
+        _consumed = len(_read_data)
+        data = self.__encoded_read_buffer + _read_data
+        self.__encoded_read_buffer = b""
+
+        # A stream is free to hand back a partial base64 quantum. Keep pulling,
+        # within what was already asked for, until a whole quantum is available -
+        # decoding nothing here would look like EOF to the caller.
+        while _bytes_to_read > _consumed and _read_data and len(data) < 4:
+            _read_data = _to_bytes(self.__wrapped.read(min(4 - len(data), _bytes_to_read - _consumed)))
+            _consumed += len(_read_data)
+            data += _read_data
+
+        # b64decode rejects a split quantum as incorrect padding, so decode only
+        # whole quanta and carry the remainder over to the next read. At EOF there
+        # is no next read, so decode what is left and let a genuinely truncated
+        # stream raise.
+        at_eof = _bytes_to_read != 0 and not _read_data
+        if not at_eof and len(data) % 4:
+            _whole_quanta = len(data) - (len(data) % 4)
+            data, self.__encoded_read_buffer = data[:_whole_quanta], data[_whole_quanta:]
 
         results = io.BytesIO()
         # First, load any stashed bytes

--- a/src/ansible_runner/utils/base64io.py
+++ b/src/ansible_runner/utils/base64io.py
@@ -269,8 +269,9 @@ class Base64IO(io.IOBase):
         # b64decode rejects a split quantum as incorrect padding, so decode only
         # whole quanta and carry the remainder over to the next read. At EOF there
         # is no next read, so decode what is left and let a genuinely truncated
-        # stream raise.
-        at_eof = _bytes_to_read != 0 and not _read_data
+        # stream raise. A readall consumes the stream outright, so it is always at
+        # EOF - holding bytes back there would drop them silently.
+        at_eof = _bytes_to_read < 0 or (_bytes_to_read != 0 and not _read_data)
         if not at_eof and len(data) % 4:
             _whole_quanta = len(data) - (len(data) % 4)
             data, self.__encoded_read_buffer = data[:_whole_quanta], data[_whole_quanta:]

--- a/src/ansible_runner/utils/streaming.py
+++ b/src/ansible_runner/utils/streaming.py
@@ -67,13 +67,17 @@ def unstream_dir(stream: io.FileIO, length: int, target_directory: str) -> None:
             with Base64IO(stream) as source:
                 remaining = length
                 chunk_size = 1024 * 1000  # 1 MB
-                while remaining != 0:
-                    chunk_size = min(chunk_size, remaining)
-
-                    data = source.read(chunk_size)
+                while remaining > 0:
+                    # A stream is free to return fewer bytes than requested, so
+                    # account for what was actually read, not what was asked for.
+                    data = source.read(min(chunk_size, remaining))
+                    if not data:
+                        raise RuntimeError(
+                            f'Stream ended before the transfer completed: {remaining} of {length} bytes missing.'
+                        )
                     target.write(data)
 
-                    remaining -= chunk_size
+                    remaining -= len(data)
 
         with zipfile.ZipFile(tmp.name, "r") as archive:
             # Fancy extraction in order to preserve permissions

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -272,8 +272,20 @@ class TestStreamingUsage:
 
         self.check_artifacts(str(process_dir), job_type)
 
+    @staticmethod
+    def _tcp_socketpair():
+        """A connected AF_INET pair, which unlike socketpair() splits reads mid-quantum."""
+        listener = socket.socket()
+        listener.bind(('127.0.0.1', 0))
+        listener.listen(1)
+        client = socket.create_connection(listener.getsockname())
+        server, _ = listener.accept()
+        listener.close()
+        return server, client
+
+    @pytest.mark.parametrize('family', ['af_unix', 'tcp'])
     @pytest.mark.timeout(timeout=180)
-    def test_large_private_data_dir_by_sockets(self, tmp_path, project_fixtures):
+    def test_large_private_data_dir_by_sockets(self, tmp_path, project_fixtures, family):
         """Assure a payload larger than the socket buffer survives short reads.
 
         A socket opened with buffering=0 is a raw SocketIO, so each read()
@@ -282,6 +294,11 @@ class TestStreamingUsage:
         payload outgrows the kernel buffer. If the reader miscounts, the
         archive is truncated and the transmitter deadlocks forever on a send
         buffer nobody is draining - a job that hangs with no error anywhere.
+
+        Both families matter. An AF_UNIX pair hands back page aligned buffers,
+        so every read happens to land on a base64 quantum boundary. TCP, which
+        is what receptor uses, segments wherever it likes and routinely splits
+        a quantum across two reads.
         """
         transmit_dir = project_fixtures / 'debug'
         # incompressible, so the zip stays much larger than any socket buffer
@@ -293,7 +310,10 @@ class TestStreamingUsage:
 
         job_kwargs = self.get_job_kwargs('run')
 
-        transmit_socket, worker_socket = socket.socketpair()
+        if family == 'tcp':
+            transmit_socket, worker_socket = self._tcp_socketpair()
+        else:
+            transmit_socket, worker_socket = socket.socketpair()
         transmit_file = transmit_socket.makefile('wb')
         worker_file = worker_socket.makefile('rb', buffering=0)
         results_file = (tmp_path / 'results').open('wb')
@@ -339,6 +359,11 @@ class TestStreamingUsage:
         assert not deadlocked, 'streaming deadlocked, the reader stopped draining the socket'
         assert not errors, f'streaming raised: {errors}'
         assert (worker_dir / 'big.bin').read_bytes() == payload
+
+        # interface.run() reports failure through the status stream rather than
+        # by raising, so assert the job really ran instead of just transferring
+        results = (tmp_path / 'results').read_bytes()
+        assert b'"status": "successful"' in results, 'worker did not report a successful job'
 
     def test_process_isolation_executable_not_exist(self, tmp_path, mocker):
         """Case transmit should not fail if process isolation executable does not exist and

--- a/test/integration/test_transmit_worker_process.py
+++ b/test/integration/test_transmit_worker_process.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import io
 import json
 import os
@@ -270,6 +271,74 @@ class TestStreamingUsage:
         assert set(os.listdir(worker_dir)) == {'artifacts', 'inventory', 'project', 'env'}
 
         self.check_artifacts(str(process_dir), job_type)
+
+    @pytest.mark.timeout(timeout=180)
+    def test_large_private_data_dir_by_sockets(self, tmp_path, project_fixtures):
+        """Assure a payload larger than the socket buffer survives short reads.
+
+        A socket opened with buffering=0 is a raw SocketIO, so each read()
+        returns a single recv(2) worth of data rather than looping until the
+        request is filled. That is how a receptor socket behaves once the
+        payload outgrows the kernel buffer. If the reader miscounts, the
+        archive is truncated and the transmitter deadlocks forever on a send
+        buffer nobody is draining - a job that hangs with no error anywhere.
+        """
+        transmit_dir = project_fixtures / 'debug'
+        # incompressible, so the zip stays much larger than any socket buffer
+        payload = os.urandom(8 * 1024 * 1024)
+        (transmit_dir / 'big.bin').write_bytes(payload)
+
+        worker_dir = tmp_path / 'for_worker'
+        worker_dir.mkdir()
+
+        job_kwargs = self.get_job_kwargs('run')
+
+        transmit_socket, worker_socket = socket.socketpair()
+        transmit_file = transmit_socket.makefile('wb')
+        worker_file = worker_socket.makefile('rb', buffering=0)
+        results_file = (tmp_path / 'results').open('wb')
+
+        errors = {}
+
+        def run_streamer(name, **kwargs):
+            def wrapped():
+                try:
+                    ansible_runner.interface.run(**kwargs)
+                except Exception as exc:  # pylint: disable=W0718
+                    errors[name] = exc
+            return wrapped
+
+        threads = [
+            threading.Thread(target=run_streamer(
+                'transmit', streamer='transmit', _output=transmit_file,
+                private_data_dir=transmit_dir, **job_kwargs), daemon=True),
+            threading.Thread(target=run_streamer(
+                'worker', streamer='worker', _input=worker_file, _output=results_file,
+                private_data_dir=worker_dir, **job_kwargs), daemon=True),
+        ]
+
+        for thread in threads:
+            thread.start()
+        deadline = time.monotonic() + 60
+        for thread in threads:
+            thread.join(timeout=max(0, deadline - time.monotonic()))
+
+        deadlocked = [thread for thread in threads if thread.is_alive()]
+
+        # tear the sockets down first, otherwise closing the file objects blocks
+        # on flushing into a send buffer that is already full
+        for s in (transmit_socket, worker_socket):
+            with contextlib.suppress(OSError):
+                s.shutdown(socket.SHUT_RDWR)
+        for f in (transmit_file, worker_file, results_file):
+            with contextlib.suppress(OSError):
+                f.close()
+        for s in (transmit_socket, worker_socket):
+            s.close()
+
+        assert not deadlocked, 'streaming deadlocked, the reader stopped draining the socket'
+        assert not errors, f'streaming raised: {errors}'
+        assert (worker_dir / 'big.bin').read_bytes() == payload
 
     def test_process_isolation_executable_not_exist(self, tmp_path, mocker):
         """Case transmit should not fail if process isolation executable does not exist and

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -420,7 +420,10 @@ class TestBase64IO:
         data = _to_bytes('te s t')
         assert obj._read_additional_data_removing_whitespace(data, 4) == b'test'
 
-    @pytest.mark.parametrize('limit', [1, 2, 3, 5, 7, 4093])
+    # Base64IO asks the wrapped stream for 1368 bytes per read(1024), so every
+    # limit here has to stay under that to actually chop anything, and none may
+    # be a multiple of 4 or the split would land on a quantum boundary
+    @pytest.mark.parametrize('limit', [1, 2, 3, 5, 7, 1021, 1023])
     def test_read_misaligned_chunks(self, limit):
         """A wrapped stream may split a 4 byte base64 quantum across two reads."""
         payload = os.urandom(64 * 1024)

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -419,3 +419,41 @@ class TestBase64IO:
         obj = Base64IO(io.StringIO(''))
         data = _to_bytes('te s t')
         assert obj._read_additional_data_removing_whitespace(data, 4) == b'test'
+
+    @pytest.mark.parametrize('limit', [1, 2, 3, 5, 7, 4093])
+    def test_read_misaligned_chunks(self, limit):
+        """A wrapped stream may split a 4 byte base64 quantum across two reads."""
+        payload = os.urandom(64 * 1024)
+
+        class Chopped(io.RawIOBase):
+            """Returns at most `limit` bytes, so reads land mid-quantum."""
+
+            def __init__(self, data):
+                self.data = data
+                self.pos = 0
+
+            def readable(self):
+                return True
+
+            def read(self, size=-1):
+                if size is None or size < 0:
+                    size = len(self.data) - self.pos
+                size = min(size, limit)
+                chunk = self.data[self.pos:self.pos + size]
+                self.pos += len(chunk)
+                return chunk
+
+        encoded = io.BytesIO()
+        encoded.name = 'not_stdout'
+        with Base64IO(encoded) as target:
+            target.write(payload)
+
+        decoded = b''
+        with Base64IO(Chopped(encoded.getvalue())) as source:
+            while len(decoded) < len(payload):
+                chunk = source.read(1024)
+                if not chunk:
+                    break
+                decoded += chunk
+
+        assert decoded == payload

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import signal
+import threading
 import time
 import stat
 
@@ -165,6 +166,73 @@ def test_unstream_dir_no_hang_on_pipe(tmp_path):
     first_line = outgoing_buffer.readline()
     size_data = json.loads(first_line.strip())
     unstream_dir(outgoing_buffer, size_data['zipfile'], dest_dir)
+
+
+@pytest.mark.timeout(timeout=30)
+def test_unstream_dir_short_reads(tmp_path):
+    """Assure a stream that returns less than was asked for is fully consumed.
+
+    An os.pipe opened with buffering=0 is a raw FileIO, so each read() is a
+    single read(2) and returns only what the 64 KB pipe buffer holds. Counting
+    the requested size rather than the returned size silently truncates the
+    archive, and leaves the writer blocked on a pipe nobody is draining.
+    """
+    pdd = tmp_path / 'short_read_source_dir'
+    pdd.mkdir()
+
+    # incompressible, so the zip stays much larger than the pipe buffer
+    payload = os.urandom(5 * 1024 * 1024)
+    (pdd / 'big.bin').write_bytes(payload)
+
+    read_fd, write_fd = os.pipe()
+
+    def produce():
+        with open(write_fd, 'wb') as writer:
+            stream_dir(pdd, writer)
+
+    producer = threading.Thread(target=produce, daemon=True)
+    producer.start()
+
+    dest_dir = tmp_path / 'short_read_dest'
+    dest_dir.mkdir()
+
+    with open(read_fd, 'rb', buffering=0) as reader:
+        # readline() on a raw stream reads a byte at a time, so it stops at the
+        # newline without consuming any of the payload behind it
+        size_data = json.loads(reader.readline().strip())
+        unstream_dir(reader, size_data['zipfile'], dest_dir)
+
+    producer.join(timeout=10)
+    assert not producer.is_alive(), 'stream_dir is still blocked writing to the pipe'
+    assert (dest_dir / 'big.bin').read_bytes() == payload
+
+
+@pytest.mark.timeout(timeout=30)
+def test_unstream_dir_truncated_stream(tmp_path):
+    """A stream that ends early must raise rather than spin or truncate silently."""
+    pdd = tmp_path / 'truncated_source_dir'
+    pdd.mkdir()
+
+    with open(pdd / 'ordinary_file.txt', 'w') as f:
+        f.write('hello world')
+
+    outgoing_buffer = io.BytesIO()
+    outgoing_buffer.name = 'not_stdout'
+    stream_dir(pdd, outgoing_buffer)
+
+    outgoing_buffer.seek(0)
+    size_data = json.loads(outgoing_buffer.readline().strip())
+
+    # lop off the tail of the base64 payload, on a 4 byte boundary so that what
+    # is left still decodes and the shortfall shows up as a premature EOF
+    contents = outgoing_buffer.read()
+    truncated = io.BytesIO(contents[:(len(contents) // 2) // 4 * 4])
+
+    dest_dir = tmp_path / 'truncated_dest'
+    dest_dir.mkdir()
+
+    with pytest.raises(RuntimeError, match='Stream ended before the transfer completed'):
+        unstream_dir(truncated, size_data['zipfile'], dest_dir)
 
 
 @pytest.mark.parametrize('fperm', [

--- a/test/unit/utils/test_utils.py
+++ b/test/unit/utils/test_utils.py
@@ -197,8 +197,6 @@ def test_unstream_dir_short_reads(tmp_path):
     dest_dir.mkdir()
 
     with open(read_fd, 'rb', buffering=0) as reader:
-        # readline() on a raw stream reads a byte at a time, so it stops at the
-        # newline without consuming any of the payload behind it
         size_data = json.loads(reader.readline().strip())
         unstream_dir(reader, size_data['zipfile'], dest_dir)
 


### PR DESCRIPTION
## Summary

Contains fixes for:

- Correcting the remaining bytes to read in `unstream_dir()`
- Makes Base64IO recognize and respect quantum boundaries so that only decoded data is returned from a `read()`, avoiding "Incorrect padding" errors.

### Details

unstream_dir() decremented `remaining` by the requested chunk size rather than the number of bytes returned. Base64IO.read() issues a single read() on the wrapped stream and does not loop to fill the request, so any short read - which is what a raw pipe or an unbuffered socket does once the payload outgrows the kernel buffer - silently drops data while still being counted as transferred.

The archive is truncated (BadZipFile, or "Incorrect padding" when the short read does not land on a base64 boundary), and worse, the reader stops draining the stream while the writer still has data to send, so the writer blocks forever in stream_dir() on a full send buffer. That surfaces as a job wedged in `running` with no error logged anywhere.

Decrement by len(data) and raise on a premature EOF. The guard matters: without it an early EOF makes the loop spin, since read() keeps returning b'' and `remaining` never reaches zero.

Adds an end-to-end regression test that drives Transmitter -> Worker over a socketpair whose read side is unbuffered, plus unit tests covering short reads over a real os.pipe and the truncated-stream case.

Fixes #1545 

Co-Authored-By: Claude Code