### PR TITLE
Remove the python-daemon dependency

### DIFF
--- a/docs/porting_guides/porting_guide_v2.5.rst
+++ b/docs/porting_guides/porting_guide_v2.5.rst
@@ -4,6 +4,33 @@ Ansible Runner 2.5 Porting Guide
 
 This section discusses the behavioral changes between Ansible Runner version 2.4 and version 2.5.
 
+Behavior Changes
+================
+
+Removal of the ``python-daemon`` dependency
+-------------------------------------------
+
+The ``python-daemon`` package is no longer a dependency of Ansible Runner. It relied on the ``lockfile``
+package, which has been unmaintained since 2015. The small amount of functionality that Ansible Runner
+used from it is now implemented directly. Packagers should drop ``python-daemon`` from their
+requirements.
+
+This changes the behavior of the ``ansible-runner start`` command in the following ways:
+
+* The file mode creation mask (``umask``) of the invoking process is now inherited by the background
+  process. Previously it was reset to ``0``, which made every file and directory the background process
+  created world writable.
+* File descriptors inherited by the background process are no longer closed. In particular, this means
+  that ``--logfile`` now works with the ``start`` command, where before it silently produced an empty
+  file.
+* The standard error of the background process is appended to ``<private_data_dir>/daemon.log`` instead
+  of being discarded. Its standard output continues to be discarded.
+* If a background process is already running for the given ``private_data_dir``, ``start`` now reports
+  the running process ID and exits with a return code of ``1`` instead of raising an unhandled exception.
+* A pid file left behind by a process that no longer exists is now discarded and reused, instead of
+  preventing any further use of the ``start`` command for that ``private_data_dir``.
+* ``start`` no longer returns until the pid file has been created.
+
 Deprecations
 ============
 

--- a/docs/standalone.rst
+++ b/docs/standalone.rst
@@ -44,6 +44,13 @@ Executing **Runner** in the background
 When launching **Runner** with the ``start`` command, the program will generate a pid file and move to the background. You can check its status with the
 ``is-alive`` command, or terminate it with the ``stop`` command. You can find the stdout, status, and return code in the ``artifacts`` directory.
 
+The pid file is written to ``<private_data_dir>/pid`` and contains the process ID of the background process. If a background process is already running for
+that ``private_data_dir``, ``start`` will report the running process ID and exit with a return code of ``1`` rather than starting a second one. A pid file
+left behind by a process that no longer exists (after a ``kill -9`` or a reboot, for example) is discarded automatically.
+
+The background process has no terminal attached to it. Its standard output is discarded, so use ``--logfile`` or read ``artifacts/<ident>/stdout`` to see what
+it did; its standard error, along with any traceback from an unexpected failure, is appended to ``<private_data_dir>/daemon.log``.
+
 Running Playbooks
 -----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
 dependencies = [
     "pexpect>=4.5",
     "packaging",
-    "python-daemon",
     "pyyaml",
 ]
 
@@ -53,7 +52,6 @@ ansible-runner = "ansible_runner.__main__:main"
 [[tool.mypy.overrides]]
 module = [
     "ansible.*",
-    "daemon.*",
     "pexpect",
 ]
 ignore_missing_imports = true

--- a/src/ansible_runner/__main__.py
+++ b/src/ansible_runner/__main__.py
@@ -33,12 +33,10 @@ import shutil
 import textwrap
 import tempfile
 
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 from uuid import uuid4
 
-import daemon
-from daemon.pidfile import TimeoutPIDLockFile
 from yaml import safe_dump, safe_load
 
 from ansible_runner import run
@@ -46,6 +44,7 @@ from ansible_runner import output
 from ansible_runner import cleanup
 from ansible_runner.utils import dump_artifact, Bunch, register_for_cleanup
 from ansible_runner.utils.capacity import get_cpu_count, get_mem_in_bytes, ensure_uuid
+from ansible_runner.utils._daemonize import DaemonContext
 from ansible_runner.utils.importlib_compat import importlib_metadata
 from ansible_runner.runner import Runner
 
@@ -847,7 +846,6 @@ def main(sys_args=None):
             raise
 
     stderr_path = None
-    context = None
     if vargs.get('command') not in ('run', 'transmit', 'worker'):
         stderr_path = os.path.join(vargs.get('private_data_dir'), 'daemon.log')
         if not os.path.exists(stderr_path):
@@ -855,8 +853,11 @@ def main(sys_args=None):
 
     if vargs.get('command') in ('start', 'run', 'transmit', 'worker', 'process'):
 
+        context: AbstractContextManager
         if vargs.get('command') == 'start':
-            context = daemon.DaemonContext(pidfile=TimeoutPIDLockFile(pidfile))
+            # Only the detached daemon returns from DaemonContext.__enter__(); the
+            # process that invoked us exits from inside the ``with`` statement below.
+            context = DaemonContext(pidfile, stderr=stderr_path)
         else:
             context = threading.Lock()
 
@@ -907,7 +908,9 @@ def main(sys_args=None):
                 except Exception:
                     e = traceback.format_exc()
                     if stderr_path:
-                        with open(stderr_path, 'w+') as ep:
+                        # Appended, not truncated: for ``start`` the daemon's stderr is
+                        # already pointed at this same file.
+                        with open(stderr_path, 'a') as ep:
                             ep.write(e)
                     else:
                         sys.stderr.write(e)

--- a/src/ansible_runner/utils/_daemonize.py
+++ b/src/ansible_runner/utils/_daemonize.py
@@ -76,11 +76,10 @@ def pid_is_running(pid: int) -> bool:
         return False
     try:
         os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
     except PermissionError:
-        # The process exists, we are simply not allowed to signal it.
-        return True
+        # The process exists, we are simply not allowed to signal it. This clause must
+        # come first: PermissionError is a subclass of OSError.
+        pass
     except OSError:
         return False
     return True

--- a/src/ansible_runner/utils/_daemonize.py
+++ b/src/ansible_runner/utils/_daemonize.py
@@ -1,0 +1,511 @@
+'''
+Minimal, dependency free POSIX daemonization support.
+
+This module is private to ``ansible_runner`` and covers only what the
+``ansible-runner start`` command needs. It is not part of the public API.
+'''
+
+from __future__ import annotations
+
+import atexit
+import errno
+import fcntl
+import logging
+import os
+import resource
+import signal
+import sys
+
+from collections.abc import Iterable
+from types import FrameType, TracebackType
+from typing import Any, NoReturn
+
+
+__all__ = ['AlreadyRunningError', 'DaemonContext', 'read_pidfile']
+
+# Requested mode of the PID file, subject to the umask of the invoking process. Matches
+# the mode used by the ``lockfile`` package that ``python-daemon`` relied on, so that PID
+# files written by older versions of ansible-runner still look the same.
+PIDFILE_MODE = 0o644
+
+STDIN_FILENO = 0
+STDOUT_FILENO = 1
+STDERR_FILENO = 2
+
+
+class AlreadyRunningError(RuntimeError):
+    '''
+    Raised when a live process already owns a PID file.
+    '''
+
+    def __init__(self, path: str, pid: int | None = None) -> None:
+        self.path = path
+        self.pid = pid
+        if pid is None:
+            message = f"a process already owns the PID file {path}"
+        else:
+            message = f"a process is already running with PID {pid} (PID file {path})"
+        super().__init__(message)
+
+
+def read_pidfile(path: str) -> int | None:
+    '''
+    Read the PID recorded in a PID file.
+
+    :param str path: Path of the PID file.
+
+    :return: The recorded PID, or ``None`` if the file is missing, unreadable, or does
+        not start with a decimal integer.
+    '''
+    try:
+        with open(path, 'r') as f:
+            return int(f.readline().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def pid_is_running(pid: int) -> bool:
+    '''
+    Determine whether a process exists.
+
+    :param int pid: Process ID to test.
+
+    :return: ``True`` if a process with that PID exists, otherwise ``False``.
+    '''
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The process exists, we are simply not allowed to signal it.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _is_same_file(fd: int, path: str) -> bool:
+    '''
+    Determine whether an open descriptor and a path still refer to the same file.
+
+    :param int fd: Open file descriptor.
+    :param str path: Path to compare it against.
+    '''
+    try:
+        by_fd = os.fstat(fd)
+        by_path = os.stat(path)
+    except OSError:
+        return False
+    return (by_fd.st_dev, by_fd.st_ino) == (by_path.st_dev, by_path.st_ino)
+
+
+def _reclaim_stale_pidfile(path: str) -> tuple[bool, int | None]:
+    '''
+    Remove a PID file if the process that recorded it no longer exists.
+
+    An exclusive ``flock`` serializes this against other processes running the same code.
+    Reading the PID and unlinking the file are separate operations, so without the lock
+    two daemons starting at once could both decide the same PID file is stale and go on
+    to delete each other's replacement, leaving both running against a single private
+    data directory with only the second one recorded.
+
+    :param str path: Path of the PID file to examine.
+
+    :return: ``(reclaimed, pid)``, where ``reclaimed`` says whether the caller should
+        retry creating the PID file, and ``pid`` is the live owner when it should not.
+    '''
+    try:
+        fd = os.open(path, os.O_RDONLY)
+    except FileNotFoundError:
+        return True, None
+
+    try:
+        try:
+            # Blocking, deliberately. The lock is only ever held across the handful of
+            # syscalls below, and waiting for the holder to finish is what lets us
+            # report its PID accurately instead of a PID we already know to be dead.
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        except OSError:
+            # Not every filesystem can lock. Carry on unserialized, which is still an
+            # improvement on never reclaiming the file at all.
+            pass
+        else:
+            # Whoever held the lock before us may have replaced the file entirely.
+            if not _is_same_file(fd, path):
+                return True, None
+
+        pid = read_pidfile(path)
+        if pid is not None and pid_is_running(pid):
+            return False, pid
+
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        return True, pid
+    finally:
+        os.close(fd)
+
+
+def _create_pidfile(path: str) -> bool:
+    '''
+    Atomically create a fully written PID file, if the path is free.
+
+    The PID is written to a uniquely named temporary file alongside the target and then
+    hard linked into place. ``os.link()`` is atomic and fails if the destination exists,
+    so this gives the same exclusivity as ``O_CREAT | O_EXCL`` while additionally
+    guaranteeing that the PID file is never observable as an empty file. That matters
+    because ``_reclaim_stale_pidfile()`` treats an unreadable PID file as stale: with a
+    plain exclusive create, a process starting concurrently could look in between our
+    create and our write, and delete the PID file out from under us.
+
+    :param str path: Path of the PID file to create.
+
+    :return: ``True`` on success, ``False`` if the PID file already exists.
+    '''
+    # No other live process can share our PID, so this name is ours alone.
+    tmp = f"{path}.{os.getpid()}"
+    try:
+        fd = os.open(tmp, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, PIDFILE_MODE)
+        with os.fdopen(fd, 'w') as f:
+            f.write(f"{os.getpid()}\n")
+
+        # The mode of the temporary file carries over: link() creates a second name for
+        # the same inode rather than a new file.
+        try:
+            os.link(tmp, path)
+        except FileExistsError:
+            return False
+        return True
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def write_pidfile(path: str) -> None:
+    '''
+    Atomically create a PID file recording the PID of the calling process.
+
+    A PID file left behind by a process that no longer exists (killed with ``SIGKILL``,
+    host reboot, ...) is treated as stale, removed, and the creation retried once.
+
+    :param str path: Path of the PID file to create.
+
+    :raises AlreadyRunningError: If a live process already owns the PID file.
+    '''
+    for final_attempt in (False, True):
+        if _create_pidfile(path):
+            return
+        if final_attempt:
+            # Another process reclaimed the PID file before we could, so it is in use.
+            raise AlreadyRunningError(path, read_pidfile(path))
+        reclaimed, pid = _reclaim_stale_pidfile(path)
+        if not reclaimed:
+            raise AlreadyRunningError(path, pid)
+
+
+def remove_pidfile(path: str) -> None:
+    '''
+    Remove a PID file, but only if it still records the PID of the calling process.
+
+    The ownership check matters because ``ansible-runner stop`` removes the PID file
+    itself before the daemon has finished dying: without it, a late running exit handler
+    could delete the PID file of a daemon started in the meantime.
+
+    :param str path: Path of the PID file to remove.
+    '''
+    if read_pidfile(path) != os.getpid():
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _ensure_stdio_fds_open() -> None:
+    '''
+    Make sure descriptors 0, 1 and 2 are open, attaching them to the null device if not.
+
+    ``os.pipe()`` and ``os.open()`` hand out the lowest free descriptors. If we were
+    invoked with, say, standard output closed, the start-up handshake pipe would be
+    allocated descriptor 1 and then destroyed by ``_redirect_std_streams()`` before the
+    daemon had a chance to report anything, silently losing the report.
+    '''
+    for fileno in (STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO):
+        try:
+            os.fstat(fileno)
+        except OSError as exc:
+            # Only EBADF means the descriptor is free. Anything else is a live but
+            # unhappy descriptor, which we must not replace with the null device.
+            if exc.errno != errno.EBADF:
+                raise
+            fd = os.open(os.devnull, os.O_RDWR)
+            if fd != fileno:
+                os.dup2(fd, fileno)
+                os.close(fd)
+
+
+def _flush_std_streams() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except (AttributeError, ValueError, OSError):
+            pass
+
+
+def _redirect_std_streams(stdout: str | None, stderr: str | None) -> None:
+    '''
+    Detach the standard streams from whatever the launching process was using.
+
+    File descriptors 0, 1 and 2 are targeted directly rather than ``sys.std*.fileno()``
+    because those objects may have been replaced (by a test harness, for example) and
+    may not be backed by the real descriptors at all.
+
+    :param stdout: File to append standard output to, or ``None`` for the null device.
+    :param stderr: File to append standard error to, or ``None`` for the null device.
+    '''
+    _flush_std_streams()
+
+    devnull = os.open(os.devnull, os.O_RDWR)
+    try:
+        os.dup2(devnull, STDIN_FILENO)
+        for path, fileno in ((stdout, STDOUT_FILENO), (stderr, STDERR_FILENO)):
+            if path is None:
+                os.dup2(devnull, fileno)
+                continue
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+            try:
+                os.dup2(fd, fileno)
+            finally:
+                if fd > STDERR_FILENO:
+                    os.close(fd)
+    finally:
+        if devnull > STDERR_FILENO:
+            os.close(devnull)
+
+    # Rebind the Python level objects too. Anything still holding the launcher's original
+    # stream objects would otherwise keep writing to them, which only happens to be
+    # harmless when those objects are backed by the descriptors redirected above.
+    old_stdout, old_stderr = sys.stdout, sys.stderr
+
+    # Line buffered, because the daemon is normally reaped with SIGKILL: ``stop`` calls
+    # Runner.handle_termination(), which does os.killpg(..., SIGKILL). A block buffered
+    # stream would discard up to a bufferful of the log file it was pointed at, and
+    # nothing would be tailable while a job runs.
+    #
+    # These deliberately outlive this function.
+    # pylint: disable=R1732
+    sys.stdin = open(STDIN_FILENO, 'r', closefd=False)
+    sys.stdout = open(STDOUT_FILENO, 'w', buffering=1, closefd=False)
+    sys.stderr = open(STDERR_FILENO, 'w', buffering=1, closefd=False)
+
+    _repoint_logging_streams(((old_stdout, sys.stdout), (old_stderr, sys.stderr)))
+
+
+def _repoint_logging_streams(replacements: Iterable[tuple[Any, Any]]) -> None:
+    '''
+    Point logging handlers that captured the launcher's stream objects at their
+    replacements.
+
+    Handlers configured before detaching hold a direct reference to the old objects, so
+    rebinding ``sys.stdout``/``sys.stderr`` is not on its own enough to stop them writing
+    to whatever the launcher was using.
+
+    :param replacements: Pairs of (old stream, new stream).
+    '''
+    loggers: list[Any] = [logging.root, *logging.Logger.manager.loggerDict.values()]
+    for logger in loggers:
+        for handler in getattr(logger, 'handlers', ()):
+            if not isinstance(handler, logging.StreamHandler):
+                continue
+            for old, new in replacements:
+                if handler.stream is old:
+                    handler.setStream(new)
+                    break
+
+
+def _terminate(signal_number: int, frame: FrameType | None) -> NoReturn:
+    # pylint: disable=W0613
+    raise SystemExit(f"Terminating on signal {signal_number}")
+
+
+def _set_signal_handlers() -> None:
+    '''
+    Install the signal dispositions a daemon is expected to have.
+
+    ``SIGTERM`` is turned into ``SystemExit`` so that the ``with`` block and the
+    ``atexit`` handlers get a chance to remove the PID file, and the job control signals
+    are ignored so that a stray ``SIGTSTP`` cannot suspend the daemon.
+    '''
+    for name in ('SIGTSTP', 'SIGTTIN', 'SIGTTOU'):
+        number = getattr(signal, name, None)
+        if number is not None:
+            signal.signal(number, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, _terminate)
+
+
+def _report_to_launcher(write_fd: int, message: str) -> None:
+    '''
+    Send a start-up report to the launching process and close the pipe.
+
+    An empty message means the daemon started successfully.
+    '''
+    try:
+        if message:
+            os.write(write_fd, message.encode('utf-8', errors='replace'))
+    except OSError:
+        pass
+    finally:
+        try:
+            os.close(write_fd)
+        except OSError:
+            pass
+
+
+def _exit_launcher(read_fd: int) -> NoReturn:
+    '''
+    Wait for the daemon's start-up report, then terminate the launching process.
+
+    ``os._exit()`` is deliberate. This process is a fork parent that shares its entire
+    state with the daemon: ``atexit`` handlers (``utils.register_for_cleanup()`` deletes
+    the private data directory!), ``multiprocessing`` bookkeeping, and duplicated stdio
+    buffers. Unwinding the stack with ``sys.exit()`` would run all of that a second time
+    against state the daemon now owns.
+    '''
+    chunks: list[bytes] = []
+    try:
+        while True:
+            data = os.read(read_fd, 4096)
+            if not data:
+                break
+            chunks.append(data)
+    except OSError:
+        pass
+    finally:
+        os.close(read_fd)
+
+    message = b''.join(chunks).decode('utf-8', errors='replace').strip()
+    if message:
+        try:
+            sys.stderr.write(f"{message}\n")
+            sys.stderr.flush()
+        except (AttributeError, ValueError, OSError):
+            pass
+        os._exit(1)  # pylint: disable=W0212
+    os._exit(0)  # pylint: disable=W0212
+
+
+class DaemonContext:
+    '''
+    Turn the calling process into a POSIX daemon for the duration of a ``with`` block.
+
+    This is a small, dependency free stand-in for ``daemon.DaemonContext`` covering only
+    what ``ansible-runner start`` needs.
+
+    Entering the context forks twice with an ``os.setsid()`` in between. The process that
+    entered the context never leaves ``__enter__()``: it waits for the daemon to report
+    that it has started, writes any failure to standard error, and exits with 0 on
+    success or 1 on failure. Only the daemon returns from ``__enter__()``.
+
+    The resulting process group contains the daemon and its descendants and nothing else,
+    which is what lets ``Runner.handle_termination()`` signal the whole job with
+    ``os.killpg()``.
+    '''
+
+    def __init__(self,
+                 pidfile: str,
+                 working_directory: str = '/',
+                 stdout: str | None = None,
+                 stderr: str | None = None,
+                 umask: int | None = None) -> None:
+        '''
+        :param str pidfile: Path of the PID file to create once detached.
+        :param str working_directory: Directory to change to, so that the daemon does not
+            keep a file system busy. Defaults to the root directory.
+        :param stdout: File to append the daemon's standard output to, or ``None`` to
+            discard it.
+        :param stderr: File to append the daemon's standard error to, or ``None`` to
+            discard it.
+        :param umask: File mode creation mask to set, or ``None`` to inherit the mask of
+            the launching process.
+        '''
+        self.pidfile = pidfile
+        self.working_directory = working_directory
+        self.stdout = stdout
+        self.stderr = stderr
+        self.umask = umask
+        self._is_open = False
+
+    @property
+    def is_open(self) -> bool:
+        return self._is_open
+
+    def open(self) -> None:
+        '''
+        Detach from the launching process and claim the PID file.
+
+        :raises AlreadyRunningError: In the daemon process only, if the PID file is
+            already owned. The launching process reports it on standard error instead.
+        '''
+        if self._is_open:
+            return
+
+        # Before allocating anything: the handshake pipe must not land on a standard
+        # descriptor that the redirect below would then overwrite.
+        _ensure_stdio_fds_open()
+
+        # Buffers are duplicated by fork(); flush now so nothing is written twice.
+        _flush_std_streams()
+
+        read_fd, write_fd = os.pipe()
+
+        if os.fork() > 0:
+            os.close(write_fd)
+            _exit_launcher(read_fd)
+
+        os.close(read_fd)
+        try:
+            # Become a session leader so the daemon has no controlling terminal, then
+            # fork again so the daemon is not a session leader and can never acquire one.
+            os.setsid()
+            if os.fork() > 0:
+                os._exit(0)  # pylint: disable=W0212
+
+            os.chdir(self.working_directory)
+            if self.umask is not None:
+                os.umask(self.umask)
+            # The daemon may hold vault passwords in memory, so do not dump core.
+            resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+            _set_signal_handlers()
+            _redirect_std_streams(self.stdout, self.stderr)
+            write_pidfile(self.pidfile)
+        except BaseException as exc:
+            _report_to_launcher(write_fd, str(exc) or exc.__class__.__name__)
+            os._exit(1)  # pylint: disable=W0212
+
+        _report_to_launcher(write_fd, '')
+        self._is_open = True
+        atexit.register(self.close)
+
+    def close(self) -> None:
+        '''
+        Release the PID file. Safe to call more than once.
+        '''
+        if not self._is_open:
+            return
+        self._is_open = False
+        remove_pidfile(self.pidfile)
+
+    def __enter__(self) -> DaemonContext:
+        self.open()
+        return self
+
+    def __exit__(self,
+                 exc_type: type[BaseException] | None,
+                 exc_value: BaseException | None,
+                 exc_tb: TracebackType | None) -> None:
+        self.close()

--- a/test/integration/test_main.py
+++ b/test/integration/test_main.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import logging
 import multiprocessing
+import subprocess
+import sys
 
 from test.utils.common import iterate_timeout
 
@@ -198,3 +201,102 @@ def test_playbook_start(project_fixtures):
 
     rc = main(['stop', str(private_data_dir)])
     assert rc == 1
+
+
+def start_in_background(args):
+    """Run ``main(args)`` in a forked process and return it, already started."""
+    mpcontext = multiprocessing.get_context('fork')
+    p = mpcontext.Process(target=main, args=[args])
+    p.start()
+    return p
+
+
+def test_start_when_already_running(project_fixtures):
+    private_data_dir = project_fixtures / 'sleep'
+    pid_path = private_data_dir / 'pid'
+
+    args = ['start', '-p', 'sleep.yml', str(private_data_dir)]
+    start_in_background(args).join()
+
+    for _ in iterate_timeout(30, "pid file creation"):
+        if pid_path.exists():
+            break
+    running_pid = pid_path.read_text().strip()
+
+    try:
+        # A second start against the same private data dir must refuse to launch
+        # rather than traceback, and must leave the running daemon's pid file alone.
+        second = start_in_background(args)
+        second.join()
+        assert second.exitcode == 1
+        assert pid_path.read_text().strip() == running_pid
+    finally:
+        assert main(['stop', str(private_data_dir)]) == 0
+
+
+def test_start_reclaims_stale_pidfile(project_fixtures):
+    private_data_dir = project_fixtures / 'sleep'
+    pid_path = private_data_dir / 'pid'
+
+    # A pid file left behind by a process that no longer exists (SIGKILL, reboot, ...)
+    # must not block subsequent starts.
+    proc = subprocess.Popen([sys.executable, '-c', ''])  # pylint: disable=R1732
+    proc.wait()
+    pid_path.write_text(f"{proc.pid}\n")
+
+    start_in_background(['start', '-p', 'sleep.yml', str(private_data_dir)]).join()
+
+    try:
+        for _ in iterate_timeout(30, "stale pid file to be reclaimed"):
+            if pid_path.exists() and pid_path.read_text().strip() != str(proc.pid):
+                break
+        assert main(['is-alive', str(private_data_dir)]) == 0
+    finally:
+        assert main(['stop', str(private_data_dir)]) == 0
+
+
+@pytest.fixture
+def no_logfile_handler():
+    """Undo any logfile handler an earlier test left on the process wide debug logger.
+
+    ``output.set_logfile()`` is a no-op once a handler named ``logfile`` is registered,
+    and the forked process inherits that state.
+    """
+    logger = logging.getLogger('ansible-runner.debug')
+    saved = list(logger.handlers)
+    logger.handlers = [h for h in saved if h.get_name() != 'logfile']
+    yield
+    logger.handlers = saved
+
+
+def test_start_writes_logfile(project_fixtures, tmp_path, no_logfile_handler):  # pylint: disable=W0613,W0621
+    # The logfile handler is opened before the process detaches, so it only survives
+    # if daemonizing leaves inherited file descriptors alone.
+    private_data_dir = project_fixtures / 'use_role'
+    logfile = tmp_path / 'runner.log'
+
+    start_in_background([
+        'start',
+        '--debug',
+        '--logfile', str(logfile),
+        '-r', 'benthomasson.hello_role',
+        '--hosts', 'localhost',
+        '--roles-path', str(private_data_dir / 'roles'),
+        str(private_data_dir),
+    ]).join()
+
+    try:
+        # Assert on a line role_manager() logs from inside the ``with`` block, after
+        # the process has detached. Merely checking that the file is non-empty would
+        # pass on the entries written by the launcher before it forked.
+        for _ in iterate_timeout(30, "daemon to write to the logfile after detaching"):
+            if logfile.exists() and 'setting ANSIBLE_ROLES_PATH' in logfile.read_text():
+                break
+    finally:
+        # The run is short, so it may well have finished already: the return code of
+        # stop is deliberately not asserted. Leaving it running would let the fixture
+        # teardown delete the private data dir out from under it.
+        main(['stop', str(private_data_dir)])
+        for _ in iterate_timeout(30, "background process to stop"):
+            if main(['is-alive', str(private_data_dir)]) == 1:
+                break

--- a/test/unit/utils/test__daemonize.py
+++ b/test/unit/utils/test__daemonize.py
@@ -1,0 +1,301 @@
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from ansible_runner.utils._daemonize import (
+    AlreadyRunningError,
+    DaemonContext,
+    PIDFILE_MODE,
+    _reclaim_stale_pidfile,
+    pid_is_running,
+    read_pidfile,
+    remove_pidfile,
+    write_pidfile,
+)
+
+
+def make_dead_pid():
+    """Return a PID that is guaranteed to be gone, and reaped so it is not a zombie."""
+    proc = subprocess.Popen([sys.executable, '-c', ''])  # pylint: disable=R1732
+    proc.wait()
+    return proc.pid
+
+
+def test_read_pidfile_missing(tmp_path):
+    assert read_pidfile(str(tmp_path / 'nope')) is None
+
+
+@pytest.mark.parametrize('contents,expected', (
+    ('', None),
+    ('\n', None),
+    ('not-a-pid', None),
+    ('1234', 1234),
+    ('1234\n', 1234),
+    (' 1234 \n', 1234),
+    ('1234\nnoise\n', 1234),
+))
+def test_read_pidfile(tmp_path, contents, expected):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(contents)
+    assert read_pidfile(str(pidfile)) == expected
+
+
+def test_read_pidfile_directory(tmp_path):
+    assert read_pidfile(str(tmp_path)) is None
+
+
+def test_pid_is_running_self():
+    assert pid_is_running(os.getpid()) is True
+
+
+def test_pid_is_running_dead():
+    assert pid_is_running(make_dead_pid()) is False
+
+
+@pytest.mark.parametrize('pid', (0, -1))
+def test_pid_is_running_non_positive(pid, mocker):
+    # A non-positive PID must never reach os.kill(): 0 would signal our own process
+    # group and -1 would signal every process we are allowed to signal.
+    kill = mocker.patch('ansible_runner.utils._daemonize.os.kill')
+    assert pid_is_running(pid) is False
+    kill.assert_not_called()
+
+
+def test_pid_is_running_permission_denied(mocker):
+    mocker.patch('ansible_runner.utils._daemonize.os.kill', side_effect=PermissionError)
+    assert pid_is_running(999999) is True
+
+
+def test_write_pidfile_creates_file(tmp_path):
+    pidfile = tmp_path / 'pid'
+
+    # The PID file mode is subject to the umask, which is now inherited rather than
+    # reset to 0, so pin it for the duration of the assertion.
+    umask = os.umask(0o022)
+    try:
+        write_pidfile(str(pidfile))
+    finally:
+        os.umask(umask)
+
+    assert pidfile.read_text() == f"{os.getpid()}\n"
+    assert stat.S_IMODE(pidfile.stat().st_mode) == PIDFILE_MODE
+
+
+def test_write_pidfile_live_owner_raises(tmp_path):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{os.getpid()}\n")
+
+    with pytest.raises(AlreadyRunningError) as exc:
+        write_pidfile(str(pidfile))
+
+    assert exc.value.pid == os.getpid()
+    assert exc.value.path == str(pidfile)
+    # The live owner's PID file must be left exactly as it was.
+    assert pidfile.read_text() == f"{os.getpid()}\n"
+
+
+@pytest.mark.parametrize('contents', ('', 'garbage\n'))
+def test_write_pidfile_reclaims_unreadable(tmp_path, contents):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(contents)
+
+    write_pidfile(str(pidfile))
+
+    assert pidfile.read_text() == f"{os.getpid()}\n"
+
+
+def test_write_pidfile_reclaims_stale(tmp_path):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{make_dead_pid()}\n")
+
+    write_pidfile(str(pidfile))
+
+    assert pidfile.read_text() == f"{os.getpid()}\n"
+
+
+def test_write_pidfile_other_oserror_propagates(tmp_path):
+    # A missing parent directory is not an "already running" condition.
+    with pytest.raises(FileNotFoundError):
+        write_pidfile(str(tmp_path / 'missing' / 'pid'))
+
+
+def test_write_pidfile_is_never_visible_empty(tmp_path, mocker):
+    # The PID file must be fully written the instant it appears. A concurrent starter
+    # that saw it empty would take it for a corrupt file and reclaim it, and both
+    # daemons would then run against one private data directory.
+    pidfile = tmp_path / 'pid'
+    observed = []
+
+    real_link = os.link
+
+    def observing_link(src, dst):
+        real_link(src, dst)
+        # Stand in for the concurrent starter, which reaches this point by way of a
+        # FileExistsError from its own creation attempt.
+        observed.append(_reclaim_stale_pidfile(str(pidfile)))
+
+    mocker.patch('ansible_runner.utils._daemonize.os.link', side_effect=observing_link)
+
+    write_pidfile(str(pidfile))
+
+    assert observed == [(False, os.getpid())]
+    assert pidfile.read_text() == f"{os.getpid()}\n"
+
+
+def test_write_pidfile_removes_its_temporary_file(tmp_path):
+    write_pidfile(str(tmp_path / 'pid'))
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ['pid']
+
+
+def test_write_pidfile_removes_its_temporary_file_on_failure(tmp_path):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{os.getpid()}\n")
+
+    with pytest.raises(AlreadyRunningError):
+        write_pidfile(str(pidfile))
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ['pid']
+
+
+def test_write_pidfile_reuses_leftover_temporary_file(tmp_path):
+    # A crash can leave a temporary file behind under a PID that is later recycled.
+    pidfile = tmp_path / 'pid'
+    (tmp_path / f"pid.{os.getpid()}").write_text('leftover junk that is longer than a pid\n')
+
+    write_pidfile(str(pidfile))
+
+    assert pidfile.read_text() == f"{os.getpid()}\n"
+
+
+def test_write_pidfile_loses_reclaim_race(tmp_path, mocker):
+    # If another process reclaims the stale PID file first, report that it is running
+    # rather than looping or clobbering it.
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{make_dead_pid()}\n")
+
+    def racer(path):  # pylint: disable=W0613
+        pidfile.write_text('4242\n')
+        return True, None
+
+    mocker.patch('ansible_runner.utils._daemonize._reclaim_stale_pidfile', side_effect=racer)
+
+    with pytest.raises(AlreadyRunningError) as exc:
+        write_pidfile(str(pidfile))
+
+    assert exc.value.pid == 4242
+    assert pidfile.read_text() == '4242\n'
+
+
+def test_reclaim_stale_pidfile_missing(tmp_path):
+    assert _reclaim_stale_pidfile(str(tmp_path / 'nope')) == (True, None)
+
+
+def test_reclaim_stale_pidfile_removes_dead_owner(tmp_path):
+    dead_pid = make_dead_pid()
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{dead_pid}\n")
+
+    assert _reclaim_stale_pidfile(str(pidfile)) == (True, dead_pid)
+    assert not pidfile.exists()
+
+
+def test_reclaim_stale_pidfile_keeps_live_owner(tmp_path):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{os.getpid()}\n")
+
+    assert _reclaim_stale_pidfile(str(pidfile)) == (False, os.getpid())
+    assert pidfile.exists()
+
+
+def test_reclaim_stale_pidfile_detects_replacement(tmp_path, mocker):
+    # A racing process can replace the PID file while we wait for the lock. Its
+    # replacement must not be unlinked as though it were the stale file we opened.
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{make_dead_pid()}\n")
+
+    def replace(fd, operation):  # pylint: disable=W0613
+        pidfile.unlink()
+        pidfile.write_text(f"{os.getpid()}\n")
+
+    mocker.patch('ansible_runner.utils._daemonize.fcntl.flock', side_effect=replace)
+
+    assert _reclaim_stale_pidfile(str(pidfile)) == (True, None)
+    assert pidfile.read_text() == f"{os.getpid()}\n"
+
+
+def test_reclaim_stale_pidfile_without_locking(tmp_path, mocker):
+    # Not every filesystem can lock; reclaiming must still work there.
+    dead_pid = make_dead_pid()
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{dead_pid}\n")
+
+    mocker.patch('ansible_runner.utils._daemonize.fcntl.flock', side_effect=OSError)
+
+    assert _reclaim_stale_pidfile(str(pidfile)) == (True, dead_pid)
+    assert not pidfile.exists()
+
+
+def test_ensure_stdio_fds_open_reopens_closed_descriptors():
+    # Must run in a subprocess: closing pytest's own descriptors in-process is not safe.
+    script = textwrap.dedent(
+        '''
+        import os
+        from ansible_runner.utils._daemonize import _ensure_stdio_fds_open
+
+        os.close(0)
+        os.close(1)
+        _ensure_stdio_fds_open()
+
+        for fileno in (0, 1, 2):
+            os.fstat(fileno)
+
+        # The handshake pipe must not be handed a standard descriptor, which the
+        # redirect performed later on would overwrite.
+        read_fd, write_fd = os.pipe()
+        assert read_fd > 2 and write_fd > 2, (read_fd, write_fd)
+        '''
+    )
+    subprocess.run([sys.executable, '-c', script], check=True)
+
+
+def test_remove_pidfile_own(tmp_path):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{os.getpid()}\n")
+
+    remove_pidfile(str(pidfile))
+
+    assert not pidfile.exists()
+
+
+def test_remove_pidfile_other_owner(tmp_path):
+    # A PID file we no longer own belongs to a daemon started after us.
+    other_pid = make_dead_pid()
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{other_pid}\n")
+
+    remove_pidfile(str(pidfile))
+
+    assert pidfile.read_text() == f"{other_pid}\n"
+
+
+def test_remove_pidfile_missing(tmp_path):
+    remove_pidfile(str(tmp_path / 'nope'))
+
+
+def test_daemon_context_close_is_idempotent(tmp_path):
+    pidfile = tmp_path / 'pid'
+    pidfile.write_text(f"{os.getpid()}\n")
+
+    context = DaemonContext(str(pidfile))
+    assert context.is_open is False
+
+    # close() on a context that was never opened must not touch the PID file.
+    context.close()
+    context.close()
+
+    assert pidfile.exists()


### PR DESCRIPTION
Remove the `python-daemon` dependency
    
`python-daemon` is used in exactly one place, and only with its defaults. It depends on `lockfile`, which has been unmaintained since 2015. Every drop-in replacement on PyPI is staler still, so implement the PEP 3143 essentials we actually need in a new private module instead.
    
Dropping `python-daemon`'s defaults also fixes several bugs in `start`:
    
* A stale pid file no longer blocks all further use of a private_data_dir. PIDLockFile had no stale detection at all, so a kill -9 or a reboot left `start` failing with a traceback until someone deleted the file by hand.
* `--logfile` works again. DaemonContext.open() closed every inherited file descriptor, including the one belonging to the logging FileHandler that `output.set_logfile()` had just opened.
* Artifacts are no longer world writable. The umask of the invoking process is inherited rather than reset to 0.
* Starting a second daemon reports the running PID instead of raising lockfile.AlreadyLocked.
* The daemon's stderr is appended to `<private_data_dir>/daemon.log`, which was already being created for it, rather than discarded. It is line buffered, because `stop` reaps the daemon with SIGKILL and a block buffered stream would discard up to a bufferful of it.

Fixes #379